### PR TITLE
Finish propagating interface changes through code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ a first glimpse).
 ```
 - Commands to read a list of CIDs from a manifest and a cid list.
 ```
-./storetheindex import manifest --dir <manifest> --providerID <peer.ID> --pieceID <cid>
-./storetheindex import cidlist --dir <manifest> --providerID <peer.ID> --pieceID <cid>
+./storetheindex import manifest --dir <manifest> --providerID <peer.ID> --metadata <bytes>
+./storetheindex import cidlist --dir <manifest> --providerID <peer.ID> --metadata <bytes>
 
 // Example
 ./storetheindex import cidlist --dir ./cid.out --providerID QmcJeseojbPW9hSejUM1sQ1a2QmbrryPK4Z8pWbRUPaYEn -e 127.0.0.1:3000

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -51,9 +51,9 @@ var ImportFlags = []cli.Flag{
 		Required: true,
 	},
 	&cli.StringFlag{
-		Name:     "piece",
-		Usage:    "Piece ID where the CIDs are sealed at provider",
-		Aliases:  []string{"pc"},
+		Name:     "metadata",
+		Usage:    "Bytes of opaque metadata corresponding to protocol 0",
+		Aliases:  []string{"m"},
 		Required: false,
 	},
 	DirFlag,

--- a/commands/import.go
+++ b/commands/import.go
@@ -82,11 +82,11 @@ func importManifestCmd(c *cli.Context) error {
 /*
 func importReader(ctx context.Context, c *cli.Context, i importer.Importer) error {
 	prov := c.String("provider")
-	piece := c.String("piece")
+	metadata := c.String("metadata")
 
 	// TODO:
 
-	log.Infof("Reading from provider: %s, and piece %s", prov, piece)
+	log.Infof("Reading from provider: %s, and metadata %s", prov, metadata)
 	cids := make(chan cid.Cid)
 	done := make(chan error)
 

--- a/store/persistent/benchmarks.go
+++ b/store/persistent/benchmarks.go
@@ -13,8 +13,12 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
-const testDataDir = "../../test_data/"
-const testDataExt = ".data"
+const (
+	testDataDir = "../../test_data/"
+	testDataExt = ".data"
+	// protocol ID for IndexEntry metadata
+	protocolID = 0
+)
 
 func prepare(s store.Storage, size string, b *testing.B) {
 	out := make(chan cid.Cid)
@@ -30,8 +34,10 @@ func prepare(s store.Storage, size string, b *testing.B) {
 	imp := importer.NewCidListImporter(file)
 
 	go imp.Read(context.Background(), out, errOut)
+
 	for c := range out {
-		err = s.Put(c, p, c)
+		entry := store.MakeIndexEntry(p, protocolID, c.Bytes())
+		err = s.Put(c, entry)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -59,18 +59,17 @@ func encodeMetadata(protocol uint64, data []byte) []byte {
 // same interface. This may change in the future if we want to discern between
 // them more easily, or if we want to introduce additional features to either of them.
 type Storage interface {
-	// Get retrieves provider-piece info for a CID
+	// Get retrieves a slice of IndexEntry for a CID
 	Get(c cid.Cid) ([]IndexEntry, bool, error)
-	// Put stores a provider-piece entry for a CID if the entry is not already
-	// stored.  New entries are added to the entries that are already there.
+	// Put stores an additional IndexEntry for a CID if the entry is not already stored
 	Put(c cid.Cid, entry IndexEntry) error
-	// PutMany stores the provider-piece entry for multiple CIDs
+	// PutMany stores an IndexEntry for multiple CIDs
 	PutMany(cs []cid.Cid, entry IndexEntry) error
-	// Remove removes a provider-piece entry for a CID
+	// Remove removes an IndexEntry for a CID
 	Remove(c cid.Cid, entry IndexEntry) error
-	// RemoveMany removes a provider-piece entry from multiple CIDs
+	// RemoveMany removes an IndexEntry from multiple CIDs
 	RemoveMany(cids []cid.Cid, entry IndexEntry) error
-	// RemoveProvider removes all enrties for specified provider.  This is used
+	// RemoveProvider removes all entries for specified provider.  This is used
 	// when a provider is no longer indexed by the indexer.
 	RemoveProvider(providerID peer.ID) error
 	// Size returns the total storage capacity being used


### PR DESCRIPTION
This is a follow-up PR to finish propagating the interface changes, that use IndexEntry instead of provider and piece ID.