### PR TITLE
Provide a way to trust all providers by default

### DIFF
--- a/command/register.go
+++ b/command/register.go
@@ -25,7 +25,7 @@ func registerCommand(cctx *cli.Context) error {
 		return fmt.Errorf("cannot load config file: %w", err)
 	}
 
-	client, err := v0client.NewIngest(cctx.String("indexer-host"))
+	client, err := v0client.NewIngest(cctx.String("indexer"))
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -91,7 +90,7 @@ func Load(filePath string) (*Config, error) {
 
 	var cfg Config
 	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("failure to decode config: %s", err)
+		return nil, err
 	}
 	return &cfg, err
 }

--- a/config/init.go
+++ b/config/init.go
@@ -37,8 +37,8 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		Discovery: Discovery{
 			LotusGateway: defaultLotusGateway,
 			Policy: Policy{
-				Action: defaultAction,
-				Trust:  []string{identity.PeerID},
+				Allow: defaultAllow,
+				Trust: defaultTrust,
 			},
 			PollInterval:   defaultPollInterval,
 			RediscoverWait: defaultRediscoverWait,

--- a/config/policy.go
+++ b/config/policy.go
@@ -1,16 +1,27 @@
 package config
 
-const defaultAction = "block"
+const (
+	defaultAllow = true
+	defaultTrust = true
+)
 
-// Policy configures which providers are allowed and blocked
+// Policy configures which providers are allowed and blocked, and which allowed
+// providers require verification or are trusted
 type Policy struct {
-	// Action is either "block" or "allow"
-	Action string
-	// Except is a list of peer IDs that are excluded from the policy action.
-	// Providers that are allowed by policy or expetion must still be valid
-	// providers.
+	// Allow is either false or true, and determines whether a provider is
+	// allowed (true) or is blocked (false), by default.
+	Allow bool
+	// Except is a list of peer IDs that are exceptions to the allow action.
+	// Providers that are allowed by policy or exception must still be verified
+	// or trusted in order to register.
 	Except []string
-	// Trust is a list of peer IDs that are allowed to register as providers
-	// without being required to be vefified on-chain
-	Trust []string
+
+	// Trust is either false or true, and determines whether a provider can
+	// skip (true) on-chain verification or not (false), by default
+	Trust bool
+	// TrustExcept is a list of peer IDs that are exceptions to the trust
+	// action.  If Trust is false then all allowed providers must be
+	// verified, except those listed here.  If Trust is true, then only the
+	// providers listed here require verification.
+	TrustExcept []string
 }

--- a/internal/providers/policy/policy.go
+++ b/internal/providers/policy/policy.go
@@ -3,64 +3,66 @@ package policy
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/filecoin-project/storetheindex/config"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 type Policy struct {
-	defaultAllow bool
-	except       map[peer.ID]struct{}
-	trust        map[peer.ID]struct{}
+	allow       bool
+	except      map[peer.ID]struct{}
+	trust       bool
+	trustExcept map[peer.ID]struct{}
 }
 
 func New(cfg config.Policy) (*Policy, error) {
-	policy := new(Policy)
-
-	switch strings.ToLower(cfg.Action) {
-	case "block":
-	case "allow":
-		policy.defaultAllow = true
-	default:
-		return nil, errors.New("default policy must be \"block\" or \"allow\"")
+	policy := &Policy{
+		allow: cfg.Allow,
+		trust: cfg.Trust,
 	}
 
-	if len(cfg.Except) != 0 {
-		exceptIDs := make(map[peer.ID]struct{}, len(cfg.Except))
-		for _, except := range cfg.Except {
-			excPeerID, err := peer.Decode(except)
-			if err != nil {
-				return nil, fmt.Errorf("error decoding except policy peer id %q: %s", except, err)
-			}
-			exceptIDs[excPeerID] = struct{}{}
-		}
-		policy.except = exceptIDs
+	var err error
+	policy.except, err = getExceptPeerIDs(cfg.Except)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read except list: %s", err)
 	}
 
-	if len(cfg.Trust) != 0 {
-		trustIDs := make(map[peer.ID]struct{}, len(cfg.Trust))
-		for _, trust := range cfg.Trust {
-			trustPeerID, err := peer.Decode(trust)
-			if err != nil {
-				return nil, fmt.Errorf("error decoding trust policy peer id %q: %s", trust, err)
-			}
-			trustIDs[trustPeerID] = struct{}{}
-		}
-		policy.trust = trustIDs
-	}
-
-	if !policy.defaultAllow && len(policy.except) == 0 && len(policy.trust) == 0 {
+	// Error if no peers are allowed
+	if !policy.allow && len(policy.except) == 0 {
 		return nil, errors.New("policy does not allow any providers")
+	}
+
+	policy.trustExcept, err = getExceptPeerIDs(cfg.TrustExcept)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read trust except list: %s", err)
 	}
 
 	return policy, nil
 }
 
+func getExceptPeerIDs(excepts []string) (map[peer.ID]struct{}, error) {
+	if len(excepts) == 0 {
+		return nil, nil
+	}
+
+	exceptIDs := make(map[peer.ID]struct{}, len(excepts))
+	for _, except := range excepts {
+		excPeerID, err := peer.Decode(except)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding peer id %q: %s", except, err)
+		}
+		exceptIDs[excPeerID] = struct{}{}
+	}
+	return exceptIDs, nil
+}
+
 // Trusted returns true if the provider is explicitly trusted.  A trusted
-// provider is allowed without requiring verification.
+// provider is allowed to register without requiring verification.
 func (p *Policy) Trusted(providerID peer.ID) bool {
-	_, ok := p.trust[providerID]
+	_, ok := p.trustExcept[providerID]
+	if p.trust {
+		return !ok
+	}
 	return ok
 }
 
@@ -69,7 +71,7 @@ func (p *Policy) Trusted(providerID peer.ID) bool {
 // provider must still be verified.
 func (p *Policy) Allowed(providerID peer.ID) bool {
 	_, ok := p.except[providerID]
-	if p.defaultAllow {
+	if p.allow {
 		return !ok
 	}
 	return ok

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -29,9 +29,10 @@ const (
 
 var discoveryCfg = config.Discovery{
 	Policy: config.Policy{
-		Action: "block",
-		Except: []string{exceptID},
-		Trust:  []string{trustedID, trustedID2},
+		Allow:       false,
+		Except:      []string{exceptID, trustedID, trustedID2},
+		Trust:       false,
+		TrustExcept: []string{trustedID, trustedID2},
 	},
 	PollInterval:   config.Duration(time.Minute),
 	RediscoverWait: config.Duration(time.Minute),
@@ -162,9 +163,9 @@ func TestDiscoveryBlocked(t *testing.T) {
 		t.Fatal("bad provider ID:", err)
 	}
 
-	discoveryCfg.Policy.Action = "allow"
+	discoveryCfg.Policy.Allow = true
 	defer func() {
-		discoveryCfg.Policy.Action = "block"
+		discoveryCfg.Policy.Allow = false
 	}()
 
 	r, err := NewRegistry(discoveryCfg, nil, mockDisco)

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -53,8 +53,10 @@ func InitIndex(t *testing.T, withCache bool) indexer.Interface {
 func InitRegistry(t *testing.T) *providers.Registry {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Action: "block",
-			Trust:  []string{providerID},
+			Allow:       false,
+			Except:      []string{providerID},
+			Trust:       false,
+			TrustExcept: []string{providerID},
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -56,8 +56,10 @@ func (m *mockIndexer) Size() (int64, error)                                     
 func init() {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Action: "block",
-			Trust:  []string{ident.PeerID},
+			Allow:       false,
+			Except:      []string{ident.PeerID},
+			Trust:       false,
+			TrustExcept: []string{ident.PeerID},
 		},
 	}
 

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -47,8 +47,10 @@ func InitIndex(t *testing.T, withCache bool) indexer.Interface {
 func InitRegistry(t *testing.T, trustedID string) *providers.Registry {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Action: "block",
-			Trust:  []string{trustedID},
+			Allow:       false,
+			Except:      []string{trustedID},
+			Trust:       false,
+			TrustExcept: []string{trustedID},
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),


### PR DESCRIPTION
Trusting a provider means that if the provider is allowed, then on-chain varification of the trusted provider's ID is not required.

Policy can now specify both "allow" by default and "trust" by default.  These can be inverted to make it necessary to explicitly specify allowed and trusted providers.  The default config, generated by init, sets policy to allow all and trust all.

Fixes issue #73