### PR TITLE
Implemented node storage. Fixed synthetic. Interface changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ a first glimpse).
 - Simple primary storage based on https://github.com/gammazero/radixtree
 - Run node (it starts the node's API, and intializes its storage).
 ```
-./storetheindex daemon -e 127.0.0.1:3000
+./storetheindex daemon --storage <persistent_backend> -e <endpoint> --dir <persistent_dir>
+# Example
+./storetheindex daemon --storage sth -e 127.0.0.1:3000 --dir /tmp/
 ```
 - Commands to read a list of CIDs from a manifest and a cid list.
 ```
-./storetheindex import manifest --dir <manifest> --providerID <peer.ID> --metadata <bytes>
-./storetheindex import cidlist --dir <manifest> --providerID <peer.ID> --metadata <bytes>
+./storetheindex import manifest --dir <manifest> --provider <peer.ID> --metadata <bytes>
+./storetheindex import cidlist --dir <manifest> --provider <peer.ID> --metadata <bytes>
 
 // Example
-./storetheindex import cidlist --dir ./cid.out --providerID QmcJeseojbPW9hSejUM1sQ1a2QmbrryPK4Z8pWbRUPaYEn -e 127.0.0.1:3000
+./storetheindex import cidlist --dir ./cid.out --provider QmcJeseojbPW9hSejUM1sQ1a2QmbrryPK4Z8pWbRUPaYEn -e 127.0.0.1:3000
 ```
 - Simple get command for single CID (for testing purposes).
 ```

--- a/commands/find.go
+++ b/commands/find.go
@@ -12,18 +12,16 @@ import (
 var GetCmd = &cli.Command{
 	Name:   "get",
 	Usage:  "Get single Cid from idexer",
-	Flags:  DaemonFlags,
+	Flags:  ClientCmdFlags,
 	Action: getCidCmd,
 }
 
 func getCidCmd(c *cli.Context) error {
 	cl := client.New(c)
 
-	log.Infow("Starting to import from cidlist file")
 	ctx, cancel := context.WithCancel(ProcessContext())
 	defer cancel()
 	cget := c.Args().Get(0)
-	fmt.Println(c.Args().Get(0))
 	if cget == "" {
 		return fmt.Errorf("no cid provided as input")
 	}

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -58,6 +58,10 @@ var DaemonFlags = []cli.Flag{
 	EndpointFlag,
 }
 
+var ClientCmdFlags = []cli.Flag{
+	EndpointFlag,
+}
+
 var ImportFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:     "provider",
@@ -87,13 +91,11 @@ var SyntheticFlags = []cli.Flag{
 		Name:     "num",
 		Usage:    "Number of entries to generate",
 		Aliases:  []string{"n"},
-		Value:    1000,
 		Required: false,
 	},
 	&cli.Int64Flag{
 		Name:     "size",
 		Usage:    "Total size of the CIDs to generate",
 		Aliases:  []string{"s"},
-		Value:    10000,
 		Required: false,
 	}}

--- a/node/find.go
+++ b/node/find.go
@@ -21,57 +21,21 @@ func (n *Node) GetSingleCidHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Infow("Find cid", "cid", mhCid)
-	var (
-		entries []store.IndexEntry
-		found   bool
-	)
 
-	// Lookup CID in primary storage if primary enabled
-	if n.primary != nil {
-		entries, found, err = n.primary.Get(c)
-		if err != nil {
-			fmt.Println(err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-	}
-
-	// Lookup CID in persistent storage if not found yet and persistent enabled
-	if !found && n.persistent != nil {
-		entries, found, err = n.primary.Get(c)
-		if err != nil {
-			fmt.Println(err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		// Store the data that was found in persistent storage in primary storage
-		if found && n.primary != nil {
-			// TODO: Implement this:
-			//err = n.primary.MapEntries(c, entries)
-			//if err != nil {
-			//	log.Errorw("failed to store data in cache", "err", err)
-			//	// Do not return an error here, since the requested was handled
-			//}
-
-			// TODO: Remove this when above is implemented
-			for i := range entries {
-				err = n.primary.Put(c, entries[i])
-				if err != nil {
-					log.Errorw("failed to store data in cache", "err", err)
-					// Do not return an error here, since the requested was handled
-					break
-				}
-			}
-		}
+	// Lookup CID in storage
+	v, found, err := n.storage.Get(c)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
 	if !found {
+		log.Infof("cid %v not found")
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
-	out := map[cid.Cid][]store.IndexEntry{c: entries}
+	out := map[cid.Cid][]store.IndexEntry{c: v}
 	err = writeResponse(w, out)
 	if err != nil {
 		fmt.Println(err)

--- a/node/import.go
+++ b/node/import.go
@@ -108,7 +108,7 @@ func (n *Node) importCallback(c cid.Cid, entry store.IndexEntry) error {
 		return nil
 	}
 	// NOTE: We disregard errors for now
-	err := n.primary.Put(c, entry)
+	_, err := n.storage.Put(c, entry)
 	if err != nil {
 		log.Errorw("primary storage Put returned error", "err", err, "cid", c)
 		return errors.New("failed to store in primary storage")

--- a/node/storage.go
+++ b/node/storage.go
@@ -1,0 +1,188 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/filecoin-project/storetheindex/store"
+	"github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+var _ store.Storage = &nodeStorage{}
+
+// nodeStorage combines a cache and a persistent storage
+type nodeStorage struct {
+	primary    store.Storage
+	persistent store.PersistentStorage
+}
+
+// NewStorage creates new nodeStorage from a primary and persistent storages
+func NewStorage(primary store.Storage, persistent store.PersistentStorage) *nodeStorage {
+	return &nodeStorage{primary, persistent}
+}
+
+// Get retrieves IndexEntries for a CID
+func (ns *nodeStorage) Get(c cid.Cid) ([]store.IndexEntry, bool, error) {
+	v := []store.IndexEntry{}
+	var found bool
+	var err error
+
+	if ns.primary != nil {
+		// Check if CID in primary storage
+		v, found, err = ns.primary.Get(c)
+
+		if ns.persistent != nil && (!found || err != nil) {
+			v, found, err = ns.persistent.Get(c)
+			// TODO: What about adding a CacheStorage interface that includes
+			// putEntries(cid, []IndexEntry) function
+			// so we don't need to loop through IndexEntry to move from
+			// one storage to another?
+			if found && err == nil {
+				// Move from persistent to cache
+				for i := range v {
+					ns.primary.Put(c, v[i])
+				}
+			}
+		}
+		return v, found, err
+	}
+
+	// If no primary storage, get from persistent
+	return ns.persistent.Get(c)
+}
+
+// Put stores entry for a CID if the entry is not already
+// stored.  New entries are added to the entries that are already there.
+func (ns *nodeStorage) Put(c cid.Cid, entry store.IndexEntry) (bool, error) {
+	return ns.put(c, entry)
+}
+
+func (ns *nodeStorage) put(c cid.Cid, entry store.IndexEntry) (bool, error) {
+	var ok bool
+	var err error
+	// If there is persistent storage we put in persistent storage
+	if ns.persistent != nil {
+		ok, err = ns.persistent.Put(c, entry)
+		if err != nil {
+			return false, err
+		}
+	} else {
+		// If not we put in primary storage right away
+		return ns.primary.Put(c, entry)
+	}
+
+	// If we have both, we need to check if there is an entry for
+	// the cid in primary and update it accordingly to keep both
+	// storages consistent
+	if ns.primary != nil {
+		_, found, _ := ns.primary.Get(c)
+		if found && ok {
+			return ns.primary.Put(c, entry)
+		}
+	}
+	return ok, err
+}
+
+// PutMany stores entry for multiple CIDs
+func (ns *nodeStorage) PutMany(cs []cid.Cid, entry store.IndexEntry) error {
+	// NOTE: We assume that if there is a persistent storage, new entries
+	// are only added in persistence, and updated in cache if already there.
+	// Under this assumption we can't use primary's PutManyCount despite being
+	// more efficient than a single PUT because we would be putting
+	// cids that were not in cache before.
+	if ns.persistent != nil && ns.primary != nil {
+		for i := range cs {
+			_, err := ns.put(cs[i], entry)
+			if err != nil {
+				// TODO: Log error but don't return. Errors for a single
+				// CID shouldn't stop from putting the rest.
+				continue
+			}
+		}
+		return nil
+	}
+	// If we have only persistence
+	if ns.persistent != nil {
+		return ns.persistent.PutMany(cs, entry)
+	}
+	// Only with cache
+	return ns.primary.PutMany(cs, entry)
+}
+
+// Remove removes entry for a CID
+func (ns *nodeStorage) Remove(c cid.Cid, entry store.IndexEntry) (bool, error) {
+	var ok bool
+	var err error
+	// If there is persistent remove from persistent storage
+	if ns.persistent != nil {
+		ok, err = ns.persistent.Remove(c, entry)
+		if err != nil {
+			return false, err
+		}
+	} else {
+		// If not we remove in primary storage right away
+		return ns.primary.Remove(c, entry)
+	}
+
+	// If we have both, we need to check if there is an entry for
+	// the cid in primary and remove it accordingly to keep both
+	// storages consistent
+	if ns.primary != nil && ok {
+		return ns.primary.Remove(c, entry)
+	}
+
+	return ok, err
+}
+
+// RemoveMany removes entry from multiple CIDs
+func (ns *nodeStorage) RemoveMany(cids []cid.Cid, entry store.IndexEntry) error {
+	// Remove first from persistence
+	if ns.persistent != nil {
+		err := ns.persistent.RemoveMany(cids, entry)
+		if err != nil {
+			return err
+		}
+	}
+	// If successfull the jump into primary
+	if ns.primary != nil {
+		err := ns.primary.RemoveMany(cids, entry)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RemoveProvider removes all entries for specified provider.  This is used
+// when a provider is no longer indexed by the indexer.
+func (ns *nodeStorage) RemoveProvider(providerID peer.ID) error {
+	// Remove first from persistence
+	if ns.persistent != nil {
+		err := ns.persistent.RemoveProvider(providerID)
+		if err != nil {
+			return err
+		}
+	}
+	// If successfull the jump into primary
+	if ns.primary != nil {
+		err := ns.primary.RemoveProvider(providerID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Size returns the total storage capacity being used
+func (ns *nodeStorage) Size() (int64, error) {
+	// If persistent exists, return total storage capacity
+	if ns.persistent != nil {
+		return ns.persistent.Size()
+	}
+	// NOTE: We won't return any Size in the combined storage for primary.
+	// Size in primary currently returns the number of CIDs in memory, which
+	// is not consistent with the value returned by persistent storages.
+	return 0, fmt.Errorf("no persistence storage configured")
+}

--- a/node/storage.go
+++ b/node/storage.go
@@ -23,13 +23,9 @@ func NewStorage(primary store.Storage, persistent store.PersistentStorage) *node
 
 // Get retrieves IndexEntries for a CID
 func (ns *nodeStorage) Get(c cid.Cid) ([]store.IndexEntry, bool, error) {
-	v := []store.IndexEntry{}
-	var found bool
-	var err error
-
 	if ns.primary != nil {
 		// Check if CID in primary storage
-		v, found, err = ns.primary.Get(c)
+		v, found, err := ns.primary.Get(c)
 
 		if ns.persistent != nil && (!found || err != nil) {
 			v, found, err = ns.persistent.Get(c)

--- a/node/storage_test.go
+++ b/node/storage_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/filecoin-project/storetheindex/store"
@@ -13,10 +14,12 @@ import (
 const protocolID = 0
 
 func initStorage(t *testing.T, withPrimary bool, withPersist bool) *nodeStorage {
-	tmpDir := t.TempDir()
+	tmpDir, err := ioutil.TempDir("", "sth")
+	if err != nil {
+		t.Fatal(err)
+	}
 	var prim store.Storage
 	var persistent store.PersistentStorage
-	var err error
 
 	if withPersist {
 		persistent, err = storethehash.New(tmpDir)

--- a/node/storage_test.go
+++ b/node/storage_test.go
@@ -80,6 +80,9 @@ func TestPassthrough(t *testing.T) {
 
 	// Remove should apply to both storages
 	_, err = s.Remove(single, entry1)
+	if err != nil {
+		t.Fatal(err)
+	}
 	persv, _, _ = s.persistent.Get(single)
 	primv, _, _ = s.primary.Get(single)
 	if len(primv) != 1 || len(persv) != 1 {
@@ -288,7 +291,7 @@ func SizeTest(t *testing.T) {
 		t.Error("failed to compute storage size")
 	}
 	s = initStorage(t, true, false)
-	size, err = s.Size()
+	_, err = s.Size()
 	if err == nil {
 		t.Fatal("should return an error when no persistence configured")
 	}

--- a/node/storage_test.go
+++ b/node/storage_test.go
@@ -1,0 +1,295 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/storetheindex/store"
+	"github.com/filecoin-project/storetheindex/store/persistent/storethehash"
+	"github.com/filecoin-project/storetheindex/store/primary"
+	"github.com/filecoin-project/storetheindex/utils"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+const protocolID = 0
+
+func initStorage(t *testing.T, withPrimary bool, withPersist bool) *nodeStorage {
+	tmpDir := t.TempDir()
+	var prim store.Storage
+	var persistent store.PersistentStorage
+	var err error
+
+	if withPersist {
+		persistent, err = storethehash.New(tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if withPrimary {
+		prim = primary.New(100000)
+	}
+	return NewStorage(prim, persistent)
+}
+
+func TestPassthrough(t *testing.T) {
+	s := initStorage(t, true, true)
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cids, err := utils.RandomCids(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry1 := store.MakeIndexEntry(p, protocolID, cids[0].Bytes())
+	entry2 := store.MakeIndexEntry(p, protocolID, cids[1].Bytes())
+	single := cids[2]
+
+	// First put should go to persistent
+	_, err = s.Put(single, entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	_, persf, _ := s.persistent.Get(single)
+	_, primf, _ := s.primary.Get(single)
+	if !persf || primf {
+		t.Fatal("single put went to persistent and cache")
+	}
+
+	// Getting the value should put it in cache
+	v, found, _ := s.Get(single)
+	if !found || !v[0].Equal(entry1) {
+		t.Fatal("value not found in combined storage")
+	}
+	_, primf, _ = s.primary.Get(single)
+	if !primf {
+		t.Fatal("cid not moved to cache after miss get")
+	}
+
+	// Updating an existing CID should also update cache
+	_, err = s.Put(single, entry2)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	persv, _, _ := s.persistent.Get(single)
+	primv, _, _ := s.primary.Get(single)
+	if len(primv) != 2 || len(persv) != 2 {
+		t.Fatal("value not updated in cache and persistent")
+	}
+
+	// Remove should apply to both storages
+	_, err = s.Remove(single, entry1)
+	persv, _, _ = s.persistent.Get(single)
+	primv, _, _ = s.primary.Get(single)
+	if len(primv) != 1 || len(persv) != 1 {
+		t.Fatal("entry not removed in both storages")
+	}
+
+	// Putting many should only update in cache the ones
+	// already stored, adding all to persistent storage.
+	err = s.PutMany(cids[2:], entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	persv, _, _ = s.persistent.Get(single)
+	primv, _, _ = s.primary.Get(single)
+	if len(primv) != 2 || len(persv) != 2 {
+		t.Fatal("value not updated in cache and persistent after PutMany")
+	}
+	// This CID should only be found in persistent
+	_, persf, _ = s.persistent.Get(cids[4])
+	_, primf, _ = s.primary.Get(cids[4])
+	if !persf || primf {
+		t.Fatal("single put went to persistent and cache")
+	}
+
+	// RemoveMany should remove the corresponding from both storages.
+	err = s.RemoveMany(cids[2:], entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	persv, _, _ = s.persistent.Get(single)
+	primv, _, _ = s.primary.Get(single)
+	if len(primv) != 1 || len(persv) != 1 {
+		t.Fatal("value not removed in cache and persistent after RemoveMany")
+	}
+	_, persf, _ = s.persistent.Get(cids[4])
+	_, primf, _ = s.primary.Get(cids[4])
+	if persf || primf {
+		t.Fatal("remove many didn't remove from both storages")
+	}
+
+}
+
+func TestOnlyPrimary(t *testing.T) {
+	s := initStorage(t, true, false)
+	e2e(t, s)
+}
+
+func TestOnlyPersistent(t *testing.T) {
+	s := initStorage(t, false, true)
+	e2e(t, s)
+}
+
+func TestBoth(t *testing.T) {
+	s := initStorage(t, true, true)
+	e2e(t, s)
+}
+
+func e2e(t *testing.T, s *nodeStorage) {
+	// Create new valid peer.ID
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cids, err := utils.RandomCids(15)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry1 := store.MakeIndexEntry(p, protocolID, cids[0].Bytes())
+	entry2 := store.MakeIndexEntry(p, protocolID, cids[1].Bytes())
+
+	single := cids[2]
+	noadd := cids[3]
+	batch := cids[4:]
+	remove := cids[4]
+
+	// Put a single CID
+	t.Logf("Put/Get a single CID in storage")
+	_, err = s.Put(single, entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+
+	i, found, err := s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("Error finding single cid")
+	}
+	if !i[0].Equal(entry1) {
+		t.Errorf("Got wrong value for single cid")
+	}
+
+	// Put a batch of CIDs
+	t.Logf("Put/Get a batch of CIDs in storage")
+	err = s.PutMany(batch, entry1)
+	if err != nil {
+		t.Fatal("Error putting batch of cids: ", err)
+	}
+
+	i, found, err = s.Get(cids[5])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("Error finding a cid from the batch")
+	}
+	if !i[0].Equal(entry1) {
+		t.Errorf("Got wrong value for single cid")
+	}
+
+	// Put on an existing key
+	t.Logf("Put/Get on existing key")
+	_, err = s.Put(single, entry2)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	i, found, err = s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("Error finding a cid from the batch")
+	}
+	if len(i) != 2 {
+		t.Fatal("Update over existing key not correct")
+	}
+	if !i[1].Equal(entry2) {
+		t.Errorf("Got wrong value for single cid")
+	}
+
+	// Get a key that is not set
+	t.Logf("Get non-existing key")
+	_, found, err = s.Get(noadd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Errorf("Error, the key for the cid shouldn't be set")
+	}
+
+	// Remove a key
+	t.Logf("Remove key")
+	_, err = s.Remove(remove, entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+
+	_, found, err = s.Get(remove)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Errorf("cid should have been removed")
+	}
+
+	// Remove an entry from the key
+	_, err = s.Remove(single, entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	i, found, err = s.Get(single)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("cid should still have one entry")
+	}
+	if len(i) != 1 {
+		t.Errorf("wrong number of entries after remove")
+	}
+
+}
+
+func SizeTest(t *testing.T) {
+	s := initStorage(t, true, true)
+	// Init storage
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cids, err := utils.RandomCids(151)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry := store.MakeIndexEntry(p, protocolID, cids[0].Bytes())
+	for _, c := range cids[1:] {
+		_, err = s.Put(c, entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	size, err := s.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size == int64(0) {
+		t.Error("failed to compute storage size")
+	}
+	s = initStorage(t, true, false)
+	size, err = s.Size()
+	if err == nil {
+		t.Fatal("should return an error when no persistence configured")
+	}
+}

--- a/store/persistent/benchmarks.go
+++ b/store/persistent/benchmarks.go
@@ -112,7 +112,7 @@ func BenchCidGet(s store.PersistentStorage, b *testing.B) {
 	s.PutMany(cids, entry)
 
 	// Bench average time for a single get
-	b.Run(fmt.Sprint("Get single"), func(b *testing.B) {
+	b.Run("Get single", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/store/persistent/benchmarks.go
+++ b/store/persistent/benchmarks.go
@@ -128,12 +128,10 @@ func BenchCidGet(s store.PersistentStorage, b *testing.B) {
 		b.Run(fmt.Sprint("Get", testCount), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				for j := 0; j < testCount; j++ {
-					_, ok, _ := s.Get(cids[j%len(cids)])
-					if !ok {
-						panic("missing cid")
-					}
+			for i := 0; i < b.N*testCount; i++ {
+				_, ok, _ := s.Get(cids[i%len(cids)])
+				if !ok {
+					panic("missing cid")
 				}
 			}
 		})

--- a/store/persistent/benchmarks.go
+++ b/store/persistent/benchmarks.go
@@ -3,6 +3,7 @@ package persistent
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"sync"
 	"testing"
@@ -22,13 +23,15 @@ const (
 	protocolID = 0
 )
 
-func prepare(s store.Storage, size string, b *testing.B) {
+// prepare reads a cidlist and imports it to persistent storage getting
+// it ready for benchmarking.
+func prepare(s store.Storage, size string, t *testing.T) {
 	out := make(chan cid.Cid)
 	errOut := make(chan error, 1)
 
 	file, err := os.OpenFile(testDataDir+size+testDataExt, os.O_RDONLY, 0644)
 	if err != nil {
-		b.Fatalf("couldn't find the right input file for %v, try synthetizing from CLI: %v", size, err)
+		t.Fatalf("couldn't find the right input file for %v, try synthetizing from CLI: %v", size, err)
 	}
 	defer file.Close()
 
@@ -41,72 +44,61 @@ func prepare(s store.Storage, size string, b *testing.B) {
 		entry := store.MakeIndexEntry(p, protocolID, c.Bytes())
 		_, err = s.Put(c, entry)
 		if err != nil {
-			b.Fatal(err)
+			t.Fatal(err)
 		}
 	}
 	err = <-errOut
 	if err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
 
 }
 
-func read(s store.Storage, size string, m *metrics, b *testing.B) {
+// readAll reads all of the cids from a file and tries to get it from
+// the persistent storage.
+func readAll(s store.Storage, size string, m *metrics, t *testing.T) {
 	out := make(chan cid.Cid)
 	errOut := make(chan error, 1)
 
 	file, err := os.OpenFile(testDataDir+size+testDataExt, os.O_RDONLY, 0644)
 	if err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
 	defer file.Close()
 
 	imp := importer.NewCidListImporter(file)
 
-	b.ResetTimer()
 	go imp.Read(context.Background(), out, errOut)
 	for c := range out {
 		now := time.Now()
 		_, found, err := s.Get(c)
 		if err != nil || !found {
-			b.Errorf("cid not found")
+			t.Errorf("cid not found")
 		}
 		m.getTime.add(time.Since(now).Microseconds())
 
 	}
 	err = <-errOut
 	if err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
 
 }
 
-func BenchSingleGet(s store.PersistentStorage, size string, b *testing.B) {
+// Benchmark the average time per get by all CIDs and the total storage used.
+func BenchReadAll(s store.PersistentStorage, size string, t *testing.T) {
 	m := initMetrics()
-	prepare(s, size, b)
-	read(s, size, m, b)
+	prepare(s, size, t)
+	readAll(s, size, m, t)
 	err := s.Flush()
 	if err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
 
-	report(s, m, true, b)
+	report(s, m, true, t)
 }
 
-func BenchParallelGet(s store.PersistentStorage, size string, b *testing.B) {
-	var wg sync.WaitGroup
-
-	wg.Add(20)
-	for i := 0; i < 20; i++ {
-		go func(wg *sync.WaitGroup) {
-			defer wg.Done()
-			BenchSingleGet(s, size, b)
-
-		}(&wg)
-	}
-	wg.Wait()
-}
-
+// Benchmark single thread get operation
 func BenchCidGet(s store.PersistentStorage, b *testing.B) {
 	cids, err := utils.RandomCids(1)
 	if err != nil {
@@ -119,22 +111,31 @@ func BenchCidGet(s store.PersistentStorage, b *testing.B) {
 	cids, _ = utils.RandomCids(4096)
 	s.PutMany(cids, entry)
 
+	// Bench average time for a single get
+	b.Run(fmt.Sprint("Get single"), func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, ok, _ := s.Get(cids[i%len(cids)])
+			if !ok {
+				panic("missing cid")
+			}
+		}
+	})
+
+	// Test time to fetch certain amount of requests
 	for testCount := 1024; testCount < 10240; testCount *= 2 {
 		b.Run(fmt.Sprint("Get", testCount), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
-			m := initMetrics()
 			for i := 0; i < b.N; i++ {
 				for j := 0; j < testCount; j++ {
-					now := time.Now()
 					_, ok, _ := s.Get(cids[j%len(cids)])
 					if !ok {
 						panic("missing cid")
 					}
-					m.getTime.add(time.Since(now).Microseconds())
 				}
 			}
-			report(s, m, false, b)
 		})
 	}
 }
@@ -150,28 +151,34 @@ func BenchParallelCidGet(s store.PersistentStorage, b *testing.B) {
 
 	cids, _ = utils.RandomCids(4096)
 	s.PutMany(cids, entry)
+	rand.Seed(time.Now().UnixNano())
 
-	for testCount := 1024; testCount < 10240; testCount *= 2 {
-		b.Run(fmt.Sprint("Get", testCount), func(b *testing.B) {
+	// Benchmark the average request time for different number of go routines.
+	for rout := 10; rout <= 100; rout += 10 {
+		b.Run(fmt.Sprint("Get parallel", rout), func(b *testing.B) {
 			var wg sync.WaitGroup
-			for i := 0; i < 20; i++ {
+			ch := make(chan bool)
+			for i := 0; i < rout; i++ {
 				wg.Add(1)
-				go func(wg *sync.WaitGroup) {
-					m := initMetrics()
+				go func(wg *sync.WaitGroup, ch chan bool) {
+					// Each go routine starts fetching CIDs from different offset.
+					// TODO: Request follow a zipf distribution.
+					off := rand.Int()
+					// Wait for all routines to be started
+					<-ch
 					for i := 0; i < b.N; i++ {
-						for j := 0; j < testCount; j++ {
-							now := time.Now()
-							_, ok, _ := s.Get(cids[j%len(cids)])
-							if !ok {
-								panic("missing cid")
-							}
-							m.getTime.add(time.Since(now).Microseconds())
+						_, ok, _ := s.Get(cids[(off+i)%len(cids)])
+						if !ok {
+							panic("missing cid")
 						}
+
 					}
-					report(s, m, false, b)
 					wg.Done()
-				}(&wg)
+				}(&wg, ch)
 			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			close(ch)
 			wg.Wait()
 		})
 	}
@@ -201,18 +208,18 @@ func initMetrics() *metrics {
 	}
 }
 
-func report(s store.PersistentStorage, m *metrics, storage bool, b *testing.B) {
+func report(s store.PersistentStorage, m *metrics, storage bool, t *testing.T) {
 	memSize, _ := s.Size()
 	avgT := m.getTime.avg() / 1000
-	b.Log("Avg time per get (ms):", avgT)
+	t.Log("Avg time per get (ms):", avgT)
 	if storage {
 		sizeMB := float64(memSize) / 1000000
-		b.Log("Memory size (MB):", sizeMB)
+		t.Log("Memory size (MB):", sizeMB)
 	}
 }
 
-func SkipStorage(b *testing.B) {
+func SkipStorage(t *testing.T) {
 	if os.Getenv("TEST_STORAGE") == "" {
-		b.SkipNow()
+		t.SkipNow()
 	}
 }

--- a/store/persistent/pogreb/pogreb_bench_test.go
+++ b/store/persistent/pogreb/pogreb_bench_test.go
@@ -8,70 +8,41 @@ import (
 	"github.com/filecoin-project/storetheindex/store/persistent"
 )
 
-func initBenchStore(b *testing.B) store.PersistentStorage {
+func initBenchStore() store.PersistentStorage {
 	s, err := initPogreb()
 	if err != nil {
-		b.Fatal(err)
+		panic(err)
 	}
 	return s
 }
 
-func BenchmarkSingle10KB(b *testing.B) {
-	skipBenchIf32bit(b)
-	persistent.SkipStorage(b)
-	persistent.BenchSingleGet(initBenchStore(b), "10KB", b)
-}
-
-func BenchmarkSingle10MB(b *testing.B) {
-	skipBenchIf32bit(b)
-	persistent.SkipStorage(b)
-	persistent.BenchSingleGet(initBenchStore(b), "10MB", b)
-}
-
-func BenchmarkSingle100MB(b *testing.B) {
-	skipBenchIf32bit(b)
-	persistent.SkipStorage(b)
-	persistent.BenchSingleGet(initBenchStore(b), "100MB", b)
-}
-
-func BenchmarkSingle1GB(b *testing.B) {
-	skipBenchIf32bit(b)
-	persistent.SkipStorage(b)
-	persistent.BenchSingleGet(initBenchStore(b), "1GB", b)
-}
-
-func BenchmarkParallel10KB(b *testing.B) {
-	skipBenchIf32bit(b)
-	persistent.SkipStorage(b)
-	persistent.BenchParallelGet(initBenchStore(b), "10KB", b)
-}
-
-func BenchmarkParallel10MB(b *testing.B) {
-	skipBenchIf32bit(b)
-	persistent.SkipStorage(b)
-	persistent.BenchParallelGet(initBenchStore(b), "10MB", b)
-}
-
-func BenchmarkParallel100MB(b *testing.B) {
-	skipBenchIf32bit(b)
-	persistent.SkipStorage(b)
-	persistent.BenchParallelGet(initBenchStore(b), "100MB", b)
-}
-
-func BenchmarkParallel1GB(b *testing.B) {
-	skipBenchIf32bit(b)
-	persistent.SkipStorage(b)
-	persistent.BenchParallelGet(initBenchStore(b), "1GB", b)
-}
-
 func BenchmarkGet(b *testing.B) {
 	skipBenchIf32bit(b)
-	persistent.BenchCidGet(initBenchStore(b), b)
+	persistent.BenchCidGet(initBenchStore(), b)
 }
-
 func BenchmarkParallelGet(b *testing.B) {
 	skipBenchIf32bit(b)
-	persistent.BenchParallelCidGet(initBenchStore(b), b)
+	persistent.BenchParallelCidGet(initBenchStore(), b)
+}
+
+// To run this storage benchmarks run:
+// TEST_STORAGE=true go test -v -timeout=30m
+func TestBenchSingle10MB(t *testing.T) {
+	skipIf32bit(t)
+	persistent.SkipStorage(t)
+	persistent.BenchReadAll(initBenchStore(), "10MB", t)
+}
+
+func TestBenchSingle100MB(t *testing.T) {
+	skipIf32bit(t)
+	persistent.SkipStorage(t)
+	persistent.BenchReadAll(initBenchStore(), "100MB", t)
+}
+
+func TestBenchSingle1GB(t *testing.T) {
+	skipIf32bit(t)
+	persistent.SkipStorage(t)
+	persistent.BenchReadAll(initBenchStore(), "1GB", t)
 }
 
 func skipBenchIf32bit(b *testing.B) {

--- a/store/persistent/pogreb/pogreb_bench_test.go
+++ b/store/persistent/pogreb/pogreb_bench_test.go
@@ -1,47 +1,81 @@
 package pogreb_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/filecoin-project/storetheindex/store"
 	"github.com/filecoin-project/storetheindex/store/persistent"
 )
 
-func initBenchStore(b *testing.B) store.StorageFlusher {
+func initBenchStore(b *testing.B) store.PersistentStorage {
 	s, err := initPogreb()
 	if err != nil {
 		b.Fatal(err)
 	}
 	return s
 }
+
 func BenchmarkSingle10KB(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.SkipStorage(b)
 	persistent.BenchSingleGet(initBenchStore(b), "10KB", b)
 }
 
 func BenchmarkSingle10MB(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.SkipStorage(b)
 	persistent.BenchSingleGet(initBenchStore(b), "10MB", b)
 }
 
 func BenchmarkSingle100MB(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.SkipStorage(b)
 	persistent.BenchSingleGet(initBenchStore(b), "100MB", b)
 }
 
 func BenchmarkSingle1GB(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.SkipStorage(b)
 	persistent.BenchSingleGet(initBenchStore(b), "1GB", b)
 }
 
 func BenchmarkParallel10KB(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.SkipStorage(b)
 	persistent.BenchParallelGet(initBenchStore(b), "10KB", b)
 }
 
 func BenchmarkParallel10MB(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.SkipStorage(b)
 	persistent.BenchParallelGet(initBenchStore(b), "10MB", b)
 }
 
 func BenchmarkParallel100MB(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.SkipStorage(b)
 	persistent.BenchParallelGet(initBenchStore(b), "100MB", b)
 }
 
 func BenchmarkParallel1GB(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.SkipStorage(b)
 	persistent.BenchParallelGet(initBenchStore(b), "1GB", b)
+}
+
+func BenchmarkGet(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.BenchCidGet(initBenchStore(b), b)
+}
+
+func BenchmarkParallelGet(b *testing.B) {
+	skipBenchIf32bit(b)
+	persistent.BenchParallelCidGet(initBenchStore(b), b)
+}
+
+func skipBenchIf32bit(b *testing.B) {
+	if runtime.GOARCH == "386" {
+		b.Skip("Pogreb cannot use GOARCH=386")
+	}
 }

--- a/store/persistent/pogreb/pogreb_test.go
+++ b/store/persistent/pogreb/pogreb_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/storetheindex/store/persistent/pogreb"
 )
 
-func initPogreb() (store.StorageFlusher, error) {
+func initPogreb() (store.PersistentStorage, error) {
 	tmpDir, err := ioutil.TempDir("", "sth")
 	if err != nil {
 		return nil, err

--- a/store/persistent/storethehash/storethehash_bench_test.go
+++ b/store/persistent/storethehash/storethehash_bench_test.go
@@ -7,56 +7,34 @@ import (
 	"github.com/filecoin-project/storetheindex/store/persistent"
 )
 
-func initBenchStore(b *testing.B) store.PersistentStorage {
+func initBenchStore() store.PersistentStorage {
 	s, err := initSth()
 	if err != nil {
-		b.Fatal(err)
+		panic(err)
 	}
 	return s
 }
-func BenchmarkSingle10KB(b *testing.B) {
-	persistent.SkipStorage(b)
-	persistent.BenchSingleGet(initBenchStore(b), "10KB", b)
-}
-
-func BenchmarkSingle10MB(b *testing.B) {
-	persistent.SkipStorage(b)
-	persistent.BenchSingleGet(initBenchStore(b), "10MB", b)
-}
-
-func BenchmarkSingle100MB(b *testing.B) {
-	persistent.SkipStorage(b)
-	persistent.BenchSingleGet(initBenchStore(b), "100MB", b)
-}
-
-func BenchmarkSingle1GB(b *testing.B) {
-	persistent.SkipStorage(b)
-	persistent.BenchSingleGet(initBenchStore(b), "1GB", b)
-}
-
-func BenchmarkParallel10KB(b *testing.B) {
-	persistent.SkipStorage(b)
-	persistent.BenchParallelGet(initBenchStore(b), "10KB", b)
-}
-
-func BenchmarkParallel10MB(b *testing.B) {
-	persistent.SkipStorage(b)
-	persistent.BenchParallelGet(initBenchStore(b), "10MB", b)
-}
-
-func BenchmarkParallel100MB(b *testing.B) {
-	persistent.SkipStorage(b)
-	persistent.BenchParallelGet(initBenchStore(b), "100MB", b)
-}
-
-func BenchmarkParallel1GB(b *testing.B) {
-	persistent.SkipStorage(b)
-	persistent.BenchParallelGet(initBenchStore(b), "1GB", b)
-}
 
 func BenchmarkGet(b *testing.B) {
-	persistent.BenchCidGet(initBenchStore(b), b)
+	persistent.BenchCidGet(initBenchStore(), b)
 }
 func BenchmarkParallelGet(b *testing.B) {
-	persistent.BenchParallelCidGet(initBenchStore(b), b)
+	persistent.BenchParallelCidGet(initBenchStore(), b)
+}
+
+// To run this storage benchmarks run:
+// TEST_STORAGE=true go test -v -timeout=30m
+func TestBenchSingle10MB(t *testing.T) {
+	persistent.SkipStorage(t)
+	persistent.BenchReadAll(initBenchStore(), "10MB", t)
+}
+
+func TestBenchSingle100MB(t *testing.T) {
+	persistent.SkipStorage(t)
+	persistent.BenchReadAll(initBenchStore(), "100MB", t)
+}
+
+func TestBenchSingle1GB(t *testing.T) {
+	persistent.SkipStorage(t)
+	persistent.BenchReadAll(initBenchStore(), "1GB", t)
 }

--- a/store/persistent/storethehash/storethehash_bench_test.go
+++ b/store/persistent/storethehash/storethehash_bench_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/storetheindex/store/persistent"
 )
 
-func initBenchStore(b *testing.B) store.StorageFlusher {
+func initBenchStore(b *testing.B) store.PersistentStorage {
 	s, err := initSth()
 	if err != nil {
 		b.Fatal(err)
@@ -15,33 +15,48 @@ func initBenchStore(b *testing.B) store.StorageFlusher {
 	return s
 }
 func BenchmarkSingle10KB(b *testing.B) {
+	persistent.SkipStorage(b)
 	persistent.BenchSingleGet(initBenchStore(b), "10KB", b)
 }
 
 func BenchmarkSingle10MB(b *testing.B) {
+	persistent.SkipStorage(b)
 	persistent.BenchSingleGet(initBenchStore(b), "10MB", b)
 }
 
 func BenchmarkSingle100MB(b *testing.B) {
+	persistent.SkipStorage(b)
 	persistent.BenchSingleGet(initBenchStore(b), "100MB", b)
 }
 
 func BenchmarkSingle1GB(b *testing.B) {
+	persistent.SkipStorage(b)
 	persistent.BenchSingleGet(initBenchStore(b), "1GB", b)
 }
 
 func BenchmarkParallel10KB(b *testing.B) {
+	persistent.SkipStorage(b)
 	persistent.BenchParallelGet(initBenchStore(b), "10KB", b)
 }
 
 func BenchmarkParallel10MB(b *testing.B) {
+	persistent.SkipStorage(b)
 	persistent.BenchParallelGet(initBenchStore(b), "10MB", b)
 }
 
 func BenchmarkParallel100MB(b *testing.B) {
+	persistent.SkipStorage(b)
 	persistent.BenchParallelGet(initBenchStore(b), "100MB", b)
 }
 
 func BenchmarkParallel1GB(b *testing.B) {
+	persistent.SkipStorage(b)
 	persistent.BenchParallelGet(initBenchStore(b), "1GB", b)
+}
+
+func BenchmarkGet(b *testing.B) {
+	persistent.BenchCidGet(initBenchStore(b), b)
+}
+func BenchmarkParallelGet(b *testing.B) {
+	persistent.BenchParallelCidGet(initBenchStore(b), b)
 }

--- a/store/persistent/storethehash/storethehash_test.go
+++ b/store/persistent/storethehash/storethehash_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/storetheindex/store/persistent/storethehash"
 )
 
-func initSth() (store.StorageFlusher, error) {
+func initSth() (store.PersistentStorage, error) {
 	tmpDir, err := ioutil.TempDir("", "sth")
 	if err != nil {
 		return nil, err

--- a/store/persistent/tests.go
+++ b/store/persistent/tests.go
@@ -8,7 +8,7 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
-func E2ETest(t *testing.T, s store.StorageFlusher) {
+func E2ETest(t *testing.T, s store.PersistentStorage) {
 	// Create new valid peer.ID
 	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	if err != nil {
@@ -30,7 +30,7 @@ func E2ETest(t *testing.T, s store.StorageFlusher) {
 
 	// Put a single CID
 	t.Logf("Put/Get a single CID in primary storage")
-	err = s.Put(single, entry1)
+	_, err = s.Put(single, entry1)
 	if err != nil {
 		t.Fatal("Error putting single cid: ", err)
 	}
@@ -66,7 +66,7 @@ func E2ETest(t *testing.T, s store.StorageFlusher) {
 
 	// Put on an existing key
 	t.Logf("Put/Get on existing key")
-	err = s.Put(single, entry2)
+	_, err = s.Put(single, entry2)
 	if err != nil {
 		t.Fatal("Error putting single cid: ", err)
 	}
@@ -99,7 +99,7 @@ func E2ETest(t *testing.T, s store.StorageFlusher) {
 
 	// Remove a key
 	t.Logf("Remove key")
-	err = s.Remove(remove, entry1)
+	_, err = s.Remove(remove, entry1)
 	if err != nil {
 		t.Fatal("Error putting single cid: ", err)
 	}
@@ -113,7 +113,7 @@ func E2ETest(t *testing.T, s store.StorageFlusher) {
 	}
 
 	// Remove an entry from the key
-	err = s.Remove(single, entry1)
+	_, err = s.Remove(single, entry1)
 	if err != nil {
 		t.Fatal("Error putting single cid: ", err)
 	}
@@ -130,7 +130,7 @@ func E2ETest(t *testing.T, s store.StorageFlusher) {
 
 }
 
-func SizeTest(t *testing.T, s store.StorageFlusher) {
+func SizeTest(t *testing.T, s store.PersistentStorage) {
 	// Init storage
 	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	if err != nil {
@@ -144,7 +144,7 @@ func SizeTest(t *testing.T, s store.StorageFlusher) {
 
 	entry := store.MakeIndexEntry(p, protocolID, cids[0].Bytes())
 	for _, c := range cids[1:] {
-		err = s.Put(c, entry)
+		_, err = s.Put(c, entry)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -159,7 +159,7 @@ func SizeTest(t *testing.T, s store.StorageFlusher) {
 	}
 }
 
-func RemoveManyTest(t *testing.T, s store.StorageFlusher) {
+func RemoveManyTest(t *testing.T, s store.PersistentStorage) {
 	// Create new valid peer.ID
 	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	if err != nil {

--- a/store/primary/primary.go
+++ b/store/primary/primary.go
@@ -54,9 +54,8 @@ func (s *rtStorage) Get(c cid.Cid) ([]store.IndexEntry, bool, error) {
 	return ret, true, nil
 }
 
-func (s *rtStorage) Put(c cid.Cid, entry store.IndexEntry) error {
-	s.PutCheck(c, entry)
-	return nil
+func (s *rtStorage) Put(c cid.Cid, entry store.IndexEntry) (bool, error) {
+	return s.PutCheck(c, entry), nil
 }
 
 // PutCheck stores an IndexEntry for a CID if the entry is not already
@@ -126,9 +125,8 @@ func (s *rtStorage) PutManyCount(cids []cid.Cid, entry store.IndexEntry) uint64 
 	return stored
 }
 
-func (s *rtStorage) Remove(c cid.Cid, entry store.IndexEntry) error {
-	s.RemoveCheck(c, entry)
-	return nil
+func (s *rtStorage) Remove(c cid.Cid, entry store.IndexEntry) (bool, error) {
+	return s.RemoveCheck(c, entry), nil
 }
 
 // RemoveCheck removes an IndexEntry for a CID.  Returns true if an

--- a/store/primary/primary_test.go
+++ b/store/primary/primary_test.go
@@ -309,7 +309,7 @@ func BenchmarkPut(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			err = s.Put(cids[i%len(cids)], entry)
+			_, err = s.Put(cids[i%len(cids)], entry)
 			if err != nil {
 				panic(err)
 			}
@@ -323,7 +323,7 @@ func BenchmarkPut(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				for j := 0; j < testCount; j++ {
-					err = s.Put(cids[j], entry)
+					_, err = s.Put(cids[j], entry)
 					if err != nil {
 						panic(err)
 					}

--- a/store/store.go
+++ b/store/store.go
@@ -62,11 +62,11 @@ type Storage interface {
 	// Get retrieves a slice of IndexEntry for a CID
 	Get(c cid.Cid) ([]IndexEntry, bool, error)
 	// Put stores an additional IndexEntry for a CID if the entry is not already stored
-	Put(c cid.Cid, entry IndexEntry) error
+	Put(c cid.Cid, entry IndexEntry) (bool, error)
 	// PutMany stores an IndexEntry for multiple CIDs
 	PutMany(cs []cid.Cid, entry IndexEntry) error
 	// Remove removes an IndexEntry for a CID
-	Remove(c cid.Cid, entry IndexEntry) error
+	Remove(c cid.Cid, entry IndexEntry) (bool, error)
 	// RemoveMany removes an IndexEntry from multiple CIDs
 	RemoveMany(cids []cid.Cid, entry IndexEntry) error
 	// RemoveProvider removes all entries for specified provider.  This is used
@@ -76,10 +76,10 @@ type Storage interface {
 	Size() (int64, error)
 }
 
-// StorageFlusher implements a storage interface with Flush capabilities
+// PersistentStorage implements a storage interface with Flush capabilities
 // to be used with persistence storage that require commitment of changes
 // on-disk.
-type StorageFlusher interface {
+type PersistentStorage interface {
 	Storage
 	// Flush commits changes to storage
 	Flush() error


### PR DESCRIPTION
- Add `nodeStorage`, which wraps the combination of a cache and a persistent storage and implements the `Storage` interface. It includes the pass-through logic, and is the backend storage for `node`. It has been decoupled from the daemon so this logic can be used as a library instead of embedding it in the node's daemon. 
- Add a slight modification to `Put` and `Remove` in `Storage` (changing output from `err` to `(bool, err)`) for convenience.
- Renamed `StorageFlusher` to `PersistentStorage` in case we end up adding (as briefly discussed) a `CacheStorage` interface.
- Refactored `synthetic`commands.
- Fixed issue with flags, and storage config in daemon.
- Update README.
- Additional benchmarks for persistent storage.

Next: 
- Add stats for `nodeStorage` (cache hits/miss, persistence miss, cid distribution, etc.)
- Improve `nodeStorage`'s `get` function adding a `PutEntries` function to `primary so we can move a list of entries efficiently between persistent storage and cache without having to loop through entries (is this worth?)