### PR TITLE
Pogreb-backed persistence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/filecoin-project/storetheindex
 go 1.16
 
 require (
+	github.com/akrylysov/pogreb v0.10.1
 	github.com/filecoin-project/dealbot v0.0.15
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.1.0
 	github.com/gammazero/radixtree v0.2.3

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-log/v2 v2.2.0
-	github.com/ipld/go-storethehash v0.0.0-20210703051105-8531c948790d
+	github.com/ipld/go-storethehash v0.0.0-20210708185310-2f630d316596
 	github.com/klauspost/cpuid/v2 v2.0.7 // indirect
 	github.com/lib/pq v1.9.0
 	github.com/libp2p/go-libp2p-core v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat6
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
+github.com/akrylysov/pogreb v0.10.1 h1:FqlR8VR7uCbJdfUob916tPM+idpKgeESDXOA1K0DK4w=
+github.com/akrylysov/pogreb v0.10.1/go.mod h1:pNs6QmpQ1UlTJKDezuRWmaqkgUE2TuU0YTWyqJZ7+lI=
 github.com/alecthomas/jsonschema v0.0.0-20200530073317-71f438968921/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/go.sum
+++ b/go.sum
@@ -695,8 +695,8 @@ github.com/ipld/go-ipld-prime-proto v0.0.0-20200428191222-c1ffdadc01e1/go.mod h1
 github.com/ipld/go-ipld-prime-proto v0.0.0-20200922192210-9a2bfd4440a6/go.mod h1:3pHYooM9Ea65jewRwrb2u5uHZCNkNTe9ABsVB+SrkH0=
 github.com/ipld/go-ipld-prime-proto v0.1.0/go.mod h1:11zp8f3sHVgIqtb/c9Kr5ZGqpnCLF1IVTNOez9TopzE=
 github.com/ipld/go-ipld-prime-proto v0.1.1/go.mod h1:cI9NwYAUKCLUwqufoUjChISxuTEkaY2yvNYCRCuhRck=
-github.com/ipld/go-storethehash v0.0.0-20210703051105-8531c948790d h1:KsZDL5wc2076TRQRW8KywQsUjsQuS335UFXm6svUXPM=
-github.com/ipld/go-storethehash v0.0.0-20210703051105-8531c948790d/go.mod h1:PwE6iq8TiWJRI3zMGA1RtkFAnrDMK93dLA5SUeu0lH8=
+github.com/ipld/go-storethehash v0.0.0-20210708185310-2f630d316596 h1:thNwkdxUEh5z+uba31yllmMSuPOLO4WpaEFX7IhmSUM=
+github.com/ipld/go-storethehash v0.0.0-20210708185310-2f630d316596/go.mod h1:PwE6iq8TiWJRI3zMGA1RtkFAnrDMK93dLA5SUeu0lH8=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/store/persistent/benchmarks.go
+++ b/store/persistent/benchmarks.go
@@ -16,41 +16,6 @@ import (
 const testDataDir = "../../test_data/"
 const testDataExt = ".data"
 
-/*
-func BenchmarkSingle10KB(b *testing.B) {
-	benchSingleGet("10KB", b)
-}
-
-func BenchmarkSingle10MB(b *testing.B) {
-	benchSingleGet("10MB", b)
-}
-
-func BenchmarkSingle100MB(b *testing.B) {
-	benchSingleGet("100MB", b)
-}
-
-func BenchmarkSingle1GB(b *testing.B) {
-	benchSingleGet("1GB", b)
-}
-
-func BenchmarkParallel10KB(b *testing.B) {
-	benchParallelGet("10KB", b)
-}
-
-func BenchmarkParallel10MB(b *testing.B) {
-	benchParallelGet("10MB", b)
-}
-
-func BenchmarkParallel100MB(b *testing.B) {
-	benchParallelGet("100MB", b)
-}
-
-func BenchmarkParallel1GB(b *testing.B) {
-
-	benchParallelGet("1GB", b)
-}
-*/
-
 func prepare(s store.Storage, size string, b *testing.B) {
 	out := make(chan cid.Cid)
 	errOut := make(chan error, 1)

--- a/store/persistent/benchmarks.go
+++ b/store/persistent/benchmarks.go
@@ -1,0 +1,169 @@
+package persistent
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/storetheindex/importer"
+	"github.com/filecoin-project/storetheindex/store"
+	"github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+const testDataDir = "../../test_data/"
+const testDataExt = ".data"
+
+/*
+func BenchmarkSingle10KB(b *testing.B) {
+	benchSingleGet("10KB", b)
+}
+
+func BenchmarkSingle10MB(b *testing.B) {
+	benchSingleGet("10MB", b)
+}
+
+func BenchmarkSingle100MB(b *testing.B) {
+	benchSingleGet("100MB", b)
+}
+
+func BenchmarkSingle1GB(b *testing.B) {
+	benchSingleGet("1GB", b)
+}
+
+func BenchmarkParallel10KB(b *testing.B) {
+	benchParallelGet("10KB", b)
+}
+
+func BenchmarkParallel10MB(b *testing.B) {
+	benchParallelGet("10MB", b)
+}
+
+func BenchmarkParallel100MB(b *testing.B) {
+	benchParallelGet("100MB", b)
+}
+
+func BenchmarkParallel1GB(b *testing.B) {
+
+	benchParallelGet("1GB", b)
+}
+*/
+
+func prepare(s store.Storage, size string, b *testing.B) {
+	out := make(chan cid.Cid)
+	errOut := make(chan error, 1)
+
+	file, err := os.OpenFile(testDataDir+size+testDataExt, os.O_RDONLY, 0644)
+	if err != nil {
+		b.Fatalf("couldn't find the right input file for %v, try synthetizing from CLI: %v", size, err)
+	}
+	defer file.Close()
+
+	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	imp := importer.NewCidListImporter(file)
+
+	go imp.Read(context.Background(), out, errOut)
+	for c := range out {
+		err = s.Put(c, p, c)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	err = <-errOut
+	if err != nil {
+		b.Fatal(err)
+	}
+
+}
+
+func read(s store.Storage, size string, m *metrics, b *testing.B) {
+	out := make(chan cid.Cid)
+	errOut := make(chan error, 1)
+
+	file, err := os.OpenFile(testDataDir+size+testDataExt, os.O_RDONLY, 0644)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	imp := importer.NewCidListImporter(file)
+
+	b.ResetTimer()
+	go imp.Read(context.Background(), out, errOut)
+	for c := range out {
+		now := time.Now()
+		_, found, err := s.Get(c)
+		if err != nil || !found {
+			b.Errorf("cid not found")
+		}
+		m.getTime.add(time.Since(now).Microseconds())
+
+	}
+	err = <-errOut
+	if err != nil {
+		b.Fatal(err)
+	}
+
+}
+
+func BenchSingleGet(s store.StorageFlusher, size string, b *testing.B) {
+	m := initMetrics()
+	prepare(s, size, b)
+	read(s, size, m, b)
+	err := s.Flush()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	report(s, m, b)
+}
+
+func BenchParallelGet(s store.StorageFlusher, size string, b *testing.B) {
+	var wg sync.WaitGroup
+
+	wg.Add(20)
+	for i := 0; i < 20; i++ {
+		go func(wg *sync.WaitGroup) {
+			defer wg.Done()
+			BenchSingleGet(s, size, b)
+
+		}(&wg)
+	}
+	wg.Wait()
+}
+
+type metric struct {
+	val int64
+	n   uint64
+}
+
+func (m *metric) add(val int64) {
+	m.val += val
+	m.n++
+}
+
+func (m *metric) avg() float64 {
+	return float64(m.val) / float64(m.n)
+}
+
+type metrics struct {
+	getTime *metric
+}
+
+func initMetrics() *metrics {
+	return &metrics{
+		getTime: &metric{},
+	}
+}
+
+func report(s store.StorageFlusher, m *metrics, b *testing.B) {
+	memSize, _ := s.Size()
+	avgT := m.getTime.avg() / 1000
+	sizeMB := float64(memSize) / 1000000
+	b.Log("Memory size (MB):", sizeMB)
+	b.Log("Avg time per get (ms):", avgT)
+
+	// TODO: Report to file to process results.
+}

--- a/store/persistent/pogreb/pogreb.go
+++ b/store/persistent/pogreb/pogreb.go
@@ -1,0 +1,195 @@
+// NOTE: Due to how pogreb is implemented, it is only capable of storing up to
+// 4 billion records max (https://github.com/akrylysov/pogreb/issues/38).
+// With our current scale I don't expect us to reach this limit, but
+// noting it here just in case it becomes an issue in the future.
+// Interesting link with alternatives: https://github.com/akrylysov/pogreb/issues/38#issuecomment-850852472
+
+package pogreb
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/akrylysov/pogreb"
+	"github.com/filecoin-project/storetheindex/store"
+
+	"github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+var _ store.StorageFlusher = &pStorage{}
+
+const DefaultSyncInterval = time.Second
+
+type pStorage struct {
+	dir   string
+	store *pogreb.DB
+}
+
+func New(dir string) (*pStorage, error) {
+	opts := pogreb.Options{BackgroundSyncInterval: DefaultSyncInterval}
+
+	s, err := pogreb.Open(dir, &opts)
+	if err != nil {
+		return nil, err
+	}
+	return &pStorage{dir: dir, store: s}, nil
+}
+
+func (s *pStorage) Get(c cid.Cid) ([]store.IndexEntry, bool, error) {
+	return s.get(c.Bytes())
+}
+
+func (s *pStorage) get(k []byte) ([]store.IndexEntry, bool, error) {
+	value, err := s.store.Get(k)
+	if err != nil {
+		return nil, false, err
+	}
+	if value == nil {
+		return nil, false, nil
+	}
+
+	out, err := store.Unmarshal(value)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+
+}
+
+func (s *pStorage) Put(c cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+	in := store.IndexEntry{ProvID: provID, PieceID: pieceID}
+	return s.put(c.Bytes(), in)
+}
+
+func (s *pStorage) put(k []byte, in store.IndexEntry) error {
+	old, found, err := s.get(k)
+	if err != nil {
+		return err
+	}
+	// If found it means there is already a value there.
+	// Check if we are trying to put a duplicate entry
+	if found && duplicateEntry(in, old) {
+		return nil
+	}
+
+	li := append(old, in)
+	b, err := store.Marshal(li)
+	if err != nil {
+		return err
+	}
+
+	return s.store.Put(k, b)
+}
+
+func (s *pStorage) PutMany(cs []cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+	in := store.IndexEntry{ProvID: provID, PieceID: pieceID}
+	for _, c := range cs {
+		err := s.put(c.Bytes(), in)
+		if err != nil {
+			// TODO: Log error but don't return. Errors for a single
+			// CID shouldn't stop from putting the rest.
+			continue
+		}
+	}
+	return nil
+}
+
+func (s *pStorage) Flush() error {
+	return s.store.Sync()
+}
+
+func (s *pStorage) Size() (int64, error) {
+	var size int64
+	err := filepath.Walk(s.dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
+
+}
+
+func (s *pStorage) Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+	_, err := s.remove(c, provID, pieceID)
+	return err
+}
+
+func (s *pStorage) remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) (bool, error) {
+	in := store.IndexEntry{ProvID: provID, PieceID: pieceID}
+	k := c.Bytes()
+	old, found, err := s.get(k)
+	if err != nil {
+		return false, err
+	}
+	// If found it means there is a value for the cid
+	// check if there is something to remove.
+	if found {
+		return s.removeEntry(k, in, old)
+	}
+	return false, nil
+}
+
+func (s *pStorage) RemoveMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+	for i := range cids {
+		_, err := s.remove(cids[i], provID, pieceID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveProvider removes all enrties for specified provider.  This is used
+// when a provider is no longer indexed by the indexer.
+func (s *pStorage) RemoveProvider(providerID peer.ID) error {
+	// NOTE: There is no straightforward way of implementing this
+	// batch remove. We could use an offline process which
+	// iterates through all keys removing/updating
+	// the ones belonging to provider.
+	// Deferring to the future
+	panic("not implemented")
+}
+
+// DuplicateEntry checks if the entry already exists in the index. An entry
+// for the same provider but a different piece is not considered
+// a duplicate entry (at least for now)
+func duplicateEntry(in store.IndexEntry, old []store.IndexEntry) bool {
+	for i := range old {
+		if in.PieceID == old[i].PieceID &&
+			in.ProvID == old[i].ProvID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *pStorage) removeEntry(k []byte, entry store.IndexEntry, stored []store.IndexEntry) (bool, error) {
+	for i := range stored {
+		if entry.PieceID == stored[i].PieceID &&
+			entry.ProvID == stored[i].ProvID {
+			// It is the only value, remove the entry
+			if len(stored) == 1 {
+				return true, s.store.Delete(k)
+			}
+
+			// else remove from entry and put updated structure
+			stored[i] = stored[len(stored)-1]
+			stored[len(stored)-1] = store.IndexEntry{}
+			b, err := store.Marshal(stored[:len(stored)-1])
+			if err != nil {
+				return false, err
+			}
+			if err := s.store.Put(k, b); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/store/persistent/pogreb/pogreb_bench_test.go
+++ b/store/persistent/pogreb/pogreb_bench_test.go
@@ -1,4 +1,4 @@
-package storethehash_test
+package pogreb_test
 
 import (
 	"testing"
@@ -11,7 +11,7 @@ const testDataDir = "../../test_data/"
 const testDataExt = ".data"
 
 func initBenchStore(b *testing.B) store.StorageFlusher {
-	s, err := initSth()
+	s, err := initPogreb()
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/store/persistent/pogreb/pogreb_test.go
+++ b/store/persistent/pogreb/pogreb_test.go
@@ -1,4 +1,4 @@
-package storethehash_test
+package pogreb_test
 
 import (
 	"io/ioutil"
@@ -6,19 +6,19 @@ import (
 
 	"github.com/filecoin-project/storetheindex/store"
 	"github.com/filecoin-project/storetheindex/store/persistent"
-	"github.com/filecoin-project/storetheindex/store/persistent/storethehash"
+	"github.com/filecoin-project/storetheindex/store/persistent/pogreb"
 )
 
-func initSth() (store.StorageFlusher, error) {
+func initPogreb() (store.StorageFlusher, error) {
 	tmpDir, err := ioutil.TempDir("", "sth")
 	if err != nil {
 		return nil, err
 	}
-	return storethehash.New(tmpDir)
+	return pogreb.New(tmpDir)
 }
 
 func TestE2E(t *testing.T) {
-	s, err := initSth()
+	s, err := initPogreb()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +26,7 @@ func TestE2E(t *testing.T) {
 }
 
 func TestSize(t *testing.T) {
-	s, err := initSth()
+	s, err := initPogreb()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestSize(t *testing.T) {
 }
 
 func TestRemoveMany(t *testing.T) {
-	s, err := initSth()
+	s, err := initPogreb()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/store/persistent/storethehash/storethehash.go
+++ b/store/persistent/storethehash/storethehash.go
@@ -173,6 +173,7 @@ func (s *sthStorage) RemoveProvider(providerID peer.ID) error {
 	// batch remove. We can either regenerate the index from
 	// the original data, or iterate through the whole the whole primary storage
 	// inspecting all entries for the provider in cids.
+	// Deferring to the future
 	panic("not implemented")
 }
 

--- a/store/persistent/storethehash/storethehash.go
+++ b/store/persistent/storethehash/storethehash.go
@@ -197,16 +197,17 @@ func (s *sthStorage) removeEntry(k []byte, entry store.IndexEntry, stored []stor
 			// It is the only value, remove the entry
 			if len(stored) == 1 {
 				return s.store.Remove(k)
-			} else {
-				stored[i] = stored[len(stored)-1]
-				stored[len(stored)-1] = store.IndexEntry{}
-				b, err := store.Marshal(stored[:len(stored)-1])
-				if err != nil {
-					return false, err
-				}
-				if err := s.store.Put(k, b); err != nil {
-					return false, err
-				}
+			}
+
+			// else remove from entry and put updated structure
+			stored[i] = stored[len(stored)-1]
+			stored[len(stored)-1] = store.IndexEntry{}
+			b, err := store.Marshal(stored[:len(stored)-1])
+			if err != nil {
+				return false, err
+			}
+			if err := s.store.Put(k, b); err != nil {
+				return false, err
 			}
 			return true, nil
 		}

--- a/store/persistent/storethehash/storethehash.go
+++ b/store/persistent/storethehash/storethehash.go
@@ -137,30 +137,42 @@ func (s *sthStorage) Size() (int64, error) {
 
 }
 func (s *sthStorage) Remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+	_, err := s.remove(c, provID, pieceID)
+	return err
+}
+
+func (s *sthStorage) remove(c cid.Cid, provID peer.ID, pieceID cid.Cid) (bool, error) {
 	in := store.IndexEntry{ProvID: provID, PieceID: pieceID}
 	k := c.Bytes()
 	old, found, err := s.get(k)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// If found it means there is a value for the cid
 	// check if there is something to remove.
 	if found {
-		_, err := s.removeEntry(k, in, old)
-		return err
+		return s.removeEntry(k, in, old)
 	}
-	return nil
-	// panic("not implemented")
+	return false, nil
 }
 
-// RemoveMany removes a provider-piece entry from multiple CIDs
-func (s *sthStorage) RemoveMany(cids []cid.Cid, providerID peer.ID, pieceID cid.Cid) error {
-	panic("not implemented")
+func (s *sthStorage) RemoveMany(cids []cid.Cid, provID peer.ID, pieceID cid.Cid) error {
+	for i := range cids {
+		_, err := s.remove(cids[i], provID, pieceID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RemoveProvider removes all enrties for specified provider.  This is used
 // when a provider is no longer indexed by the indexer.
 func (s *sthStorage) RemoveProvider(providerID peer.ID) error {
+	// NOTE: There is no straightforward way of implementing this
+	// batch remove. We can either regenerate the index from
+	// the original data, or iterate through the whole the whole primary storage
+	// inspecting all entries for the provider in cids.
 	panic("not implemented")
 }
 

--- a/store/persistent/storethehash/storethehash_bench_test.go
+++ b/store/persistent/storethehash/storethehash_bench_test.go
@@ -31,6 +31,34 @@ func BenchmarkSingle1GB(b *testing.B) {
 	benchSingleGet("1GB", b)
 }
 
+func BenchmarkParallel10KB(b *testing.B) {
+	benchSingleGet("10KB", b)
+}
+
+func BenchmarkParallel10MB(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			BenchmarkSingle10MB(b)
+		}
+	})
+}
+
+func BenchmarkParallel100MB(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			BenchmarkSingle100MB(b)
+		}
+	})
+}
+
+func BenchmarkParallel1GB(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			BenchmarkSingle100MB(b)
+		}
+	})
+}
+
 func prepare(s store.Storage, size string, b *testing.B) {
 	out := make(chan cid.Cid)
 	errOut := make(chan error, 1)

--- a/store/persistent/storethehash/storethehash_bench_test.go
+++ b/store/persistent/storethehash/storethehash_bench_test.go
@@ -3,6 +3,7 @@ package storethehash_test
 import (
 	"context"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,31 +33,19 @@ func BenchmarkSingle1GB(b *testing.B) {
 }
 
 func BenchmarkParallel10KB(b *testing.B) {
-	benchSingleGet("10KB", b)
+	benchParallelGet("10KB", b)
 }
 
 func BenchmarkParallel10MB(b *testing.B) {
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			BenchmarkSingle10MB(b)
-		}
-	})
+	benchParallelGet("10MB", b)
 }
 
 func BenchmarkParallel100MB(b *testing.B) {
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			BenchmarkSingle100MB(b)
-		}
-	})
+	benchParallelGet("100MB", b)
 }
 
 func BenchmarkParallel1GB(b *testing.B) {
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			BenchmarkSingle100MB(b)
-		}
-	})
+	benchParallelGet("1GB", b)
 }
 
 func prepare(s store.Storage, size string, b *testing.B) {
@@ -130,9 +119,21 @@ func benchSingleGet(size string, b *testing.B) {
 		b.Fatal(err)
 	}
 
-	memSize, _ := s.Size()
-	b.ReportMetric(float64(memSize)/1000000, "MB")
-	b.ReportMetric(m.getTime.avg()/1000, "ms/op")
+	report(s, m, b)
+}
+
+func benchParallelGet(size string, b *testing.B) {
+	var wg sync.WaitGroup
+
+	wg.Add(20)
+	for i := 0; i < 20; i++ {
+		go func(wg *sync.WaitGroup) {
+			defer wg.Done()
+			benchSingleGet(size, b)
+
+		}(&wg)
+	}
+	wg.Wait()
 }
 
 type metric struct {
@@ -157,4 +158,14 @@ func initMetrics() *metrics {
 	return &metrics{
 		getTime: &metric{},
 	}
+}
+
+func report(s store.StorageFlusher, m *metrics, b *testing.B) {
+	memSize, _ := s.Size()
+	avgT := m.getTime.avg() / 1000
+	sizeMB := float64(memSize) / 1000000
+	b.Log("Memory size (MB):", sizeMB)
+	b.Log("Avg time per get (ms):", avgT)
+
+	// TODO: Report to file to process results.
 }

--- a/store/persistent/storethehash/storethehash_test.go
+++ b/store/persistent/storethehash/storethehash_test.go
@@ -109,6 +109,26 @@ func TestE2E(t *testing.T) {
 	if found {
 		t.Errorf("Error, the key for the cid shouldn't be set")
 	}
+
+	// Remove a key
+
+	// Put a single CID
+	t.Logf("Remove key")
+	err = s.Remove(single, p, piece)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+
+	_, found, err = s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Errorf("cid should have been removed")
+	}
+
+	// TODO: Test removing a an entry from the key
+
 }
 
 func TestSize(t *testing.T) {

--- a/store/persistent/storethehash/storethehash_test.go
+++ b/store/persistent/storethehash/storethehash_test.go
@@ -40,6 +40,7 @@ func TestE2E(t *testing.T) {
 	single := cids[1]
 	noadd := cids[2]
 	batch := cids[3:]
+	remove := cids[3]
 
 	// Put a single CID
 	t.Logf("Put/Get a single CID in primary storage")
@@ -114,12 +115,12 @@ func TestE2E(t *testing.T) {
 
 	// Put a single CID
 	t.Logf("Remove key")
-	err = s.Remove(single, p, piece)
+	err = s.Remove(remove, p, piece)
 	if err != nil {
 		t.Fatal("Error putting single cid: ", err)
 	}
 
-	_, found, err = s.Get(single)
+	i, found, err = s.Get(remove)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +128,21 @@ func TestE2E(t *testing.T) {
 		t.Errorf("cid should have been removed")
 	}
 
-	// TODO: Test removing a an entry from the key
+	// Remove an entry from the key
+	err = s.Remove(single, p, piece)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	i, found, err = s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("cid should still have one entry")
+	}
+	if len(i) != 1 {
+		t.Errorf("wrong number of entries after remove")
+	}
 
 }
 

--- a/store/persistent/storethehash/storethehash_test.go
+++ b/store/persistent/storethehash/storethehash_test.go
@@ -112,8 +112,6 @@ func TestE2E(t *testing.T) {
 	}
 
 	// Remove a key
-
-	// Put a single CID
 	t.Logf("Remove key")
 	err = s.Remove(remove, p, piece)
 	if err != nil {
@@ -173,4 +171,52 @@ func TestSize(t *testing.T) {
 	if size == int64(0) {
 		t.Error("failed to compute storage size")
 	}
+}
+
+func TestRemoveMany(t *testing.T) {
+	// Create new valid peer.ID
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Init storage
+	s, err := initSth()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cids, err := utils.RandomCids(15)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	piece := cids[0]
+	batch := cids[1:]
+
+	// Put a batch of CIDs
+	t.Logf("Put/Get a batch of CIDs in primary storage")
+	err = s.PutMany(batch, p, piece)
+	if err != nil {
+		t.Fatal("Error putting batch of cids: ", err)
+	}
+
+	// Put a single CID
+	t.Logf("Remove key")
+	err = s.RemoveMany(cids[2:], p, piece)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+
+	i, found, err := s.Get(cids[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("cid should not have been removed")
+	}
+	if len(i) != 1 {
+		t.Errorf("wrong number of cids removed")
+	}
+
 }

--- a/store/persistent/tests.go
+++ b/store/persistent/tests.go
@@ -1,0 +1,196 @@
+package persistent
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/storetheindex/store"
+	"github.com/filecoin-project/storetheindex/utils"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+func E2ETest(t *testing.T, s store.StorageFlusher) {
+	// Create new valid peer.ID
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cids, err := utils.RandomCids(15)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	piece := cids[0]
+	single := cids[1]
+	noadd := cids[2]
+	batch := cids[3:]
+	remove := cids[3]
+
+	// Put a single CID
+	t.Logf("Put/Get a single CID in primary storage")
+	err = s.Put(single, p, piece)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+
+	i, found, err := s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("Error finding single cid")
+	}
+	if i[0].PieceID != piece || i[0].ProvID != p {
+		t.Errorf("Got wrong value for single cid")
+	}
+
+	// Put a batch of CIDs
+	t.Logf("Put/Get a batch of CIDs in primary storage")
+	err = s.PutMany(batch, p, piece)
+	if err != nil {
+		t.Fatal("Error putting batch of cids: ", err)
+	}
+
+	i, found, err = s.Get(cids[5])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("Error finding a cid from the batch")
+	}
+	if i[0].PieceID != piece || i[0].ProvID != p {
+		t.Errorf("Got wrong value for single cid")
+	}
+
+	// Put on an existing key
+	t.Logf("Put/Get on existing key")
+	err = s.Put(single, p, noadd)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	i, found, err = s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("Error finding a cid from the batch")
+	}
+	if len(i) != 2 {
+		t.Fatal("Update over existing key not correct")
+	}
+	if i[1].PieceID != noadd || i[1].ProvID != p {
+		t.Errorf("Got wrong value for single cid")
+	}
+
+	// Get a key that is not set
+	t.Logf("Get non-existing key")
+	_, found, err = s.Get(noadd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Errorf("Error, the key for the cid shouldn't be set")
+	}
+
+	// Remove a key
+	t.Logf("Remove key")
+	err = s.Remove(remove, p, piece)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+
+	i, found, err = s.Get(remove)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Errorf("cid should have been removed")
+	}
+
+	// Remove an entry from the key
+	err = s.Remove(single, p, piece)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	i, found, err = s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("cid should still have one entry")
+	}
+	if len(i) != 1 {
+		t.Errorf("wrong number of entries after remove")
+	}
+
+}
+
+func SizeTest(t *testing.T, s store.StorageFlusher) {
+	// Init storage
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cids, err := utils.RandomCids(150)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range cids {
+		s.Put(c, p, c)
+	}
+
+	size, err := s.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size == int64(0) {
+		t.Error("failed to compute storage size")
+	}
+}
+
+func RemoveManyTest(t *testing.T, s store.StorageFlusher) {
+	// Create new valid peer.ID
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cids, err := utils.RandomCids(15)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	piece := cids[0]
+	batch := cids[1:]
+
+	// Put a batch of CIDs
+	t.Logf("Put/Get a batch of CIDs in primary storage")
+	err = s.PutMany(batch, p, piece)
+	if err != nil {
+		t.Fatal("Error putting batch of cids: ", err)
+	}
+
+	// Put a single CID
+	t.Logf("Remove key")
+	err = s.RemoveMany(cids[2:], p, piece)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+
+	i, found, err := s.Get(cids[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("cid should not have been removed")
+	}
+	if len(i) != 1 {
+		t.Errorf("wrong number of cids removed")
+	}
+
+}


### PR DESCRIPTION
Depends on: https://github.com/filecoin-project/storetheindex/pull/10

This PR: 
- Implements `StorageFlusher` interface for Pogreb.
- Organizes the code so persistent storage implementation can reuse core unit tests and benchmarks code.

__Sidenote regarding storetheindex storage interface: Is true that pogreb and storethehash are quite alike, but implementing a new k-v storage for our interface has been quite straightforward and no changes have been needed in the interface. It may be worth doing this same exercise with a full-fledge database like PostgreSQL to further validate this.

Also, worth checking this out for alternatives to Pogreb: https://github.com/akrylysov/pogreb/issues/38#issuecomment-850852472__

//cc @gammazero 