### PR TITLE
Use multiple caches to for concurrent access

### DIFF
--- a/node/import.go
+++ b/node/import.go
@@ -104,12 +104,8 @@ func (n *Node) importCallback(c, piece cid.Cid, prov peer.ID) error {
 		return nil
 	}
 	// NOTE: We disregard errors for now
-	err := n.primary.Put(c, prov, piece)
-	if err != nil {
-		log.Errorw("Error importing cid", "cid", c, "err", err)
-	} else {
-		// TODO: Change to Debug
-		log.Infow("Imported successfully", "cid", c)
-	}
+	isNew := n.primary.Put(c, prov, piece)
+	// TODO: Change to Debug
+	log.Infow("Imported successfully", "new", isNew, "cid", c)
 	return nil
 }

--- a/store/persistent/persistent.go
+++ b/store/persistent/persistent.go
@@ -24,9 +24,15 @@ func New() store.Storage {
 func (s *sthStorage) Get(c cid.Cid) ([]store.IndexEntry, bool) {
 	panic("Not implemented")
 }
+
 func (s *sthStorage) Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) error {
 	panic("Not implemented")
 }
+
 func (s *sthStorage) PutMany(cs []cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+	panic("Not implemented")
+}
+
+func (s *sthStorage) Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) bool {
 	panic("Not implemented")
 }

--- a/store/persistent/persistent.go
+++ b/store/persistent/persistent.go
@@ -25,14 +25,22 @@ func (s *sthStorage) Get(c cid.Cid) ([]store.IndexEntry, bool) {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+func (s *sthStorage) Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) bool {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) PutMany(cs []cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+func (s *sthStorage) PutMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) int {
 	panic("Not implemented")
 }
 
 func (s *sthStorage) Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) bool {
+	panic("Not implemented")
+}
+
+func (s *sthStorage) RemoveMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) int {
+	panic("Not implemented")
+}
+
+func (s *sthStorage) RemoveProvider(providerID peer.ID) int {
 	panic("Not implemented")
 }

--- a/store/primary/primary.go
+++ b/store/primary/primary.go
@@ -9,26 +9,41 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
-// numLocks is the lock granularity for radixtree. Must be power of two.
-const numLocks = 64
+// concurrrency is the lock granularity for radixtree. Must be power of two.
+const concurrency = 16
 
 var _ store.Storage = &rtStorage{}
 
+// syncCache is a rotatable cache. Multiples instances may be used to decrease
+// concurrent access collision.
+type syncCache struct {
+	current   *radixtree.Bytes
+	previous  *radixtree.Bytes
+	mutex     sync.Mutex
+	rotations int
+}
+
 // Adaptive Radix Tree primary storage
 type rtStorage struct {
-	branchLocks []sync.Mutex
-	current     *radixtree.Bytes
-	previous    *radixtree.Bytes
-	sizeLimit   int
+	cacheSet   []*syncCache
+	rotateSize int
 }
 
 // New creates a new Adaptive Radix Tree storage
 func New(size int) store.Storage {
+	cacheSetSize := concurrency
+	if size < 256 {
+		cacheSetSize = 1
+	}
+	cacheSet := make([]*syncCache, cacheSetSize)
+	for i := range cacheSet {
+		cacheSet[i] = &syncCache{
+			current: radixtree.New(),
+		}
+	}
 	return &rtStorage{
-		branchLocks: make([]sync.Mutex, numLocks),
-		current:     radixtree.New(),
-		previous:    nil,
-		sizeLimit:   size / 2,
+		cacheSet:   cacheSet,
+		rotateSize: size / (cacheSetSize * 2),
 	}
 }
 
@@ -37,35 +52,11 @@ func (s *rtStorage) Get(c cid.Cid) ([]store.IndexEntry, bool) {
 	// Keys indexed as multihash
 	k := string(c.Hash())
 
-	s.lockBranch(k)
-	defer s.unlockBranch(k)
+	cache := s.getCache(k)
+	cache.lock()
+	defer cache.unlock()
 
-	return s.get(k)
-}
-
-func (s *rtStorage) get(k string) ([]store.IndexEntry, bool) {
-	// Search current cache
-	v, found := s.current.Get(k)
-	if found {
-		return v.([]store.IndexEntry), found
-	}
-
-	if s.previous == nil {
-		return nil, false
-	}
-
-	// Search previous if not found in current
-	v, found = s.previous.Get(k)
-
-	// If nothing has been found return nil
-	if !found {
-		return nil, false
-	}
-
-	// Put the value found in the previous tree into the current one.
-	s.current.Put(k, v)
-
-	return v.([]store.IndexEntry), found
+	return cache.get(k)
 }
 
 // Put adds indexEntry info for a CID. Put currently is non-destructive
@@ -79,27 +70,100 @@ func (s *rtStorage) Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) error {
 
 	// Get multihash from cid
 	k := string(c.Hash())
+	cache := s.getCache(k)
 
-	s.lockBranch(k)
-
-	if !s.put(k, in) {
-		s.unlockBranch(k)
-		return nil
+	cache.lock()
+	if cache.put(k, in) && cache.current.Len() > s.rotateSize {
+		// Only rotate one cache at a time. This may leave older entries in
+		// other caches, but if CIDs are dirstributed evenly over the cache set
+		// then over time all members should be rotated the same amount on
+		// average.  This is done so that it is not necessary to lock all
+		// caches in order to perform a rotation.  This also means that items
+		// age out more incrementally.
+		cache.rotate()
 	}
+	cache.unlock()
 
-	if s.current.Len() >= s.sizeLimit {
-		s.unlockBranch(k)
-		s.rotateCache()
-	} else {
-		s.unlockBranch(k)
+	return nil
+}
+
+// PutMany puts store.IndexEntry information in several CIDs.
+// This is usually triggered when a bulk update for a providerID-pieceID
+// arrives.
+func (s *rtStorage) PutMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+	in := store.IndexEntry{ProvID: provID, PieceID: pieceID}
+
+	for i := range cids {
+		k := string(cids[i].Hash())
+		cache := s.getCache(k)
+		cache.lock()
+		if cache.put(k, in) && cache.current.Len() > s.rotateSize {
+			cache.rotate()
+		}
+		cache.unlock()
 	}
 
 	return nil
 }
 
-func (s *rtStorage) put(k string, entry store.IndexEntry) bool {
+func (s *rtStorage) Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) bool {
+	in := store.IndexEntry{ProvID: provID, PieceID: pieceID}
+
+	// Get multihash from cid
+	k := string(c.Hash())
+
+	cache := s.getCache(k)
+	cache.lock()
+	defer cache.unlock()
+
+	return cache.remove(k, in)
+}
+
+// getCache returns the cache that stores the given key.  This function must
+// evenly distribute keys over the set of caches.
+func (s *rtStorage) getCache(k string) *syncCache {
+	var idx int
+	if k != "" {
+		// Use last bits of key for good distribution
+		//
+		// bitwise modulus requires that size of cache set is power of 2
+		idx = int(k[len(k)-1]) & (len(s.cacheSet) - 1)
+	}
+	return s.cacheSet[idx]
+}
+
+func (c *syncCache) lock()     { c.mutex.Lock() }
+func (c *syncCache) unlock()   { c.mutex.Unlock() }
+func (c *syncCache) size() int { return c.current.Len() + c.previous.Len() }
+
+func (c *syncCache) get(k string) ([]store.IndexEntry, bool) {
+	// Search current cache
+	v, found := c.current.Get(k)
+	if found {
+		return v.([]store.IndexEntry), found
+	}
+
+	if c.previous == nil {
+		return nil, false
+	}
+
+	// Search previous if not found in current
+	v, found = c.previous.Get(k)
+
+	// If nothing has been found return nil
+	if !found {
+		return nil, false
+	}
+
+	// Put the value found in the previous tree into the current one.
+	c.current.Put(k, v)
+
+	return v.([]store.IndexEntry), found
+}
+
+func (c *syncCache) put(k string, entry store.IndexEntry) bool {
 	// Get from current or previous cache
-	old, found := s.get(k)
+	old, found := c.get(k)
 	// If found it means there is already a value there.
 	// Check if we are trying to put a duplicate entry
 	// NOTE: If we end up having a lot of entries for the
@@ -109,55 +173,53 @@ func (s *rtStorage) put(k string, entry store.IndexEntry) bool {
 		return false
 	}
 
-	s.current.Put(k, append(old, entry))
+	c.current.Put(k, append(old, entry))
 	return true
 }
 
-func (s *rtStorage) rotateCache() {
-	// Acquire all locks
-	for i := range s.branchLocks {
-		s.branchLocks[i].Lock()
+func (c *syncCache) remove(k string, entry store.IndexEntry) bool {
+	removed := removeEntry(c.current, k, entry)
+	if removeEntry(c.previous, k, entry) {
+		removed = true
 	}
-
-	if s.current.Len() >= s.sizeLimit {
-		s.previous, s.current = s.current, radixtree.New()
-	}
-
-	// Release all locks
-	for i := range s.branchLocks {
-		s.branchLocks[i].Unlock()
-	}
+	return removed
 }
 
-// PutMany puts store.IndexEntry information in several CIDs.
-// This is usually triggered when a bulk update for a providerID-pieceID
-// arrives.
-func (s *rtStorage) PutMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) error {
-	in := store.IndexEntry{ProvID: provID, PieceID: pieceID}
-	var addedEntry bool
-
-	for i := range cids {
-		k := string(cids[i].Hash())
-		s.lockBranch(k)
-
-		if s.put(k, in) {
-			addedEntry = true
-		}
-		s.unlockBranch(k)
+func removeEntry(cache *radixtree.Bytes, k string, entry store.IndexEntry) bool {
+	// Get from current cache
+	v, found := cache.Get(k)
+	if !found {
+		return false
 	}
 
-	if addedEntry {
-		// Check if rotation needed
-		s.lockBranch("")
-		if s.current.Len() >= s.sizeLimit {
-			s.unlockBranch("")
-			s.rotateCache()
-		} else {
-			s.unlockBranch("")
+	values := v.([]store.IndexEntry)
+	for i := range values {
+		if entry.PieceID == values[i].PieceID &&
+			entry.ProvID == values[i].ProvID {
+			if len(values) == 1 {
+				cache.Delete(k)
+			} else {
+				values[i] = values[len(values)-1]
+				values[len(values)-1] = store.IndexEntry{}
+				cache.Put(k, values[:len(values)-1])
+			}
+			return true
 		}
 	}
+	return false
+}
 
-	return nil
+func (c *syncCache) removeAll(k string) bool {
+	removed := c.current.Delete(k)
+	if c.previous.Delete(k) {
+		removed = true
+	}
+	return removed
+}
+
+func (c *syncCache) rotate() {
+	c.previous, c.current = c.current, radixtree.New()
+	c.rotations++
 }
 
 // Checks if the entry already exists in the index. An entry
@@ -171,30 +233,4 @@ func duplicateEntry(in store.IndexEntry, old []store.IndexEntry) bool {
 		}
 	}
 	return false
-}
-
-// lockBranch locks a "branch" of the tree so that one lock prevents any other
-// access to the same section of the tree, and this requires using the first
-// bits of the key key. There is an implicit relationship between this locking
-// strategy and how a radix tree works.
-//
-// TODO: If most keys have a common prefix this will cause lock collision and
-// become ineffective.  It may be necessary to hash over multiple tree or use a
-// RWlock over the whole tree.
-func (s *rtStorage) lockBranch(k string) {
-	var idx int
-	if k != "" {
-		// bitwise modulus requires that s.locks is power of 2
-		idx = int(k[0]) & (len(s.branchLocks) - 1)
-	}
-	s.branchLocks[idx].Lock()
-}
-
-func (s *rtStorage) unlockBranch(k string) {
-	var idx int
-	if k != "" {
-		// bitwise modulus requires that s.locks is power of 2
-		idx = int(k[0]) & (len(s.branchLocks) - 1)
-	}
-	s.branchLocks[idx].Unlock()
 }

--- a/store/primary/primary_test.go
+++ b/store/primary/primary_test.go
@@ -9,7 +9,7 @@ import (
 
 var p peer.ID = "12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA"
 
-func TestE2E(t *testing.T) {
+func TestPutGetRemove(t *testing.T) {
 	s := New(1000000)
 	cids, err := utils.RandomCids(15)
 	if err != nil {
@@ -17,63 +17,107 @@ func TestE2E(t *testing.T) {
 	}
 
 	piece := cids[0]
-	single := cids[1]
-	noadd := cids[2]
-	batch := cids[3:]
+	otherPiece := cids[1]
+	single := cids[2]
+	noadd := cids[3]
+	batch := cids[4:]
 
 	// Put a single CID
-	t.Logf("Put/Get a single CID in primary storage")
-	err = s.Put(single, p, piece)
-	if err != nil {
-		t.Fatal("Error putting single cid: ", err)
+	t.Log("Put/Get a single CID in primary storage")
+	if !s.Put(single, p, piece) {
+		t.Fatal("Did not put new single cid")
+	}
+	ents, found := s.Get(single)
+	if !found {
+		t.Error("Error finding single cid")
+	}
+	if ents[0].PieceID != piece || ents[0].ProvID != p {
+		t.Error("Got wrong value for single cid")
 	}
 
-	i, found := s.Get(single)
-	if !found {
-		t.Errorf("Error finding single cid")
+	t.Log("Put existing CID provider-piece entry")
+	if s.Put(single, p, piece) {
+		t.Fatal("should not have put new entry")
 	}
-	if i[0].PieceID != piece || i[0].ProvID != p {
-		t.Errorf("Got wrong value for single cid")
+
+	t.Log("Put existing CID and provider with new piece entry")
+	if !s.Put(single, p, otherPiece) {
+		t.Fatal("should have put new entry")
+	}
+
+	t.Log("Check for all entries for single CID")
+	ents, found = s.Get(single)
+	if !found {
+		t.Error("Error finding a cid from the batch")
+	}
+	if len(ents) != 2 {
+		t.Fatal("Update over existing key not correct")
+	}
+	if ents[1].PieceID != otherPiece || ents[1].ProvID != p {
+		t.Error("Got wrong value for single cid")
 	}
 
 	// Put a batch of CIDs
-	t.Logf("Put/Get a batch of CIDs in primary storage")
-	err = s.PutMany(batch, p, piece)
-	if err != nil {
-		t.Fatal("Error putting batch of cids: ", err)
+	t.Log("Put/Get a batch of CIDs in primary storage")
+	count := s.PutMany(batch, p, piece)
+	if count == 0 {
+		t.Fatal("Did not put batch of cids")
 	}
+	t.Logf("Stored %d new entries out of %d total", count, len(batch))
 
-	i, found = s.Get(cids[5])
+	ents, found = s.Get(cids[5])
 	if !found {
-		t.Errorf("Error finding a cid from the batch")
+		t.Error("Error finding a cid from the batch")
 	}
-	if i[0].PieceID != piece || i[0].ProvID != p {
-		t.Errorf("Got wrong value for single cid")
-	}
-
-	// Put on an existing key
-	t.Logf("Put/Get on existing key")
-	err = s.Put(single, p, noadd)
-	if err != nil {
-		t.Fatal("Error putting single cid: ", err)
-	}
-
-	i, found = s.Get(single)
-	if !found {
-		t.Errorf("Error finding a cid from the batch")
-	}
-	if len(i) != 2 {
-		t.Fatal("Update over existing key not correct")
-	}
-	if i[1].PieceID != noadd || i[1].ProvID != p {
-		t.Errorf("Got wrong value for single cid")
+	if ents[0].PieceID != piece || ents[0].ProvID != p {
+		t.Error("Got wrong value for single cid")
 	}
 
 	// Get a key that is not set
-	t.Logf("Get non-existing key")
+	t.Log("Get non-existing key")
 	_, found = s.Get(noadd)
 	if found {
-		t.Errorf("Error, the key for the cid shouldn't be set")
+		t.Error("Error, the key for the cid shouldn't be set")
+	}
+
+	t.Log("Remove entry for CID")
+	if !s.Remove(single, p, otherPiece) {
+		t.Fatal("should have removed entry")
+	}
+
+	t.Log("Check for all entries for single CID")
+	ents, found = s.Get(single)
+	if !found {
+		t.Error("Error finding a cid from the batch")
+	}
+	if len(ents) != 1 {
+		t.Fatal("Update over existing key not correct")
+	}
+	if ents[0].PieceID != piece || ents[0].ProvID != p {
+		t.Error("Got wrong value for single cid")
+	}
+
+	t.Log("Remove only entry for CID")
+	if !s.Remove(single, p, piece) {
+		t.Fatal("should have removed entry")
+	}
+	_, found = s.Get(single)
+	if found {
+		t.Fatal("Should not have found CID with no entries")
+	}
+	t.Log("Remove entry for non-existent CID")
+	if s.Remove(single, p, piece) {
+		t.Fatal("should not have removed non-existent entry")
+	}
+
+	storeSize := s.Size()
+	t.Log("Remove provider")
+	removed := s.RemoveProvider(p)
+	if removed < storeSize {
+		t.Fatalf("should have removed at least %d entries, only removed %d", storeSize, removed)
+	}
+	if s.Size() != 0 {
+		t.Fatal("should have 0 size after removing only provider")
 	}
 }
 
@@ -93,19 +137,18 @@ func TestRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = s.PutMany(cids, p, piece)
-	if err != nil {
-		t.Fatal("Error putting batch of cids: ", err)
+	if s.PutMany(cids, p, piece) == 0 {
+		t.Fatal("did not put batch of cids")
 	}
 
 	_, found := s.Get(cids[0])
 	if !found {
-		t.Errorf("Error finding a cid from previous cache")
+		t.Error("Error finding a cid from previous cache")
 	}
 
 	_, found = s.Get(cids[maxSize+2])
 	if !found {
-		t.Errorf("Error finding a cid from new cache")
+		t.Error("Error finding a cid from new cache")
 	}
 
 	cids2, err := utils.RandomCids(maxSize)
@@ -113,26 +156,25 @@ func TestRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = s.PutMany(cids2, p, piece2)
-	if err != nil {
-		t.Fatal("Error putting batch of cids: ", err)
+	if s.PutMany(cids2, p, piece2) == 0 {
+		t.Fatal("did not put batch of cids")
 	}
 
 	// Should find this because it was moved to new cache after 1st rotation
 	_, found = s.Get(cids[0])
 	if !found {
-		t.Errorf("Error finding a cid from previous cache")
+		t.Error("Error finding a cid from previous cache")
 	}
 
 	// Should find this because it should be in old cache after 2nd rotation
 	_, found = s.Get(cids[maxSize+2])
 	if !found {
-		t.Errorf("Error finding a cid from new cache")
+		t.Error("Error finding a cid from new cache")
 	}
 
 	// Should not find this because it was only in old cache after 1st rotation
 	_, found = s.Get(cids[2])
 	if found {
-		t.Errorf("cid should have been rotated out of cache")
+		t.Error("cid should have been rotated out of cache")
 	}
 }

--- a/store/primary/primary_test.go
+++ b/store/primary/primary_test.go
@@ -37,7 +37,7 @@ func TestE2E(t *testing.T) {
 	}
 
 	// Put a batch of CIDs
-	t.Logf("Put/Get a batch of CIDd in primary storage")
+	t.Logf("Put/Get a batch of CIDs in primary storage")
 	err = s.PutMany(batch, p, piece)
 	if err != nil {
 		t.Fatal("Error putting batch of cids: ", err)

--- a/store/store.go
+++ b/store/store.go
@@ -24,4 +24,6 @@ type Storage interface {
 	// NOTE: The interface may change if we see some other function
 	// signature more handy for updating process.
 	PutMany(cs []cid.Cid, provID peer.ID, pieceID cid.Cid) error
+	// Remove info for CID
+	Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) bool
 }

--- a/store/store.go
+++ b/store/store.go
@@ -16,14 +16,21 @@ type IndexEntry struct {
 // same interface. This may change in the future if we want to discern between
 // them more easily, or if we want to introduce additional features to either of them.
 type Storage interface {
-	// Get info for CID from primary storage.
+	// Get retrieves provider-piece info for a CID
 	Get(c cid.Cid) ([]IndexEntry, bool)
-	// Put info for CID in primary storage.
-	Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) error
-	// Bulk put in primary storage
-	// NOTE: The interface may change if we see some other function
-	// signature more handy for updating process.
-	PutMany(cs []cid.Cid, provID peer.ID, pieceID cid.Cid) error
-	// Remove info for CID
-	Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) bool
+	// Put stores a provider-piece entry for a CID if the entry is
+	// not already stored.  New entries are added to the entries that are already
+	// there.  Returns true if a new entry was added to the cache.
+	Put(c cid.Cid, providerID peer.ID, pieceID cid.Cid) bool
+	// PutMany stores the provider-piece entry for multiple CIDs.  Returns the
+	// number of new entries stored.
+	PutMany(cs []cid.Cid, providerID peer.ID, pieceID cid.Cid) int
+	// Remove removes a provider-piece entry for a CID
+	Remove(c cid.Cid, providerID peer.ID, pieceID cid.Cid) bool
+	// RemoveMany removes a provider-piece entry from multiple CIDs.  Returns
+	// the number of entries removed.
+	RemoveMany(cids []cid.Cid, providerID peer.ID, pieceID cid.Cid) int
+	// RemoveProvider removes all enrties for specified provider.  This is used
+	// when a provider is no longer indexed by the indexer.
+	RemoveProvider(providerID peer.ID) int
 }


### PR DESCRIPTION
Instead of having to release a read lock and acquire a write lock and redo a lookup, whenever an entry is put into the current cache from the previous, just exclusively lock the cache.  To lessen lock contention with concurrent access use multiple cache instances over which keys are evenly distributed.

Implement a method to remove single entry (provider-ID + piece-ID) from the cache.