### PR TITLE
Read daemon config values from config file

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -25,11 +25,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const (
-	dataStoreDir  = "datastore"
-	dataStoreType = "levelds"
-)
-
 // shutdownTimeout is the duration that a graceful shutdown has to complete
 const shutdownTimeout = 5 * time.Second
 
@@ -140,6 +135,7 @@ func daemonCommand(cctx *cli.Context) error {
 	// Create libp2p host
 	if !cfg.Addresses.DisableP2P && !cctx.Bool("disablep2p") {
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
 		privKey, err := cfg.Identity.DecodePrivateKey("")
 		if err != nil {
@@ -152,13 +148,11 @@ func daemonCommand(cctx *cli.Context) error {
 			libp2p.Identity(privKey),
 		)
 		if err != nil {
-			cancel()
 			return err
 		}
 
 		p2pAPI, err = p2pfinderserver.New(ctx, p2pHost, indexerCore)
 		if err != nil {
-			cancel()
 			return err
 		}
 		cancelP2pFinder = cancel

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -53,6 +53,10 @@ func daemonCommand(cctx *cli.Context) error {
 		return fmt.Errorf("cannot load config file: %w", err)
 	}
 
+	if cfg.Datastore.Type != "levelds" {
+		return fmt.Errorf("only levelds datastore type supported, %q not supported", cfg.Datastore.Type)
+	}
+
 	// Create value store
 	valueStorePath, err := config.Path("", cfg.Indexer.ValueStoreDir)
 	if err != nil {
@@ -82,17 +86,17 @@ func daemonCommand(cctx *cli.Context) error {
 	indexerCore := core.NewEngine(resultCache, valueStore)
 	log.Infow("Indexer engine initialized")
 
-	// Create datastore
 	/*
+		// Create datastore
 		dataStorePath, err := config.Path("", cfg.Datastore.Dir)
 		if err != nil {
 			return err
 		}
 		err = checkWritable(dataStorePath)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		dstore, err := leveldb.NewDatastore(dataStorePath)
+		dstore, err := leveldb.NewDatastore(dataStorePath, nil)
 		if err != nil {
 			return err
 		}

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -5,11 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/signal"
-	"path/filepath"
 	"time"
-
-	"github.com/urfave/cli/v2"
 
 	core "github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/go-indexer-core/cache"
@@ -17,15 +13,22 @@ import (
 	"github.com/filecoin-project/go-indexer-core/store"
 	"github.com/filecoin-project/go-indexer-core/store/pogreb"
 	"github.com/filecoin-project/go-indexer-core/store/storethehash"
+	"github.com/filecoin-project/storetheindex/config"
 	adminserver "github.com/filecoin-project/storetheindex/server/admin"
 	httpfinderserver "github.com/filecoin-project/storetheindex/server/finder/http"
 	p2pfinderserver "github.com/filecoin-project/storetheindex/server/finder/libp2p"
+	//"github.com/ipfs/go-ds-leveldb"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
-	"github.com/mitchellh/go-homedir"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+	"github.com/urfave/cli/v2"
 )
 
-const defaultStorageDir = ".storetheindex"
+const (
+	dataStoreDir  = "datastore"
+	dataStoreType = "levelds"
+)
 
 // shutdownTimeout is the duration that a graceful shutdown has to complete
 const shutdownTimeout = 5 * time.Second
@@ -45,59 +48,109 @@ var DaemonCmd = &cli.Command{
 }
 
 func daemonCommand(cctx *cli.Context) error {
-	// TODO: get from config file
-	storeDir := cctx.String("dir")
-	storeType := cctx.String("storage")
-	valueStore, err := createValueStore(storeDir, storeType)
+	cfg, err := config.Load("")
+	if err != nil {
+		if err == config.ErrNotInitialized {
+			fmt.Fprintln(os.Stderr, "storetheindex is not initialized")
+			fmt.Fprintln(os.Stderr, "To initialize, run the command: ./storetheindex init")
+			os.Exit(1)
+		}
+		return fmt.Errorf("cannot load config file: %w", err)
+	}
+
+	// Create value store
+	valueStorePath, err := config.Path("", cfg.Indexer.ValueStoreDir)
 	if err != nil {
 		return err
 	}
-	log.Infow("Value storage initialized", "type", storeType, "dir", storeDir)
+	valueStoreType := cfg.Indexer.ValueStoreType
+	valueStore, err := createValueStore(valueStorePath, valueStoreType)
+	if err != nil {
+		return err
+	}
+	log.Infow("Value storage initialized", "type", valueStoreType, "path", valueStorePath)
 
+	// Create result cache
 	var resultCache cache.Interface
-	// TODO: get from config file
 	cacheSize := int(cctx.Int64("cachesize"))
-	if cacheSize != 0 {
+	if cacheSize < 0 {
+		cacheSize = cfg.Indexer.CacheSize
+	}
+	if cacheSize > 0 {
 		resultCache = radixcache.New(cacheSize)
 		log.Infow("result cache enabled", "size", cacheSize)
 	} else {
 		log.Info("result cache disabled")
 	}
 
+	// Create indexer core
 	indexerCore := core.NewEngine(resultCache, valueStore)
 	log.Infow("Indexer engine initialized")
 
-	// TODO: get from config file
-	finderAddr := cctx.String("finder_ep")
-	finderAPI, err := httpfinderserver.New(finderAddr, indexerCore)
-	if err != nil {
-		return err
-	}
-	log.Infow("Admin API initialized")
+	// Create datastore
+	/*
+		dataStorePath, err := config.Path("", cfg.Datastore.Dir)
+		if err != nil {
+			return err
+		}
+		err = checkWritable(dataStorePath)
+		if err != nil {
+			return nil, err
+		}
+		dstore, err := leveldb.NewDatastore(dataStorePath)
+		if err != nil {
+			return err
+		}
+	*/
 
-	adminAddr := cctx.String("admin_ep")
-	adminAPI, err := adminserver.New(adminAddr, indexerCore)
+	// Create admin HTTP server
+	maddr, err := ma.NewMultiaddr(cfg.Addresses.Admin)
+	if err != nil {
+		return fmt.Errorf("bad admin address in config %s: %s", cfg.Addresses.Admin, err)
+	}
+	adminAddr, err := manet.ToNetAddr(maddr)
 	if err != nil {
 		return err
 	}
-	log.Infow("Client finder API initialized")
+	adminAPI, err := adminserver.New(adminAddr.String(), indexerCore)
+	if err != nil {
+		return err
+	}
+	log.Infow("Admin API initialized", "address", adminAddr)
+
+	// Create finder HTTP server
+	maddr, err = ma.NewMultiaddr(cfg.Addresses.Finder)
+	if err != nil {
+		return fmt.Errorf("bad finder address in config %s: %s", cfg.Addresses.Finder, err)
+	}
+	finderAddr, err := manet.ToNetAddr(maddr)
+	if err != nil {
+		return err
+	}
+	finderAPI, err := httpfinderserver.New(finderAddr.String(), indexerCore)
+	if err != nil {
+		return err
+	}
+	log.Infow("Client finder API initialized", "address", finderAddr)
 
 	var (
 		p2pAPI          *p2pfinderserver.Server
 		cancelP2pFinder context.CancelFunc
 	)
-
-	// TODO: get from config file
-	p2pEnabled := cctx.Bool("enablep2p")
-	if p2pEnabled {
+	// Create libp2p host
+	if !cfg.Addresses.DisableP2P && !cctx.Bool("disablep2p") {
 		ctx, cancel := context.WithCancel(context.Background())
 
-		// NOTE: We are creating a new flat libp2p host here because no other
-		// process in the indexer node needs a libp2p host. In the future, when
-		// the indexer node starts using other libp2p protocols to interact with
-		// miners and other indexers, we may need to initialize it before and
-		// use it here so we have a single libp2p host giving service to the whole indexer.
-		p2pHost, err := libp2p.New(ctx)
+		privKey, err := cfg.Identity.DecodePrivateKey("")
+		if err != nil {
+			return err
+		}
+		// TODO: Do we want to the libp2p host to listen on any particular
+		// addresss and port?
+		p2pHost, err := libp2p.New(ctx,
+			// Use the keypair generated during init
+			libp2p.Identity(privKey),
+		)
 		if err != nil {
 			cancel()
 			return err
@@ -109,7 +162,7 @@ func daemonCommand(cctx *cli.Context) error {
 			return err
 		}
 		cancelP2pFinder = cancel
-		log.Infow("Client libp2p API initialized")
+		log.Infow("Client libp2p API initialized", "host_id", p2pHost.ID())
 	}
 
 	log.Info("Starting daemon servers")
@@ -122,11 +175,9 @@ func daemonCommand(cctx *cli.Context) error {
 	}()
 
 	var finalErr error
-	// Wait for SIGINT (CTRL-c), then close server and exit.
-	sigint := make(chan os.Signal, 1)
-	signal.Notify(sigint, os.Interrupt)
 	select {
-	case <-sigint:
+	case <-cctx.Done():
+		// Command was canceled (ctrl-c)
 	case err = <-errChan:
 		log.Errorw("Failed to start server", "err", err)
 		finalErr = ErrDaemonStart
@@ -138,13 +189,12 @@ func daemonCommand(cctx *cli.Context) error {
 	defer cancel()
 
 	go func() {
-		select {
-		case <-ctx.Done():
+		// Wait for context to be canceled.  If timeout, then exit with error.
+		<-ctx.Done()
+		if ctx.Err() == context.DeadlineExceeded {
 			fmt.Println("Timed out on shutdown, terminating...")
-		case <-sigint:
-			fmt.Println("Received another interrupt before graceful shutdown, terminating...")
+			os.Exit(-1)
 		}
-		os.Exit(-1)
 	}()
 
 	if p2pAPI != nil {
@@ -164,13 +214,14 @@ func daemonCommand(cctx *cli.Context) error {
 		log.Errorw("Error closing value store", "err", err)
 		finalErr = ErrDaemonStop
 	}
+	cancel()
 
 	log.Infow("node stopped")
 	return finalErr
 }
 
 func createValueStore(dir, storeType string) (store.Interface, error) {
-	dir, err := checkStorageDir(dir)
+	err := checkWritable(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -183,45 +234,4 @@ func createValueStore(dir, storeType string) (store.Interface, error) {
 	}
 
 	return nil, fmt.Errorf("unrecognized store type: %s", storeType)
-}
-
-func checkStorageDir(dir string) (string, error) {
-	var err error
-	if dir != "" {
-		dir, err = homedir.Expand(dir)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		home, err := homedir.Dir()
-		if err != nil {
-			return "", err
-		}
-		if home == "" {
-			return "", errors.New("could not determine storage directory, home dir not set")
-		}
-
-		dir = filepath.Join(home, defaultStorageDir)
-	}
-
-	if err = checkMkDir(dir); err != nil {
-		return "", err
-	}
-
-	return dir, nil
-}
-
-// checkMkDir checks that the directory exists, and if not, creates it
-func checkMkDir(dir string) error {
-	_, err := os.Stat(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			if err = os.Mkdir(dir, 0644); err != nil {
-				return err
-			}
-			return nil
-		}
-		return err
-	}
-	return nil
 }

--- a/command/flags.go
+++ b/command/flags.go
@@ -6,23 +6,31 @@ import (
 	"github.com/urfave/cli/v2/altsrc"
 )
 
-var FinderEndpointFlag = altsrc.NewStringFlag(&cli.StringFlag{
-	Name:     "finder_ep",
-	Usage:    "Finder HTTP API endpoint",
+var FinderAddrFlag = altsrc.NewStringFlag(&cli.StringFlag{
+	Name:     "finderaddr",
+	Usage:    "Finder HTTP API address",
 	Aliases:  []string{"fep"},
-	EnvVars:  []string{"FINDER_ENDPOINT"},
+	EnvVars:  []string{"FINDER_ADDRESS"},
 	Required: false,
 	Value:    "127.0.0.0:3000",
 })
 
-var AdminEndpointFlag = altsrc.NewStringFlag(&cli.StringFlag{
-	Name:     "admin_ep",
-	Usage:    "Admin HTTP API endpoint",
+var AdminAddrFlag = altsrc.NewStringFlag(&cli.StringFlag{
+	Name:     "adminaddr",
+	Usage:    "Admin HTTP API address",
 	Aliases:  []string{"aep"},
-	EnvVars:  []string{"ADMIN_ENDPOINT"},
+	EnvVars:  []string{"ADMIN_ARRDESS"},
 	Required: false,
 	Value:    "127.0.0.0:3001",
 })
+
+var CacheSizeFlag = &cli.Int64Flag{
+	Name:     "cachesize",
+	Usage:    "Maximum number of CIDs that cache can hold, 0 to disable cache",
+	Aliases:  []string{"c"},
+	Required: false,
+	Value:    -1,
+}
 
 var DirFlag = &cli.StringFlag{
 	Name:     "dir",
@@ -32,41 +40,18 @@ var DirFlag = &cli.StringFlag{
 }
 
 var DaemonFlags = []cli.Flag{
-	&cli.Int64Flag{
-		Name:     "cachesize",
-		Usage:    "Maximum number of CIDs that cache can hold",
-		Aliases:  []string{"c"},
-		EnvVars:  []string{"CACHE_SIZE"},
-		Value:    100000,
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "storage",
-		Usage:    "Type of persistent storage (none, sth, pogreb)",
-		Aliases:  []string{"s"},
-		EnvVars:  []string{"STORAGE_TYPE"},
-		Value:    "sth",
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "dir",
-		Usage:    "Directory for persistent storage, default: ~/.storetheindex",
-		Aliases:  []string{"d"},
-		Required: false,
-	},
+	CacheSizeFlag,
 	&cli.BoolFlag{
-		Name:     "enablep2p",
-		Usage:    "Enable libp2p client api for indexer",
-		Aliases:  []string{"p2p"},
+		Name:     "disablep2p",
+		Usage:    "Disable libp2p client api for indexer",
+		Aliases:  []string{"nop2p"},
 		Value:    false,
 		Required: false,
 	},
-	FinderEndpointFlag,
-	AdminEndpointFlag,
 }
 
 var ClientCmdFlags = []cli.Flag{
-	FinderEndpointFlag,
+	FinderAddrFlag,
 	&cli.StringFlag{
 		Name:     "protocol",
 		Usage:    "Protocol to query the indexer (http, libp2p currently supported)",
@@ -90,14 +75,25 @@ var ImportFlags = []cli.Flag{
 		Required: false,
 	},
 	DirFlag,
-	AdminEndpointFlag,
+	AdminAddrFlag,
 }
 
 var InitFlags = []cli.Flag{
+	CacheSizeFlag,
 	&cli.StringFlag{
 		Name:     "store",
 		Usage:    "Type of value store (sth, pogreb). Default is \"sth\"",
 		Aliases:  []string{"s"},
+		Required: false,
+	},
+	&cli.StringFlag{
+		Name:     "adminaddr",
+		Usage:    "Admin HTTP API listen address",
+		Required: false,
+	},
+	&cli.StringFlag{
+		Name:     "finderaddr",
+		Usage:    "Finder HTTP API listen address",
 		Required: false,
 	},
 }

--- a/command/fsutil.go
+++ b/command/fsutil.go
@@ -1,0 +1,59 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+// checkWritable checks the the directory is writable.  If the directory does
+// not exist it is created with writable permission.
+func checkWritable(dir string) error {
+	if dir == "" {
+		return errors.New("cannot check empty directory")
+	}
+
+	var err error
+	dir, err = homedir.Expand(dir)
+	if err != nil {
+		return err
+	}
+
+	_, err = os.Stat(dir)
+	if err == nil {
+		// dir exists, make sure we can write to it
+		testfile := filepath.Join(dir, "test")
+		fi, err := os.Create(testfile)
+		if err != nil {
+			if os.IsPermission(err) {
+				return fmt.Errorf("%s is not writeable by the current user", dir)
+			}
+			return fmt.Errorf("unexpected error while checking writeablility of repo root: %s", err)
+		}
+		fi.Close()
+		return os.Remove(testfile)
+	}
+
+	if os.IsNotExist(err) {
+		// dir doesn't exist, check that we can create it
+		return os.Mkdir(dir, 0775)
+	}
+
+	if os.IsPermission(err) {
+		return fmt.Errorf("cannot write to %s, incorrect permissions", err)
+	}
+
+	return err
+}
+
+// fileExists return true if the file exists
+func fileExists(filename string) bool {
+	fi, err := os.Lstat(filename)
+	if fi != nil || (err != nil && !os.IsNotExist(err)) {
+		return true
+	}
+	return false
+}

--- a/command/init.go
+++ b/command/init.go
@@ -3,9 +3,9 @@ package command
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/filecoin-project/storetheindex/config"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
 )
 
@@ -19,6 +19,36 @@ var InitCmd = &cli.Command{
 func initCommand(cctx *cli.Context) error {
 	log.Info("Initializing indexer config file")
 
+	// First read and validate flag values
+	adminAddr := cctx.String("adminaddr")
+	if adminAddr != "" {
+		_, err := multiaddr.NewMultiaddr(adminAddr)
+		if err != nil {
+			return fmt.Errorf("bad admiaddr: %s", err)
+		}
+	}
+
+	finderAddr := cctx.String("finderaddr")
+	if finderAddr != "" {
+		_, err := multiaddr.NewMultiaddr(finderAddr)
+		if err != nil {
+			return fmt.Errorf("bad finderaddr: %s", err)
+		}
+	}
+
+	cacheSize := int(cctx.Int64("cachesize"))
+
+	storeType := cctx.String("store")
+	switch storeType {
+	case "":
+		// Use config default
+	case "sth", "pogreb":
+		// These are good
+	default:
+		return fmt.Errorf("unrecognized store type: %s", storeType)
+	}
+
+	// Check that the config root exists and it writable.
 	configRoot, err := config.PathRoot()
 	if err != nil {
 		return err
@@ -42,51 +72,19 @@ func initCommand(cctx *cli.Context) error {
 		return err
 	}
 
-	store := cctx.String("store")
-	switch store {
-	case "":
-		// Use config default
-	case "sth", "pogreb":
-		cfg.Indexer.StoreType = store
-	default:
-		return fmt.Errorf("unrecognized store type: %s", store)
+	// Use values from flags to override defaults
+	if cacheSize >= 0 {
+		cfg.Indexer.CacheSize = cacheSize
+	}
+	if storeType != "" {
+		cfg.Indexer.ValueStoreType = storeType
+	}
+	if adminAddr != "" {
+		cfg.Addresses.Admin = adminAddr
+	}
+	if finderAddr != "" {
+		cfg.Addresses.Finder = finderAddr
 	}
 
 	return cfg.Save(configFile)
-}
-
-func checkWritable(dir string) error {
-	_, err := os.Stat(dir)
-	if err == nil {
-		// dir exists, make sure we can write to it
-		testfile := filepath.Join(dir, "test")
-		fi, err := os.Create(testfile)
-		if err != nil {
-			if os.IsPermission(err) {
-				return fmt.Errorf("%s is not writeable by the current user", dir)
-			}
-			return fmt.Errorf("unexpected error while checking writeablility of repo root: %s", err)
-		}
-		fi.Close()
-		return os.Remove(testfile)
-	}
-
-	if os.IsNotExist(err) {
-		// dir doesn't exist, check that we can create it
-		return os.Mkdir(dir, 0775)
-	}
-
-	if os.IsPermission(err) {
-		return fmt.Errorf("cannot write to %s, incorrect permissions", err)
-	}
-
-	return err
-}
-
-func fileExists(filename string) bool {
-	fi, err := os.Lstat(filename)
-	if fi != nil || (err != nil && !os.IsNotExist(err)) {
-		return true
-	}
-	return false
 }

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -1,0 +1,69 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/filecoin-project/storetheindex/config"
+	"github.com/urfave/cli/v2"
+)
+
+func TestInit(t *testing.T) {
+	// Set up a context that is canceled when the command is interrupted
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tempDir := t.TempDir()
+	os.Setenv(config.EnvDir, tempDir)
+
+	app := &cli.App{
+		Name: "indexer",
+		Commands: []*cli.Command{
+			InitCmd,
+		},
+	}
+
+	badAddr := "ip3/127.0.0.1/tcp/9999"
+	err := app.RunContext(ctx, []string{"storetheindex", "init", "-adminaddr", badAddr})
+	if err == nil {
+		log.Fatal("expected error")
+	}
+
+	err = app.RunContext(ctx, []string{"storetheindex", "init", "-finderaddr", badAddr})
+	if err == nil {
+		log.Fatal("expected error")
+	}
+
+	goodAddr := "/ip4/127.0.0.1/tcp/7777"
+	storeType := "pogreb"
+	cacheSize := 2701
+	args := []string{
+		"storetheindex", "init",
+		"-finderaddr", goodAddr,
+		"-cachesize", fmt.Sprint(cacheSize),
+		"-store", storeType,
+	}
+	err = app.RunContext(ctx, args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cfg, err := config.Load("")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if cfg.Addresses.Finder != goodAddr {
+		t.Error("finder listen address was not configured")
+	}
+	if cfg.Indexer.CacheSize != cacheSize {
+		t.Error("cache size was tno configured")
+	}
+	if cfg.Indexer.ValueStoreType != storeType {
+		t.Error("value store type was not configured")
+	}
+
+	t.Log(cfg.String())
+}

--- a/config/addresses.go
+++ b/config/addresses.go
@@ -1,7 +1,7 @@
 package config
 
 const (
-	defaultAdminAddr  = "/ip4/0.0.0.0/tcp/3002"
+	defaultAdminAddr  = "/ip4/127.0.0.1/tcp/3002"
 	defaultFinderAddr = "/ip4/0.0.0.0/tcp/3000"
 	defaultIngestAddr = "/ip4/0.0.0.0/tcp/3001"
 )
@@ -14,4 +14,6 @@ type Addresses struct {
 	Finder string
 	// Ingest is the index data ingestion API listen address
 	Ingest string
+	// DisbleP2P disables libp2p hosting
+	DisableP2P bool
 }

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -1,0 +1,14 @@
+package config
+
+const (
+	defaultDatastoreType = "levelds"
+	defaultDatastoreDir  = "datastore"
+)
+
+// Datastore tracks the configuration of the datastore.
+type Datastore struct {
+	// Type is the type of datastore
+	Type string
+	// Dir is the directory withing the config root where the datastore is kept
+	Dir string
+}

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -1,12 +1,17 @@
 package config
 
 const (
-	defaultCacheSize = 300000
-	defaultStoreType = "sth"
+	defaultCacheSize      = 300000
+	defaultValueStoreType = "sth"
+	defaultValueStoreDir  = "valuestore"
 )
 
 // Indexer holds configuration for the indexer core
 type Indexer struct {
+	// Maximum number of CIDs that cache can hold,0 to disable cache
 	CacheSize int
-	StoreType string
+	// Directory withing config root where value store is kept
+	ValueStoreDir string
+	// Type of value store to use
+	ValueStoreType string
 }

--- a/config/init.go
+++ b/config/init.go
@@ -47,7 +47,7 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 
 		Providers: Providers{
 			Policy:       defaultPolicy,
-			Except:       []string{identity.PeerID},
+			Trust:        []string{identity.PeerID},
 			PollInterval: defaultPollInterval,
 		},
 	}

--- a/config/init.go
+++ b/config/init.go
@@ -28,6 +28,11 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 			Ingest: defaultIngestAddr,
 		},
 
+		Datastore: Datastore{
+			Type: defaultDatastoreType,
+			Dir:  defaultDatastoreDir,
+		},
+
 		Discovery: Discovery{
 			Topic: defaultTopic,
 		},
@@ -35,8 +40,9 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		Identity: identity,
 
 		Indexer: Indexer{
-			CacheSize: defaultCacheSize,
-			StoreType: defaultStoreType,
+			CacheSize:      defaultCacheSize,
+			ValueStoreDir:  defaultValueStoreDir,
+			ValueStoreType: defaultValueStoreType,
 		},
 
 		Providers: Providers{

--- a/config/providers.go
+++ b/config/providers.go
@@ -8,8 +8,13 @@ const (
 type Providers struct {
 	// Policy is either "block" or "allow"
 	Policy string
-	// Except is a list of peer IDs that are excluded from the policy
+	// Except is a list of peer IDs that are excluded from the policy.
+	// Providers that are allowed by policy or expetion must still be valid
+	// providers.
 	Except []string
+	// Trust is a list of peer IDs that are allowed with being required to be
+	// valid providers.
+	Trust []string
 	// PollInterval is the amount of time to wait without getting any updates
 	// from a provider, before sending a request for the latest advertisement.
 	// Values are a number ending in "s", "m", "h" for seconds. minutes, hours.

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ func main() {
 			cancel()
 		case <-ctx.Done():
 		}
+		// Allow any forther SIGTERM or SIGING to kill process
+		signal.Stop(interrupt)
 	}()
 
 	if err := logging.SetLogLevel("*", "info"); err != nil {
@@ -45,7 +47,6 @@ func main() {
 			command.InitCmd,
 			command.SyntheticCmd,
 		},
-		// Before: altsrc.InitInputSourceWithContext(append(appFlags, commands.AllFlags...), altsrc.NewYamlSourceFromFlagFunc("config")),
 	}
 
 	if err := app.RunContext(ctx, os.Args); err != nil {


### PR DESCRIPTION
- Only use CLI flags for overriding some config values, otherwise all values come from config file
- Store datastore and valuestore config in config so it can be read by future migrations
- Unit test for init command
- Reorg command flags
- Fix daemon signal handling and shutdown