### PR TITLE
Integrate ingest admin interface into CLI

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -66,6 +66,16 @@ var ImportFlags = []cli.Flag{
 	IndexerHostFlag,
 }
 
+var IngestFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:     "provider",
+		Usage:    "Provider to interact with",
+		Aliases:  []string{"prov"},
+		Required: true,
+	},
+	IndexerHostFlag,
+}
+
 var InitFlags = []cli.Flag{
 	CacheSizeFlag,
 	&cli.StringFlag{

--- a/command/ingest.go
+++ b/command/ingest.go
@@ -1,0 +1,123 @@
+package command
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	httpclient "github.com/filecoin-project/storetheindex/internal/httpclient"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	adminPort      = 3002
+	ingestResource = "ingest"
+)
+
+var subscribe = &cli.Command{
+	Name:   "subscribe",
+	Usage:  "Subscribe indexer with provider",
+	Flags:  IngestFlags,
+	Action: subscribeCmd,
+}
+
+var unsubscribe = &cli.Command{
+	Name:   "unsubscribe",
+	Usage:  "Unsubscribe indexer from provider",
+	Flags:  IngestFlags,
+	Action: unsubscribeCmd,
+}
+
+var sync = &cli.Command{
+	Name:   "sync",
+	Usage:  "Sync indexer with provider",
+	Flags:  IngestFlags,
+	Action: syncCmd,
+}
+
+var IngestCmd = &cli.Command{
+	Name:  "ingest",
+	Usage: "Admin commands to manage ingestion config of indexer",
+	Subcommands: []*cli.Command{
+		subscribe,
+		unsubscribe,
+		sync,
+	},
+}
+
+type ingestClient struct {
+	c       *http.Client
+	baseurl *url.URL
+}
+
+func newIngestClient(baseurl string) (*ingestClient, error) {
+	url, c, err := httpclient.NewClient(baseurl, ingestResource, adminPort)
+	if err != nil {
+		return nil, err
+	}
+	return &ingestClient{
+		c,
+		url,
+	}, nil
+}
+
+func sendRequest(cctx *cli.Context, action string) error {
+	cl, err := newIngestClient(cctx.String("indexer-host"))
+	if err != nil {
+		return err
+	}
+	prov := cctx.String("provider")
+	p, err := peer.Decode(prov)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(cctx.Context, "GET", path.Join(cl.baseurl.Path, action, p.String()), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := cl.c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return httpclient.ReadError(resp.StatusCode, body)
+	}
+	return nil
+}
+
+func subscribeCmd(cctx *cli.Context) error {
+	err := sendRequest(cctx, "subscribe")
+	if err != nil {
+		return err
+	}
+	log.Errorf("Successfully subscribed to provider")
+	return nil
+}
+
+func unsubscribeCmd(cctx *cli.Context) error {
+	err := sendRequest(cctx, "unsubscribe")
+	if err != nil {
+		return err
+	}
+	log.Errorf("Successfully unsubscribed from provider")
+	return nil
+}
+
+func syncCmd(cctx *cli.Context) error {
+	err := sendRequest(cctx, "sync")
+	if err != nil {
+		return err
+	}
+	log.Errorf("Syncing request accepted. Come back later to check if syncing was successful")
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 			command.InitCmd,
 			command.RegisterCmd,
 			command.SyntheticCmd,
+			command.IngestCmd,
 		},
 	}
 

--- a/server/admin/http/handler/ingester.go
+++ b/server/admin/http/handler/ingester.go
@@ -15,7 +15,7 @@ func (h *AdminHandler) Subscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	vars := mux.Vars(r)
-	m := vars["minerid"]
+	m := vars["provider"]
 	miner, err := peer.Decode(m)
 	if err != nil {
 		log.Errorw("error decoding miner id into peerID", "miner", m, "err", err)
@@ -39,7 +39,7 @@ func (h *AdminHandler) Unsubscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	vars := mux.Vars(r)
-	m := vars["minerid"]
+	m := vars["provider"]
 	miner, err := peer.Decode(m)
 	if err != nil {
 		log.Errorw("error decoding miner id into peerID", "miner", m, "err", err)
@@ -63,7 +63,7 @@ func (h *AdminHandler) Sync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	vars := mux.Vars(r)
-	m := vars["minerid"]
+	m := vars["provider"]
 	miner, err := peer.Decode(m)
 	if err != nil {
 		log.Errorw("error decoding miner id into peerID", "miner", m, "err", err)

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -50,9 +50,9 @@ func New(listen string, indexer indexer.Interface, ingester ingestion.Ingester, 
 	r.HandleFunc("/healthcheck", adminHandler.HealthCheckHandler).Methods("GET")
 
 	// Ingester routes
-	r.HandleFunc("/ingest/subscribe/{minerid}", adminHandler.Subscribe).Methods("POST")
-	r.HandleFunc("/ingest/unsubscribe/{minerid}", adminHandler.Unsubscribe).Methods("POST")
-	r.HandleFunc("/ingest/sync/{minerid}", adminHandler.Sync).Methods("POST")
+	r.HandleFunc("/ingest/subscribe/{provider}", adminHandler.Subscribe).Methods("GET")
+	r.HandleFunc("/ingest/unsubscribe/{provider}", adminHandler.Unsubscribe).Methods("GET")
+	r.HandleFunc("/ingest/sync/{provider}", adminHandler.Sync).Methods("GET")
 
 	return s, nil
 }


### PR DESCRIPTION
This PR:

- Adds a few commands in CLI to interact with the indexer's admin API to manually trigger ingestion operations. These commands are mainly targeted for testing purposes.