### PR TITLE
Return errors from Storage interface

### DIFF
--- a/node/find.go
+++ b/node/find.go
@@ -21,7 +21,7 @@ func (n *Node) GetSingleCidHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Infow("Find cid", "cid", mhCid)
 	// Get Cid from primary storage
-	i, _ := n.primary.Get(c)
+	i, _, _ := n.primary.Get(c)
 	out := map[cid.Cid][]store.IndexEntry{c: i}
 
 	err = writeResponse(w, out)

--- a/node/import.go
+++ b/node/import.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/filecoin-project/storetheindex/importer"
@@ -104,7 +105,11 @@ func (n *Node) importCallback(c, piece cid.Cid, prov peer.ID) error {
 		return nil
 	}
 	// NOTE: We disregard errors for now
-	isNew := n.primary.Put(c, prov, piece)
+	isNew, err := n.primary.Put(c, prov, piece)
+	if err != nil {
+		log.Errorw("primary storage Put returned error", "err", err, "cid", c)
+		return errors.New("failed to store in primary storage")
+	}
 	// TODO: Change to Debug
 	log.Infow("Imported successfully", "new", isNew, "cid", c)
 	return nil

--- a/node/import.go
+++ b/node/import.go
@@ -105,12 +105,12 @@ func (n *Node) importCallback(c, piece cid.Cid, prov peer.ID) error {
 		return nil
 	}
 	// NOTE: We disregard errors for now
-	isNew, err := n.primary.Put(c, prov, piece)
+	err := n.primary.Put(c, prov, piece)
 	if err != nil {
 		log.Errorw("primary storage Put returned error", "err", err, "cid", c)
 		return errors.New("failed to store in primary storage")
 	}
 	// TODO: Change to Debug
-	log.Infow("Imported successfully", "new", isNew, "cid", c)
+	log.Infow("Imported successfully", "cid", c)
 	return nil
 }

--- a/store/persistent/persistent.go
+++ b/store/persistent/persistent.go
@@ -25,22 +25,22 @@ func (s *sthStorage) Get(c cid.Cid) ([]store.IndexEntry, bool, error) {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) (bool, error) {
+func (s *sthStorage) Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) error {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) PutMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) (int, error) {
+func (s *sthStorage) PutMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) error {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) (bool, error) {
+func (s *sthStorage) Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) error {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) RemoveMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) (int, error) {
+func (s *sthStorage) RemoveMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) error {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) RemoveProvider(providerID peer.ID) (int64, error) {
+func (s *sthStorage) RemoveProvider(providerID peer.ID) error {
 	panic("Not implemented")
 }

--- a/store/persistent/persistent.go
+++ b/store/persistent/persistent.go
@@ -21,26 +21,26 @@ func New() store.Storage {
 	return nil
 }
 
-func (s *sthStorage) Get(c cid.Cid) ([]store.IndexEntry, bool) {
+func (s *sthStorage) Get(c cid.Cid) ([]store.IndexEntry, bool, error) {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) bool {
+func (s *sthStorage) Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) (bool, error) {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) PutMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) int {
+func (s *sthStorage) PutMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) (int, error) {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) bool {
+func (s *sthStorage) Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) (bool, error) {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) RemoveMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) int {
+func (s *sthStorage) RemoveMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) (int, error) {
 	panic("Not implemented")
 }
 
-func (s *sthStorage) RemoveProvider(providerID peer.ID) int {
+func (s *sthStorage) RemoveProvider(providerID peer.ID) (int64, error) {
 	panic("Not implemented")
 }

--- a/store/primary/primary_test.go
+++ b/store/primary/primary_test.go
@@ -24,11 +24,7 @@ func TestPutGetRemove(t *testing.T) {
 
 	// Put a single CID
 	t.Log("Put/Get a single CID in primary storage")
-	ok, err := s.Put(single, p, piece)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
+	if !s.PutCheck(single, p, piece) {
 		t.Fatal("Did not put new single cid")
 	}
 	ents, found, err := s.Get(single)
@@ -43,20 +39,12 @@ func TestPutGetRemove(t *testing.T) {
 	}
 
 	t.Log("Put existing CID provider-piece entry")
-	ok, err = s.Put(single, p, piece)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok {
+	if s.PutCheck(single, p, piece) {
 		t.Fatal("should not have put new entry")
 	}
 
 	t.Log("Put existing CID and provider with new piece entry")
-	ok, err = s.Put(single, p, otherPiece)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
+	if !s.PutCheck(single, p, otherPiece) {
 		t.Fatal("should have put new entry")
 	}
 
@@ -77,10 +65,7 @@ func TestPutGetRemove(t *testing.T) {
 
 	// Put a batch of CIDs
 	t.Log("Put/Get a batch of CIDs in primary storage")
-	count, err := s.PutMany(batch, p, piece)
-	if err != nil {
-		t.Fatal(err)
-	}
+	count := s.PutManyCount(batch, p, piece)
 	if count == 0 {
 		t.Fatal("Did not put batch of cids")
 	}
@@ -108,11 +93,7 @@ func TestPutGetRemove(t *testing.T) {
 	}
 
 	t.Log("Remove entry for CID")
-	ok, err = s.Remove(single, p, otherPiece)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
+	if !s.RemoveCheck(single, p, otherPiece) {
 		t.Fatal("should have removed entry")
 	}
 
@@ -132,11 +113,7 @@ func TestPutGetRemove(t *testing.T) {
 	}
 
 	t.Log("Remove only entry for CID")
-	ok, err = s.Remove(single, p, piece)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
+	if !s.RemoveCheck(single, p, piece) {
 		t.Fatal("should have removed entry")
 	}
 	_, found, err = s.Get(single)
@@ -147,21 +124,14 @@ func TestPutGetRemove(t *testing.T) {
 		t.Fatal("Should not have found CID with no entries")
 	}
 	t.Log("Remove entry for non-existent CID")
-	ok, err = s.Remove(single, p, piece)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok {
+	if s.RemoveCheck(single, p, piece) {
 		t.Fatal("should not have removed non-existent entry")
 	}
 
 	cidCount := s.CidCount()
 	t.Log("Remove provider")
-	removed, err := s.RemoveProvider(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if removed < int64(cidCount) {
+	removed := s.RemoveProviderCount(p)
+	if removed < cidCount {
 		t.Fatalf("should have removed at least %d entries, only removed %d", cidCount, removed)
 	}
 	if s.CidCount() != 0 {
@@ -185,11 +155,7 @@ func TestRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	count, err := s.PutMany(cids, p, piece)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if count == 0 {
+	if s.PutManyCount(cids, p, piece) == 0 {
 		t.Fatal("did not put batch of cids")
 	}
 
@@ -214,11 +180,7 @@ func TestRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	count, err = s.PutMany(cids2, p, piece2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if count == 0 {
+	if s.PutManyCount(cids2, p, piece2) == 0 {
 		t.Fatal("did not put batch of cids")
 	}
 

--- a/store/primary/primary_test.go
+++ b/store/primary/primary_test.go
@@ -24,10 +24,17 @@ func TestPutGetRemove(t *testing.T) {
 
 	// Put a single CID
 	t.Log("Put/Get a single CID in primary storage")
-	if !s.Put(single, p, piece) {
+	ok, err := s.Put(single, p, piece)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
 		t.Fatal("Did not put new single cid")
 	}
-	ents, found := s.Get(single)
+	ents, found, err := s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !found {
 		t.Error("Error finding single cid")
 	}
@@ -36,17 +43,28 @@ func TestPutGetRemove(t *testing.T) {
 	}
 
 	t.Log("Put existing CID provider-piece entry")
-	if s.Put(single, p, piece) {
+	ok, err = s.Put(single, p, piece)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
 		t.Fatal("should not have put new entry")
 	}
 
 	t.Log("Put existing CID and provider with new piece entry")
-	if !s.Put(single, p, otherPiece) {
+	ok, err = s.Put(single, p, otherPiece)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
 		t.Fatal("should have put new entry")
 	}
 
 	t.Log("Check for all entries for single CID")
-	ents, found = s.Get(single)
+	ents, found, err = s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !found {
 		t.Error("Error finding a cid from the batch")
 	}
@@ -59,15 +77,21 @@ func TestPutGetRemove(t *testing.T) {
 
 	// Put a batch of CIDs
 	t.Log("Put/Get a batch of CIDs in primary storage")
-	count := s.PutMany(batch, p, piece)
+	count, err := s.PutMany(batch, p, piece)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if count == 0 {
 		t.Fatal("Did not put batch of cids")
 	}
 	t.Logf("Stored %d new entries out of %d total", count, len(batch))
 
-	ents, found = s.Get(cids[5])
+	ents, found, err = s.Get(cids[5])
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !found {
-		t.Error("Error finding a cid from the batch")
+		t.Error("did not find a cid from the batch")
 	}
 	if ents[0].PieceID != piece || ents[0].ProvID != p {
 		t.Error("Got wrong value for single cid")
@@ -75,18 +99,28 @@ func TestPutGetRemove(t *testing.T) {
 
 	// Get a key that is not set
 	t.Log("Get non-existing key")
-	_, found = s.Get(noadd)
+	_, found, err = s.Get(noadd)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if found {
 		t.Error("Error, the key for the cid shouldn't be set")
 	}
 
 	t.Log("Remove entry for CID")
-	if !s.Remove(single, p, otherPiece) {
+	ok, err = s.Remove(single, p, otherPiece)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
 		t.Fatal("should have removed entry")
 	}
 
 	t.Log("Check for all entries for single CID")
-	ents, found = s.Get(single)
+	ents, found, err = s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !found {
 		t.Error("Error finding a cid from the batch")
 	}
@@ -98,25 +132,39 @@ func TestPutGetRemove(t *testing.T) {
 	}
 
 	t.Log("Remove only entry for CID")
-	if !s.Remove(single, p, piece) {
+	ok, err = s.Remove(single, p, piece)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
 		t.Fatal("should have removed entry")
 	}
-	_, found = s.Get(single)
+	_, found, err = s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if found {
 		t.Fatal("Should not have found CID with no entries")
 	}
 	t.Log("Remove entry for non-existent CID")
-	if s.Remove(single, p, piece) {
+	ok, err = s.Remove(single, p, piece)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
 		t.Fatal("should not have removed non-existent entry")
 	}
 
-	storeSize := s.Size()
+	cidCount := s.CidCount()
 	t.Log("Remove provider")
-	removed := s.RemoveProvider(p)
-	if removed < storeSize {
-		t.Fatalf("should have removed at least %d entries, only removed %d", storeSize, removed)
+	removed, err := s.RemoveProvider(p)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if s.Size() != 0 {
+	if removed < int64(cidCount) {
+		t.Fatalf("should have removed at least %d entries, only removed %d", cidCount, removed)
+	}
+	if s.CidCount() != 0 {
 		t.Fatal("should have 0 size after removing only provider")
 	}
 }
@@ -137,16 +185,26 @@ func TestRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if s.PutMany(cids, p, piece) == 0 {
+	count, err := s.PutMany(cids, p, piece)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count == 0 {
 		t.Fatal("did not put batch of cids")
 	}
 
-	_, found := s.Get(cids[0])
+	_, found, err := s.Get(cids[0])
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !found {
 		t.Error("Error finding a cid from previous cache")
 	}
 
-	_, found = s.Get(cids[maxSize+2])
+	_, found, err = s.Get(cids[maxSize+2])
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !found {
 		t.Error("Error finding a cid from new cache")
 	}
@@ -156,24 +214,37 @@ func TestRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if s.PutMany(cids2, p, piece2) == 0 {
+	count, err = s.PutMany(cids2, p, piece2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count == 0 {
 		t.Fatal("did not put batch of cids")
 	}
 
 	// Should find this because it was moved to new cache after 1st rotation
-	_, found = s.Get(cids[0])
+	_, found, err = s.Get(cids[0])
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !found {
 		t.Error("Error finding a cid from previous cache")
 	}
 
 	// Should find this because it should be in old cache after 2nd rotation
-	_, found = s.Get(cids[maxSize+2])
+	_, found, err = s.Get(cids[maxSize+2])
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !found {
 		t.Error("Error finding a cid from new cache")
 	}
 
 	// Should not find this because it was only in old cache after 1st rotation
-	_, found = s.Get(cids[2])
+	_, found, err = s.Get(cids[2])
+	if err != nil {
+		t.Fatal(err)
+	}
 	if found {
 		t.Error("cid should have been rotated out of cache")
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -18,19 +18,16 @@ type IndexEntry struct {
 type Storage interface {
 	// Get retrieves provider-piece info for a CID
 	Get(c cid.Cid) ([]IndexEntry, bool, error)
-	// Put stores a provider-piece entry for a CID if the entry is
-	// not already stored.  New entries are added to the entries that are already
-	// there.  Returns true if a new entry was added to the cache.
-	Put(c cid.Cid, providerID peer.ID, pieceID cid.Cid) (bool, error)
-	// PutMany stores the provider-piece entry for multiple CIDs.  Returns the
-	// number of new entries stored.
-	PutMany(cs []cid.Cid, providerID peer.ID, pieceID cid.Cid) (int, error)
+	// Put stores a provider-piece entry for a CID if the entry is not already
+	// stored.  New entries are added to the entries that are already there.
+	Put(c cid.Cid, providerID peer.ID, pieceID cid.Cid) error
+	// PutMany stores the provider-piece entry for multiple CIDs
+	PutMany(cs []cid.Cid, providerID peer.ID, pieceID cid.Cid) error
 	// Remove removes a provider-piece entry for a CID
-	Remove(c cid.Cid, providerID peer.ID, pieceID cid.Cid) (bool, error)
-	// RemoveMany removes a provider-piece entry from multiple CIDs.  Returns
-	// the number of entries removed.
-	RemoveMany(cids []cid.Cid, providerID peer.ID, pieceID cid.Cid) (int, error)
+	Remove(c cid.Cid, providerID peer.ID, pieceID cid.Cid) error
+	// RemoveMany removes a provider-piece entry from multiple CIDs
+	RemoveMany(cids []cid.Cid, providerID peer.ID, pieceID cid.Cid) error
 	// RemoveProvider removes all enrties for specified provider.  This is used
 	// when a provider is no longer indexed by the indexer.
-	RemoveProvider(providerID peer.ID) (int64, error)
+	RemoveProvider(providerID peer.ID) error
 }

--- a/store/store.go
+++ b/store/store.go
@@ -17,20 +17,20 @@ type IndexEntry struct {
 // them more easily, or if we want to introduce additional features to either of them.
 type Storage interface {
 	// Get retrieves provider-piece info for a CID
-	Get(c cid.Cid) ([]IndexEntry, bool)
+	Get(c cid.Cid) ([]IndexEntry, bool, error)
 	// Put stores a provider-piece entry for a CID if the entry is
 	// not already stored.  New entries are added to the entries that are already
 	// there.  Returns true if a new entry was added to the cache.
-	Put(c cid.Cid, providerID peer.ID, pieceID cid.Cid) bool
+	Put(c cid.Cid, providerID peer.ID, pieceID cid.Cid) (bool, error)
 	// PutMany stores the provider-piece entry for multiple CIDs.  Returns the
 	// number of new entries stored.
-	PutMany(cs []cid.Cid, providerID peer.ID, pieceID cid.Cid) int
+	PutMany(cs []cid.Cid, providerID peer.ID, pieceID cid.Cid) (int, error)
 	// Remove removes a provider-piece entry for a CID
-	Remove(c cid.Cid, providerID peer.ID, pieceID cid.Cid) bool
+	Remove(c cid.Cid, providerID peer.ID, pieceID cid.Cid) (bool, error)
 	// RemoveMany removes a provider-piece entry from multiple CIDs.  Returns
 	// the number of entries removed.
-	RemoveMany(cids []cid.Cid, providerID peer.ID, pieceID cid.Cid) int
+	RemoveMany(cids []cid.Cid, providerID peer.ID, pieceID cid.Cid) (int, error)
 	// RemoveProvider removes all enrties for specified provider.  This is used
 	// when a provider is no longer indexed by the indexer.
-	RemoveProvider(providerID peer.ID) int
+	RemoveProvider(providerID peer.ID) (int64, error)
 }


### PR DESCRIPTION
Removed these in a previous PR, but they should be there in case an underlying implementation returns errors.