### PR TITLE
API takes IndexEntry instead of providerID + data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/lib/pq v1.9.0
 	github.com/libp2p/go-libp2p-core v0.7.0
 	github.com/multiformats/go-multihash v0.0.15
+	github.com/multiformats/go-varint v0.0.6
 	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e // indirect
 	github.com/urfave/cli/v2 v2.3.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20210422071115-ad5b82622e0f // indirect

--- a/store/store.go
+++ b/store/store.go
@@ -1,16 +1,57 @@
 package store
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-core/peer"
+	varint "github.com/multiformats/go-varint"
 )
 
 // IndexEntry describes the information to be stored for each CID in the indexer.
 type IndexEntry struct {
-	ProvID  peer.ID // ID of the provider of the CID.
-	PieceID cid.Cid // PieceID of the CID where the CID is stored in the provider (may be nil)
+	// PrividerID is the peer ID of the provider of the CID
+	ProviderID peer.ID
+	// Metadata is serialized data that provides information about retrieving
+	// data, for the indexed CID, from the identified provider.
+	Metadata []byte
+}
+
+func MakeIndexEntry(providerID peer.ID, protocol uint64, data []byte) IndexEntry {
+	return IndexEntry{
+		ProviderID: providerID,
+		Metadata:   encodeMetadata(protocol, data),
+	}
+}
+
+// PutData writes the protocol ID and the encoded data to IndexEntry.Metadata
+func (ie *IndexEntry) PutData(protocol uint64, data []byte) {
+	ie.Metadata = encodeMetadata(protocol, data)
+}
+
+// GetData returns the protocol ID and the encoded data from the IndexEntry.Metadata
+func (ie *IndexEntry) GetData() (uint64, []byte, error) {
+	protocol, len, err := varint.FromUvarint(ie.Metadata)
+	if err != nil {
+		return 0, nil, err
+	}
+	return protocol, ie.Metadata[len:], nil
+}
+
+// Equal returns true if two IndexEntry instances are identical
+func (ie IndexEntry) Equal(other IndexEntry) bool {
+	return ie.ProviderID == other.ProviderID && bytes.Equal(ie.Metadata, other.Metadata)
+}
+
+func encodeMetadata(protocol uint64, data []byte) []byte {
+	varintSize := varint.UvarintSize(protocol)
+	buf := make([]byte, varintSize+len(data))
+	varint.PutUvarint(buf, protocol)
+	if len(data) != 0 {
+		copy(buf[varintSize:], data)
+	}
+	return buf
 }
 
 // Storage is the main interface for storage systems used in the indexer.
@@ -22,13 +63,13 @@ type Storage interface {
 	Get(c cid.Cid) ([]IndexEntry, bool, error)
 	// Put stores a provider-piece entry for a CID if the entry is not already
 	// stored.  New entries are added to the entries that are already there.
-	Put(c cid.Cid, providerID peer.ID, pieceID cid.Cid) error
+	Put(c cid.Cid, entry IndexEntry) error
 	// PutMany stores the provider-piece entry for multiple CIDs
-	PutMany(cs []cid.Cid, providerID peer.ID, pieceID cid.Cid) error
+	PutMany(cs []cid.Cid, entry IndexEntry) error
 	// Remove removes a provider-piece entry for a CID
-	Remove(c cid.Cid, providerID peer.ID, pieceID cid.Cid) error
+	Remove(c cid.Cid, entry IndexEntry) error
 	// RemoveMany removes a provider-piece entry from multiple CIDs
-	RemoveMany(cids []cid.Cid, providerID peer.ID, pieceID cid.Cid) error
+	RemoveMany(cids []cid.Cid, entry IndexEntry) error
 	// RemoveProvider removes all enrties for specified provider.  This is used
 	// when a provider is no longer indexed by the indexer.
 	RemoveProvider(providerID peer.ID) error


### PR DESCRIPTION
The information associated with a CID will depend on the provider protocol.  This has been changed from storing PieceID to storing a byte slice that starts with a uvarint  to encode a protocol number that will indicate how to decode the following bytes.

- IndexEntry does not have PieceID, but now has uvarint + data
- Add Memory use tests for primary (run with `TEST_MEM_USE=1 go test -v`)
- Rename IndexEntry.ProvID -> IndexEntry.ProviderID
