### PR TITLE
Ingest multihashes as a linked list of Bytes instead of a list of CIDs

### DIFF
--- a/api/v0/ingest/schema/gen.go
+++ b/api/v0/ingest/schema/gen.go
@@ -63,13 +63,14 @@ func main() {
 		}),
 	))
 
-	// List string
+	// List multihash
 	ts.Accumulate(schema.SpawnStruct("EntryChunk", []schema.StructField{
-		schema.SpawnStructField("Entries", "List_String", false, false),
+		schema.SpawnStructField("Entries", "List_Bytes", false, false),
 		schema.SpawnStructField("Next", "Link_EntryChunk", true, false),
 	}, schema.SpawnStructRepresentationMap(map[string]string{})))
 	ts.Accumulate(schema.SpawnLinkReference("Link_EntryChunk", "EntryChunk"))
 	ts.Accumulate(schema.SpawnList("List_String", "String", false))
+	ts.Accumulate(schema.SpawnList("List_Bytes", "Bytes", false))
 
 	// Advertisement
 	ts.Accumulate(schema.SpawnStruct("Advertisement", []schema.StructField{

--- a/api/v0/ingest/schema/ipldsch_satisfaction.go
+++ b/api/v0/ingest/schema/ipldsch_satisfaction.go
@@ -2898,7 +2898,7 @@ var _ datamodel.Node = &_Bytes__Repr{}
 type _Bytes__ReprPrototype = _Bytes__Prototype
 type _Bytes__ReprAssembler = _Bytes__Assembler
 
-func (n _EntryChunk) FieldEntries() List_String {
+func (n _EntryChunk) FieldEntries() List_Bytes {
 	return &n.Entries
 }
 func (n _EntryChunk) FieldNext() MaybeLink_EntryChunk {
@@ -3075,7 +3075,7 @@ type _EntryChunk__Assembler struct {
 	f     int
 
 	cm         schema.Maybe
-	ca_Entries _List_String__Assembler
+	ca_Entries _List_Bytes__Assembler
 	ca_Next    _Link_EntryChunk__Assembler
 }
 
@@ -3539,7 +3539,7 @@ type _EntryChunk__ReprAssembler struct {
 	f     int
 
 	cm         schema.Maybe
-	ca_Entries _List_String__ReprAssembler
+	ca_Entries _List_Bytes__ReprAssembler
 	ca_Next    _Link_EntryChunk__ReprAssembler
 }
 
@@ -5474,6 +5474,597 @@ func (la *_List__ReprAssembler) Finish() error {
 }
 func (la *_List__ReprAssembler) ValuePrototype(_ int64) datamodel.NodePrototype {
 	return _Any__ReprPrototype{}
+}
+
+func (n *_List_Bytes) Lookup(idx int64) Bytes {
+	if n.Length() <= idx {
+		return nil
+	}
+	v := &n.x[idx]
+	return v
+}
+func (n *_List_Bytes) LookupMaybe(idx int64) MaybeBytes {
+	if n.Length() <= idx {
+		return nil
+	}
+	v := &n.x[idx]
+	return &_Bytes__Maybe{
+		m: schema.Maybe_Value,
+		v: *v,
+	}
+}
+
+var _List_Bytes__valueAbsent = _Bytes__Maybe{m: schema.Maybe_Absent}
+
+func (n List_Bytes) Iterator() *List_Bytes__Itr {
+	return &List_Bytes__Itr{n, 0}
+}
+
+type List_Bytes__Itr struct {
+	n   List_Bytes
+	idx int
+}
+
+func (itr *List_Bytes__Itr) Next() (idx int64, v Bytes) {
+	if itr.idx >= len(itr.n.x) {
+		return -1, nil
+	}
+	idx = int64(itr.idx)
+	v = &itr.n.x[itr.idx]
+	itr.idx++
+	return
+}
+func (itr *List_Bytes__Itr) Done() bool {
+	return itr.idx >= len(itr.n.x)
+}
+
+type _List_Bytes__Maybe struct {
+	m schema.Maybe
+	v _List_Bytes
+}
+type MaybeList_Bytes = *_List_Bytes__Maybe
+
+func (m MaybeList_Bytes) IsNull() bool {
+	return m.m == schema.Maybe_Null
+}
+func (m MaybeList_Bytes) IsAbsent() bool {
+	return m.m == schema.Maybe_Absent
+}
+func (m MaybeList_Bytes) Exists() bool {
+	return m.m == schema.Maybe_Value
+}
+func (m MaybeList_Bytes) AsNode() datamodel.Node {
+	switch m.m {
+	case schema.Maybe_Absent:
+		return datamodel.Absent
+	case schema.Maybe_Null:
+		return datamodel.Null
+	case schema.Maybe_Value:
+		return &m.v
+	default:
+		panic("unreachable")
+	}
+}
+func (m MaybeList_Bytes) Must() List_Bytes {
+	if !m.Exists() {
+		panic("unbox of a maybe rejected")
+	}
+	return &m.v
+}
+
+var _ datamodel.Node = (List_Bytes)(&_List_Bytes{})
+var _ schema.TypedNode = (List_Bytes)(&_List_Bytes{})
+
+func (List_Bytes) Kind() datamodel.Kind {
+	return datamodel.Kind_List
+}
+func (List_Bytes) LookupByString(string) (datamodel.Node, error) {
+	return mixins.List{TypeName: "schema.List_Bytes"}.LookupByString("")
+}
+func (n List_Bytes) LookupByNode(k datamodel.Node) (datamodel.Node, error) {
+	idx, err := k.AsInt()
+	if err != nil {
+		return nil, err
+	}
+	return n.LookupByIndex(idx)
+}
+func (n List_Bytes) LookupByIndex(idx int64) (datamodel.Node, error) {
+	if n.Length() <= idx {
+		return nil, datamodel.ErrNotExists{Segment: datamodel.PathSegmentOfInt(idx)}
+	}
+	v := &n.x[idx]
+	return v, nil
+}
+func (n List_Bytes) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
+	i, err := seg.Index()
+	if err != nil {
+		return nil, datamodel.ErrInvalidSegmentForList{TypeName: "schema.List_Bytes", TroubleSegment: seg, Reason: err}
+	}
+	return n.LookupByIndex(i)
+}
+func (List_Bytes) MapIterator() datamodel.MapIterator {
+	return nil
+}
+func (n List_Bytes) ListIterator() datamodel.ListIterator {
+	return &_List_Bytes__ListItr{n, 0}
+}
+
+type _List_Bytes__ListItr struct {
+	n   List_Bytes
+	idx int
+}
+
+func (itr *_List_Bytes__ListItr) Next() (idx int64, v datamodel.Node, _ error) {
+	if itr.idx >= len(itr.n.x) {
+		return -1, nil, datamodel.ErrIteratorOverread{}
+	}
+	idx = int64(itr.idx)
+	x := &itr.n.x[itr.idx]
+	v = x
+	itr.idx++
+	return
+}
+func (itr *_List_Bytes__ListItr) Done() bool {
+	return itr.idx >= len(itr.n.x)
+}
+
+func (n List_Bytes) Length() int64 {
+	return int64(len(n.x))
+}
+func (List_Bytes) IsAbsent() bool {
+	return false
+}
+func (List_Bytes) IsNull() bool {
+	return false
+}
+func (List_Bytes) AsBool() (bool, error) {
+	return mixins.List{TypeName: "schema.List_Bytes"}.AsBool()
+}
+func (List_Bytes) AsInt() (int64, error) {
+	return mixins.List{TypeName: "schema.List_Bytes"}.AsInt()
+}
+func (List_Bytes) AsFloat() (float64, error) {
+	return mixins.List{TypeName: "schema.List_Bytes"}.AsFloat()
+}
+func (List_Bytes) AsString() (string, error) {
+	return mixins.List{TypeName: "schema.List_Bytes"}.AsString()
+}
+func (List_Bytes) AsBytes() ([]byte, error) {
+	return mixins.List{TypeName: "schema.List_Bytes"}.AsBytes()
+}
+func (List_Bytes) AsLink() (datamodel.Link, error) {
+	return mixins.List{TypeName: "schema.List_Bytes"}.AsLink()
+}
+func (List_Bytes) Prototype() datamodel.NodePrototype {
+	return _List_Bytes__Prototype{}
+}
+
+type _List_Bytes__Prototype struct{}
+
+func (_List_Bytes__Prototype) NewBuilder() datamodel.NodeBuilder {
+	var nb _List_Bytes__Builder
+	nb.Reset()
+	return &nb
+}
+
+type _List_Bytes__Builder struct {
+	_List_Bytes__Assembler
+}
+
+func (nb *_List_Bytes__Builder) Build() datamodel.Node {
+	if *nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_List_Bytes__Builder) Reset() {
+	var w _List_Bytes
+	var m schema.Maybe
+	*nb = _List_Bytes__Builder{_List_Bytes__Assembler{w: &w, m: &m}}
+}
+
+type _List_Bytes__Assembler struct {
+	w     *_List_Bytes
+	m     *schema.Maybe
+	state laState
+
+	cm schema.Maybe
+	va _Bytes__Assembler
+}
+
+func (na *_List_Bytes__Assembler) reset() {
+	na.state = laState_initial
+	na.va.reset()
+}
+func (_List_Bytes__Assembler) BeginMap(sizeHint int64) (datamodel.MapAssembler, error) {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes"}.BeginMap(0)
+}
+func (na *_List_Bytes__Assembler) BeginList(sizeHint int64) (datamodel.ListAssembler, error) {
+	switch *na.m {
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
+	}
+	*na.m = midvalue
+	if sizeHint < 0 {
+		sizeHint = 0
+	}
+	if sizeHint > 0 {
+		na.w.x = make([]_Bytes, 0, sizeHint)
+	}
+	return na, nil
+}
+func (na *_List_Bytes__Assembler) AssignNull() error {
+	switch *na.m {
+	case allowNull:
+		*na.m = schema.Maybe_Null
+		return nil
+	case schema.Maybe_Absent:
+		return mixins.ListAssembler{TypeName: "schema.List_Bytes"}.AssignNull()
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+	}
+	panic("unreachable")
+}
+func (_List_Bytes__Assembler) AssignBool(bool) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes"}.AssignBool(false)
+}
+func (_List_Bytes__Assembler) AssignInt(int64) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes"}.AssignInt(0)
+}
+func (_List_Bytes__Assembler) AssignFloat(float64) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes"}.AssignFloat(0)
+}
+func (_List_Bytes__Assembler) AssignString(string) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes"}.AssignString("")
+}
+func (_List_Bytes__Assembler) AssignBytes([]byte) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes"}.AssignBytes(nil)
+}
+func (_List_Bytes__Assembler) AssignLink(datamodel.Link) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes"}.AssignLink(nil)
+}
+func (na *_List_Bytes__Assembler) AssignNode(v datamodel.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_List_Bytes); ok {
+		switch *na.m {
+		case schema.Maybe_Value, schema.Maybe_Null:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		case midvalue:
+			panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+		}
+		*na.w = *v2
+		*na.m = schema.Maybe_Value
+		return nil
+	}
+	if v.Kind() != datamodel.Kind_List {
+		return datamodel.ErrWrongKind{TypeName: "schema.List_Bytes", MethodName: "AssignNode", AppropriateKind: datamodel.KindSet_JustList, ActualKind: v.Kind()}
+	}
+	itr := v.ListIterator()
+	for !itr.Done() {
+		_, v, err := itr.Next()
+		if err != nil {
+			return err
+		}
+		if err := na.AssembleValue().AssignNode(v); err != nil {
+			return err
+		}
+	}
+	return na.Finish()
+}
+func (_List_Bytes__Assembler) Prototype() datamodel.NodePrototype {
+	return _List_Bytes__Prototype{}
+}
+func (la *_List_Bytes__Assembler) valueFinishTidy() bool {
+	switch la.cm {
+	case schema.Maybe_Value:
+		la.va.w = nil
+		la.cm = schema.Maybe_Absent
+		la.state = laState_initial
+		la.va.reset()
+		return true
+	default:
+		return false
+	}
+}
+func (la *_List_Bytes__Assembler) AssembleValue() datamodel.NodeAssembler {
+	switch la.state {
+	case laState_initial:
+		// carry on
+	case laState_midValue:
+		if !la.valueFinishTidy() {
+			panic("invalid state: AssembleValue cannot be called when still in the middle of assembling the previous value")
+		} // if tidy success: carry on
+	case laState_finished:
+		panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
+	}
+	la.w.x = append(la.w.x, _Bytes{})
+	la.state = laState_midValue
+	row := &la.w.x[len(la.w.x)-1]
+	la.va.w = row
+	la.va.m = &la.cm
+	return &la.va
+}
+func (la *_List_Bytes__Assembler) Finish() error {
+	switch la.state {
+	case laState_initial:
+		// carry on
+	case laState_midValue:
+		if !la.valueFinishTidy() {
+			panic("invalid state: Finish cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case laState_finished:
+		panic("invalid state: Finish cannot be called on an assembler that's already finished")
+	}
+	la.state = laState_finished
+	*la.m = schema.Maybe_Value
+	return nil
+}
+func (la *_List_Bytes__Assembler) ValuePrototype(_ int64) datamodel.NodePrototype {
+	return _Bytes__Prototype{}
+}
+func (List_Bytes) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (n List_Bytes) Representation() datamodel.Node {
+	return (*_List_Bytes__Repr)(n)
+}
+
+type _List_Bytes__Repr _List_Bytes
+
+var _ datamodel.Node = &_List_Bytes__Repr{}
+
+func (_List_Bytes__Repr) Kind() datamodel.Kind {
+	return datamodel.Kind_List
+}
+func (_List_Bytes__Repr) LookupByString(string) (datamodel.Node, error) {
+	return mixins.List{TypeName: "schema.List_Bytes.Repr"}.LookupByString("")
+}
+func (nr *_List_Bytes__Repr) LookupByNode(k datamodel.Node) (datamodel.Node, error) {
+	v, err := (List_Bytes)(nr).LookupByNode(k)
+	if err != nil || v == datamodel.Null {
+		return v, err
+	}
+	return v.(Bytes).Representation(), nil
+}
+func (nr *_List_Bytes__Repr) LookupByIndex(idx int64) (datamodel.Node, error) {
+	v, err := (List_Bytes)(nr).LookupByIndex(idx)
+	if err != nil || v == datamodel.Null {
+		return v, err
+	}
+	return v.(Bytes).Representation(), nil
+}
+func (n _List_Bytes__Repr) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
+	i, err := seg.Index()
+	if err != nil {
+		return nil, datamodel.ErrInvalidSegmentForList{TypeName: "schema.List_Bytes.Repr", TroubleSegment: seg, Reason: err}
+	}
+	return n.LookupByIndex(i)
+}
+func (_List_Bytes__Repr) MapIterator() datamodel.MapIterator {
+	return nil
+}
+func (nr *_List_Bytes__Repr) ListIterator() datamodel.ListIterator {
+	return &_List_Bytes__ReprListItr{(List_Bytes)(nr), 0}
+}
+
+type _List_Bytes__ReprListItr _List_Bytes__ListItr
+
+func (itr *_List_Bytes__ReprListItr) Next() (idx int64, v datamodel.Node, err error) {
+	idx, v, err = (*_List_Bytes__ListItr)(itr).Next()
+	if err != nil || v == datamodel.Null {
+		return
+	}
+	return idx, v.(Bytes).Representation(), nil
+}
+func (itr *_List_Bytes__ReprListItr) Done() bool {
+	return (*_List_Bytes__ListItr)(itr).Done()
+}
+
+func (rn *_List_Bytes__Repr) Length() int64 {
+	return int64(len(rn.x))
+}
+func (_List_Bytes__Repr) IsAbsent() bool {
+	return false
+}
+func (_List_Bytes__Repr) IsNull() bool {
+	return false
+}
+func (_List_Bytes__Repr) AsBool() (bool, error) {
+	return mixins.List{TypeName: "schema.List_Bytes.Repr"}.AsBool()
+}
+func (_List_Bytes__Repr) AsInt() (int64, error) {
+	return mixins.List{TypeName: "schema.List_Bytes.Repr"}.AsInt()
+}
+func (_List_Bytes__Repr) AsFloat() (float64, error) {
+	return mixins.List{TypeName: "schema.List_Bytes.Repr"}.AsFloat()
+}
+func (_List_Bytes__Repr) AsString() (string, error) {
+	return mixins.List{TypeName: "schema.List_Bytes.Repr"}.AsString()
+}
+func (_List_Bytes__Repr) AsBytes() ([]byte, error) {
+	return mixins.List{TypeName: "schema.List_Bytes.Repr"}.AsBytes()
+}
+func (_List_Bytes__Repr) AsLink() (datamodel.Link, error) {
+	return mixins.List{TypeName: "schema.List_Bytes.Repr"}.AsLink()
+}
+func (_List_Bytes__Repr) Prototype() datamodel.NodePrototype {
+	return _List_Bytes__ReprPrototype{}
+}
+
+type _List_Bytes__ReprPrototype struct{}
+
+func (_List_Bytes__ReprPrototype) NewBuilder() datamodel.NodeBuilder {
+	var nb _List_Bytes__ReprBuilder
+	nb.Reset()
+	return &nb
+}
+
+type _List_Bytes__ReprBuilder struct {
+	_List_Bytes__ReprAssembler
+}
+
+func (nb *_List_Bytes__ReprBuilder) Build() datamodel.Node {
+	if *nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_List_Bytes__ReprBuilder) Reset() {
+	var w _List_Bytes
+	var m schema.Maybe
+	*nb = _List_Bytes__ReprBuilder{_List_Bytes__ReprAssembler{w: &w, m: &m}}
+}
+
+type _List_Bytes__ReprAssembler struct {
+	w     *_List_Bytes
+	m     *schema.Maybe
+	state laState
+
+	cm schema.Maybe
+	va _Bytes__ReprAssembler
+}
+
+func (na *_List_Bytes__ReprAssembler) reset() {
+	na.state = laState_initial
+	na.va.reset()
+}
+func (_List_Bytes__ReprAssembler) BeginMap(sizeHint int64) (datamodel.MapAssembler, error) {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes.Repr"}.BeginMap(0)
+}
+func (na *_List_Bytes__ReprAssembler) BeginList(sizeHint int64) (datamodel.ListAssembler, error) {
+	switch *na.m {
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
+	}
+	*na.m = midvalue
+	if sizeHint < 0 {
+		sizeHint = 0
+	}
+	if sizeHint > 0 {
+		na.w.x = make([]_Bytes, 0, sizeHint)
+	}
+	return na, nil
+}
+func (na *_List_Bytes__ReprAssembler) AssignNull() error {
+	switch *na.m {
+	case allowNull:
+		*na.m = schema.Maybe_Null
+		return nil
+	case schema.Maybe_Absent:
+		return mixins.ListAssembler{TypeName: "schema.List_Bytes.Repr.Repr"}.AssignNull()
+	case schema.Maybe_Value, schema.Maybe_Null:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	case midvalue:
+		panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+	}
+	panic("unreachable")
+}
+func (_List_Bytes__ReprAssembler) AssignBool(bool) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes.Repr"}.AssignBool(false)
+}
+func (_List_Bytes__ReprAssembler) AssignInt(int64) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes.Repr"}.AssignInt(0)
+}
+func (_List_Bytes__ReprAssembler) AssignFloat(float64) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes.Repr"}.AssignFloat(0)
+}
+func (_List_Bytes__ReprAssembler) AssignString(string) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes.Repr"}.AssignString("")
+}
+func (_List_Bytes__ReprAssembler) AssignBytes([]byte) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes.Repr"}.AssignBytes(nil)
+}
+func (_List_Bytes__ReprAssembler) AssignLink(datamodel.Link) error {
+	return mixins.ListAssembler{TypeName: "schema.List_Bytes.Repr"}.AssignLink(nil)
+}
+func (na *_List_Bytes__ReprAssembler) AssignNode(v datamodel.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_List_Bytes); ok {
+		switch *na.m {
+		case schema.Maybe_Value, schema.Maybe_Null:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		case midvalue:
+			panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+		}
+		*na.w = *v2
+		*na.m = schema.Maybe_Value
+		return nil
+	}
+	if v.Kind() != datamodel.Kind_List {
+		return datamodel.ErrWrongKind{TypeName: "schema.List_Bytes.Repr", MethodName: "AssignNode", AppropriateKind: datamodel.KindSet_JustList, ActualKind: v.Kind()}
+	}
+	itr := v.ListIterator()
+	for !itr.Done() {
+		_, v, err := itr.Next()
+		if err != nil {
+			return err
+		}
+		if err := na.AssembleValue().AssignNode(v); err != nil {
+			return err
+		}
+	}
+	return na.Finish()
+}
+func (_List_Bytes__ReprAssembler) Prototype() datamodel.NodePrototype {
+	return _List_Bytes__ReprPrototype{}
+}
+func (la *_List_Bytes__ReprAssembler) valueFinishTidy() bool {
+	switch la.cm {
+	case schema.Maybe_Value:
+		la.va.w = nil
+		la.cm = schema.Maybe_Absent
+		la.state = laState_initial
+		la.va.reset()
+		return true
+	default:
+		return false
+	}
+}
+func (la *_List_Bytes__ReprAssembler) AssembleValue() datamodel.NodeAssembler {
+	switch la.state {
+	case laState_initial:
+		// carry on
+	case laState_midValue:
+		if !la.valueFinishTidy() {
+			panic("invalid state: AssembleValue cannot be called when still in the middle of assembling the previous value")
+		} // if tidy success: carry on
+	case laState_finished:
+		panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
+	}
+	la.w.x = append(la.w.x, _Bytes{})
+	la.state = laState_midValue
+	row := &la.w.x[len(la.w.x)-1]
+	la.va.w = row
+	la.va.m = &la.cm
+	return &la.va
+}
+func (la *_List_Bytes__ReprAssembler) Finish() error {
+	switch la.state {
+	case laState_initial:
+		// carry on
+	case laState_midValue:
+		if !la.valueFinishTidy() {
+			panic("invalid state: Finish cannot be called when in the middle of assembling a value")
+		} // if tidy success: carry on
+	case laState_finished:
+		panic("invalid state: Finish cannot be called on an assembler that's already finished")
+	}
+	la.state = laState_finished
+	*la.m = schema.Maybe_Value
+	return nil
+}
+func (la *_List_Bytes__ReprAssembler) ValuePrototype(_ int64) datamodel.NodePrototype {
+	return _Bytes__ReprPrototype{}
 }
 
 func (n *_List_String) Lookup(idx int64) String {

--- a/api/v0/ingest/schema/ipldsch_types.go
+++ b/api/v0/ingest/schema/ipldsch_types.go
@@ -42,6 +42,8 @@ type typeSlab struct {
 	Link_EntryChunk__Repr    _Link_EntryChunk__ReprPrototype
 	List                     _List__Prototype
 	List__Repr               _List__ReprPrototype
+	List_Bytes               _List_Bytes__Prototype
+	List_Bytes__Repr         _List_Bytes__ReprPrototype
 	List_String              _List_String__Prototype
 	List_String__Repr        _List_String__ReprPrototype
 	Map                      _Map__Prototype
@@ -93,7 +95,7 @@ type _Bytes struct{ x []byte }
 // EntryChunk matches the IPLD Schema type "EntryChunk".  It has Struct type-kind, and may be interrogated like map kind.
 type EntryChunk = *_EntryChunk
 type _EntryChunk struct {
-	Entries _List_String
+	Entries _List_Bytes
 	Next    _Link_EntryChunk__Maybe
 }
 
@@ -121,6 +123,12 @@ type _Link_EntryChunk struct{ x datamodel.Link }
 type List = *_List
 type _List struct {
 	x []_Any__Maybe
+}
+
+// List_Bytes matches the IPLD Schema type "List_Bytes".  It has list kind.
+type List_Bytes = *_List_Bytes
+type _List_Bytes struct {
+	x []_Bytes
 }
 
 // List_String matches the IPLD Schema type "List_String".  It has list kind.

--- a/api/v0/ingest/schema/utils.go
+++ b/api/v0/ingest/schema/utils.go
@@ -38,10 +38,10 @@ const (
 	IsAdKey = LinkContextKey("isAdLink")
 )
 
-func cidsToString(cids []cid.Cid) []_String {
-	out := make([]_String, len(cids))
-	for i := range cids {
-		out[i] = _String{x: cids[i].String()}
+func mhsToBytes(mhs []mh.Multihash) []_Bytes {
+	out := make([]_Bytes, len(mhs))
+	for i := range mhs {
+		out[i] = _Bytes{x: mhs[i]}
 	}
 	return out
 }
@@ -63,23 +63,23 @@ func (l Advertisement) LinkContext(ctx context.Context) ipld.LinkContext {
 	}
 }
 
-// NewListOfCids is a convenient method to create a new list of strings
-// from a list of Cids that may be consumed by a linksystem.
-func NewListOfCids(lsys ipld.LinkSystem, cids []cid.Cid) (ipld.Link, error) {
-	cStr := &_List_String{x: cidsToString(cids)}
+// NewListOfMhs is a convenient method to create a new list of bytes
+// from a list of multihashes that may be consumed by a linksystem.
+func NewListOfMhs(lsys ipld.LinkSystem, mhs []mh.Multihash) (ipld.Link, error) {
+	cStr := &_List_Bytes{x: mhsToBytes(mhs)}
 	return lsys.Store(ipld.LinkContext{}, Linkproto, cStr)
 }
 
-// NewListStringFromCids converts the cid to a list of strings
-func NewListStringFromCids(cids []cid.Cid) List_String {
-	return &_List_String{x: cidsToString(cids)}
+// NewListBytesFromMhs converts multihashes to a list of bytes
+func NewListBytesFromMhs(mhs []mh.Multihash) List_Bytes {
+	return &_List_Bytes{x: mhsToBytes(mhs)}
 }
 
-// NewLinkedListOfCids creates a new element of a linked list that
+// NewLinkedListOfMhs creates a new element of a linked list that
 // can be used to paginate large lists.
-func NewLinkedListOfCids(lsys ipld.LinkSystem, cids []cid.Cid, next ipld.Link) (ipld.Link, EntryChunk, error) {
+func NewLinkedListOfMhs(lsys ipld.LinkSystem, mhs []mh.Multihash, next ipld.Link) (ipld.Link, EntryChunk, error) {
 	cStr := &_EntryChunk{
-		Entries: _List_String{x: cidsToString(cids)},
+		Entries: _List_Bytes{x: mhsToBytes(mhs)},
 	}
 	// If no next in the list.
 	if next == nil {

--- a/api/v0/ingest/schema/utils_test.go
+++ b/api/v0/ingest/schema/utils_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/storetheindex/internal/utils"
-	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	ipld "github.com/ipld/go-ipld-prime"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/test"
+	mh "github.com/multiformats/go-multihash"
 
 	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -40,12 +40,12 @@ func mkLinkSystem(ds datastore.Batching) ipld.LinkSystem {
 
 func genCidsAndAdv(t *testing.T, lsys ipld.LinkSystem,
 	priv crypto.PrivKey,
-	previous Link_Advertisement) ([]cid.Cid, ipld.Link, Advertisement, Link_Advertisement) {
+	previous Link_Advertisement) ([]mh.Multihash, ipld.Link, Advertisement, Link_Advertisement) {
 
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
-	cids, _ := utils.RandomCids(10)
-	val := indexer.MakeValue(p, 0, cids[0].Bytes())
-	cidsLnk, err := NewListOfCids(lsys, cids)
+	mhs, _ := utils.RandomMultihashes(10)
+	val := indexer.MakeValue(p, 0, mhs[0])
+	cidsLnk, err := NewListOfMhs(lsys, mhs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func genCidsAndAdv(t *testing.T, lsys ipld.LinkSystem,
 	if err != nil {
 		t.Fatal(err)
 	}
-	return cids, cidsLnk, adv, advLnk
+	return mhs, cidsLnk, adv, advLnk
 }
 
 func TestChainAdvertisements(t *testing.T) {
@@ -84,8 +84,8 @@ func TestChainAdvertisements(t *testing.T) {
 func TestLinkedList(t *testing.T) {
 	dstore := datastore.NewMapDatastore()
 	lsys := mkLinkSystem(dstore)
-	cids, _ := utils.RandomCids(10)
-	lnk1, ch1, err := NewLinkedListOfCids(lsys, cids, nil)
+	mhs, _ := utils.RandomMultihashes(10)
+	lnk1, ch1, err := NewLinkedListOfMhs(lsys, mhs, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestLinkedList(t *testing.T) {
 	if ch1.FieldNext().v.x != nil {
 		t.Fatal("no link should have been assigned")
 	}
-	lnk2, ch2, err := NewLinkedListOfCids(lsys, cids, lnk1)
+	lnk2, ch2, err := NewLinkedListOfMhs(lsys, mhs, lnk1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestLinkedList(t *testing.T) {
 		t.Fatal("elnk1 should equal ch2 fieldNext")
 	}
 	elnk2 := &_Link_EntryChunk{x: lnk2}
-	_, ch3, err := NewLinkedListOfCids(lsys, cids, lnk2)
+	_, ch3, err := NewLinkedListOfMhs(lsys, mhs, lnk2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -210,9 +210,9 @@ func (i *legIngester) processEntries(adCid cid.Cid, p peer.ID, nentries ipld.Nod
 	cit := entries.ListIterator()
 	for !cit.Done() {
 		_, cnode, _ := cit.Next()
-		cs, _ := cnode.AsString()
-		c, err := cid.Decode(cs)
+		h, err := cnode.AsBytes()
 		if err != nil {
+			log.Errorf("Error decoding an entry from the ingestion list: %v", err)
 			return err
 		}
 		val := indexer.MakeValue(p, 0, metadata)
@@ -221,18 +221,18 @@ func (i *legIngester) processEntries(adCid cid.Cid, p peer.ID, nentries ipld.Nod
 			// because we may not receive the list of CIDs to remove and we'll
 			// have to use a routine that looks for the CIDs for a specific
 			// key.
-			if _, err := i.indexer.Remove(c.Hash(), val); err != nil {
+			if _, err := i.indexer.Remove(h, val); err != nil {
 				log.Errorf("Error removing entry from indexer: %v", err)
 				return err
 			}
 
 		} else {
-			if _, err := i.indexer.Put(c.Hash(), val); err != nil {
+			if _, err := i.indexer.Put(h, val); err != nil {
 				log.Errorf("Error putting entry in indexer: %v", err)
 				return err
 			}
 		}
-		log.Debugf("Success processing entry", "multihash", c.Hash().B58String())
+		log.Debugf("Success processing entry", "multihash", h)
 	}
 
 	// If there is a next link, update the mapping so we know the AdID


### PR DESCRIPTION
This PR:
- Updates the schema to use a linked list of bytes for ingestion.
- Adds utils to generate advertisements from a list of multihashes
- Integrates the new schema into the ingestion protocol.