### PR TITLE
Assets to run load tests using locust

### DIFF
--- a/utils/load/README.md
+++ b/utils/load/README.md
@@ -1,0 +1,32 @@
+# Load tests
+
+### Start a daemon
+To run load tests over `storetheindex` we need to first run the node in the infrastructure:
+- Start a `storetheindex` daemon:
+```
+./storetheindex daemon --storage <persistence> -e 0.0.0.0:3000 --cachesize <cache_size> --dir <data-dir>
+```
+- Import cid data into the indexer:
+```
+./storetheindex import cidlist --dir ./utils/load/cids.data --provider 12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA --metadata <metadata> -e 127.0.0.1:3000
+``` 
+
+### Run the test
+We can then start the load tests client. The load test script has `locust` and `numpy` as dependencies. Be sure that you have `python3` installed
+and that you `pip install locust numpy`.
+
+- A test run with 4 workers and a master client can be easily run through the `./run.sh` script. This script starts the client workers. To configure the
+test run and visualize the results go to locust UI at `http://localhost:8089`.
+- Locust can also be run from the CLI, and to stress test a single endpoint we can also use [this tool](https://github.com/rakyll/hey), which can be run
+using:
+```
+./hey_linux_amd64 -m GET -z <test-duration> -c <concurrent_clients> <endpoint>/cid/bafkreigxvijvpvmt7xnk2nxzudha22jf7fawi2vbjpsnh7cejagquq6z4y
+
+# Example
+./hey_linux_amd64 -m GET -z 30s -c 10000 http://18.169.134.123:3000/cid/bafkreigxvijvpvmt7xnk2nxzudha22jf7fawi2vbjpsnh7cejagquq6z4y
+```
+
+### File Descriptor Limit
+When trying to run a huge load over the node, the local client may reach the OS file descriptor limit (even if this is set to the maximum limit allowed).
+To send more load to the node the load generation needs to be distributed in different machines.
+

--- a/utils/load/load.py
+++ b/utils/load/load.py
@@ -1,0 +1,46 @@
+"""
+This locust test randomly gets CIDs from a
+storetheindex daemon. CIDs are chosen randomly following a 
+ZIPF distribution. 
+"""
+
+import numpy as np
+
+import time
+from locust import HttpUser, task, between
+import random
+
+# Initializing Zipf distribution
+a = 2.  # Zipf parameter (feel free to change it)
+
+# Read from a list of imported cids
+def read_cids(filepath):
+    file1 = open(filepath, 'r')
+    lines = file1.readlines()
+    cids = []
+    for line in lines:
+        cids.append(line.strip())
+    return cids
+
+# Choosing a random CID from the list of imported ones
+def random_sample(cids, is_zipf=True):
+    if is_zipf:
+        return cids[np.random.zipf(a)%len(cids)]
+
+    return random.choice(cids)
+
+
+# Importing CIDs to request
+cids = read_cids("cids.data")
+print("Reading CIDs complete!")
+
+
+# Test case
+class IndexUser(HttpUser):
+    #  wait_time = between(1, 2.5)
+
+    @task
+    def get_cid(self):
+        # Get random cid Zipf distribution
+        self.client.get("/cid/"+random_sample(cids))
+

--- a/utils/load/load.py
+++ b/utils/load/load.py
@@ -15,12 +15,9 @@ a = 2.  # Zipf parameter (feel free to change it)
 
 # Read from a list of imported cids
 def read_cids(filepath):
-    file1 = open(filepath, 'r')
-    lines = file1.readlines()
-    cids = []
-    for line in lines:
-        cids.append(line.strip())
-    return cids
+    with open (filepath) as file1:
+        lines = file1.readlines()
+        return [line.strip() for line in lines]
 
 # Choosing a random CID from the list of imported ones
 def random_sample(cids, is_zipf=True):
@@ -33,7 +30,6 @@ def random_sample(cids, is_zipf=True):
 # Importing CIDs to request
 cids = read_cids("cids.data")
 print("Reading CIDs complete!")
-
 
 # Test case
 class IndexUser(HttpUser):

--- a/utils/load/run.sh
+++ b/utils/load/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+NUM_WORKERS=4
+START=1
+# Start locust workers
+while [[ $i -le $NUM_WORKERS ]]
+do
+        echo "Starting worker$number"
+        locust -f load.py --worker &
+        ((i = i + 1))
+done
+# Start locust master
+locust -f load.py --master


### PR DESCRIPTION
- Include assets to run load tests against a `storetheindex` daemon using https://locust.io/
- Add README to guide through how to replicate the tests 