### PR TITLE
Fix storethehash periodic flush

### DIFF
--- a/store/persistent/pogreb/pogreb.go
+++ b/store/persistent/pogreb/pogreb.go
@@ -102,6 +102,10 @@ func (s *pStorage) Flush() error {
 	return s.store.Sync()
 }
 
+func (s *pStorage) Close() error {
+	return s.store.Close()
+}
+
 func (s *pStorage) Size() (int64, error) {
 	var size int64
 	err := filepath.Walk(s.dir, func(_ string, info os.FileInfo, err error) error {

--- a/store/persistent/storethehash/storethehash.go
+++ b/store/persistent/storethehash/storethehash.go
@@ -216,7 +216,6 @@ func (s *sthStorage) removeEntry(k []byte, entry store.IndexEntry, stored []stor
 
 // Close stops all storage-related routines, and flushes
 // pending data
-// NOTE: Add it to storage interface?
 func (s *sthStorage) Close() error {
 	return s.store.Close()
 }

--- a/store/persistent/storethehash/storethehash.go
+++ b/store/persistent/storethehash/storethehash.go
@@ -42,6 +42,7 @@ func New(dir string) (*sthStorage, error) {
 	if err != nil {
 		return nil, err
 	}
+	s.Start()
 	return &sthStorage{dir: dir, store: s}, nil
 }
 
@@ -211,4 +212,11 @@ func (s *sthStorage) removeEntry(k []byte, entry store.IndexEntry, stored []stor
 		}
 	}
 	return false, nil
+}
+
+// Close stops all storage-related routines, and flushes
+// pending data
+// NOTE: Add it to storage interface?
+func (s *sthStorage) Close() error {
+	return s.store.Close()
 }

--- a/store/persistent/storethehash/storethehash_test.go
+++ b/store/persistent/storethehash/storethehash_test.go
@@ -80,7 +80,6 @@ func TestPeriodicFlush(t *testing.T) {
 
 	// Sleep for 2 sync Intervals to ensure that data is flushed
 	time.Sleep(2 * storethehash.DefaultSyncInterval)
-	s.Close()
 
 	// Regenerate new storage from primary
 	s2, err := storethehash.New(tmpDir)

--- a/store/persistent/storethehash/storethehash_test.go
+++ b/store/persistent/storethehash/storethehash_test.go
@@ -2,6 +2,7 @@ package storethehash_test
 
 import (
 	"io/ioutil"
+	"runtime"
 	"testing"
 	"time"
 
@@ -45,6 +46,9 @@ func TestRemoveMany(t *testing.T) {
 }
 
 func TestPeriodicFlush(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
 	// Init storage
 	tmpDir, err := ioutil.TempDir("", "sth")
 	if err != nil {

--- a/store/persistent/storethehash/storethehash_test.go
+++ b/store/persistent/storethehash/storethehash_test.go
@@ -3,10 +3,13 @@ package storethehash_test
 import (
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/filecoin-project/storetheindex/store"
 	"github.com/filecoin-project/storetheindex/store/persistent"
 	"github.com/filecoin-project/storetheindex/store/persistent/storethehash"
+	"github.com/filecoin-project/storetheindex/utils"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 func initSth() (store.PersistentStorage, error) {
@@ -39,4 +42,58 @@ func TestRemoveMany(t *testing.T) {
 		t.Fatal(err)
 	}
 	persistent.RemoveManyTest(t, s)
+}
+
+func TestPeriodicFlush(t *testing.T) {
+	// Init storage
+	tmpDir, err := ioutil.TempDir("", "sth")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := storethehash.New(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put some data in the first storage.
+	cids, err := utils.RandomCids(151)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry := store.MakeIndexEntry(p, 0, cids[0].Bytes())
+	for _, c := range cids[1:] {
+		_, err = s.Put(c, entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Sleep for 2 sync Intervals to ensure that data is flushed
+	time.Sleep(2 * storethehash.DefaultSyncInterval)
+	s.Close()
+
+	// Regenerate new storage from primary
+	s2, err := storethehash.New(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get data. If re-generated correctly we should find the CID
+	i, found, err := s2.Get(cids[3])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("Error finding single cid")
+	}
+	if !i[0].Equal(entry) {
+		t.Errorf("Got wrong value for single cid")
+	}
+
 }

--- a/store/store.go
+++ b/store/store.go
@@ -83,6 +83,8 @@ type PersistentStorage interface {
 	Storage
 	// Flush commits changes to storage
 	Flush() error
+	// Close gracefully closes the database flushing all pending data from memory
+	Close() error
 }
 
 // Marshal serializes IndexEntry list for storage


### PR DESCRIPTION
- Fixes a bug where `storethehash` persistence wasn't starting its sync routine and was not periodically flushing from memory.
- Adds unit test.