### PR TITLE
Use api model data types only in client api

### DIFF
--- a/api/v0/ingest/client/http/ingest.go
+++ b/api/v0/ingest/client/http/ingest.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/models"
-	"github.com/filecoin-project/storetheindex/config"
 	httpclient "github.com/filecoin-project/storetheindex/internal/httpclient"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multihash"
@@ -103,8 +102,8 @@ func (cl *IngestClient) GetProvider(ctx context.Context, providerID peer.ID) (*m
 	return &providerInfo, nil
 }
 
-func (cl *IngestClient) IndexContent(ctx context.Context, providerIdent config.Identity, m multihash.Multihash, protocol uint64, metadata []byte) error {
-	data, err := models.MakeIngestRequest(providerIdent, m, protocol, metadata)
+func (cl *IngestClient) IndexContent(ctx context.Context, providerID, privateKey string, m multihash.Multihash, protocol uint64, metadata []byte) error {
+	data, err := models.MakeIngestRequest(providerID, privateKey, m, protocol, metadata)
 	if err != nil {
 		return err
 	}
@@ -132,8 +131,8 @@ func (cl *IngestClient) IndexContent(ctx context.Context, providerIdent config.I
 	return nil
 }
 
-func (cl *IngestClient) Register(ctx context.Context, providerIdent config.Identity, addrs []string) error {
-	data, err := models.MakeRegisterRequest(providerIdent, addrs)
+func (cl *IngestClient) Register(ctx context.Context, providerID, privateKey string, addrs []string) error {
+	data, err := models.MakeRegisterRequest(providerID, privateKey, addrs)
 	if err != nil {
 		return err
 	}

--- a/api/v0/ingest/client/interface.go
+++ b/api/v0/ingest/client/interface.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/models"
-	"github.com/filecoin-project/storetheindex/config"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multihash"
 )
@@ -13,6 +12,6 @@ import (
 type Ingest interface {
 	GetProvider(ctx context.Context, providerID peer.ID) (*models.ProviderInfo, error)
 	ListProviders(ctx context.Context) ([]*models.ProviderInfo, error)
-	Register(ctx context.Context, providerIdent config.Identity, addrs []string) error
-	IndexContent(ctx context.Context, providerIdent config.Identity, m multihash.Multihash, protocol uint64, metadata []byte) error
+	Register(ctx context.Context, providerID, privateKey string, addrs []string) error
+	IndexContent(ctx context.Context, providerID, privateKey string, m multihash.Multihash, protocol uint64, metadata []byte) error
 }

--- a/api/v0/ingest/client/libp2p/client.go
+++ b/api/v0/ingest/client/libp2p/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/filecoin-project/storetheindex/api/v0"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/models"
 	pb "github.com/filecoin-project/storetheindex/api/v0/ingest/pb"
-	"github.com/filecoin-project/storetheindex/config"
 	"github.com/filecoin-project/storetheindex/internal/libp2pclient"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -73,8 +72,8 @@ func (cl *Ingest) GetProvider(ctx context.Context, providerID peer.ID) (*models.
 	return &providerInfo, nil
 }
 
-func (cl *Ingest) Register(ctx context.Context, providerIdent config.Identity, addrs []string) error {
-	data, err := models.MakeRegisterRequest(providerIdent, addrs)
+func (cl *Ingest) Register(ctx context.Context, providerID, privateKey string, addrs []string) error {
+	data, err := models.MakeRegisterRequest(providerID, privateKey, addrs)
 	if err != nil {
 		return err
 	}
@@ -92,8 +91,8 @@ func (cl *Ingest) Register(ctx context.Context, providerIdent config.Identity, a
 	return nil
 }
 
-func (cl *Ingest) IndexContent(ctx context.Context, providerIdent config.Identity, m multihash.Multihash, protocol uint64, metadata []byte) error {
-	data, err := models.MakeIngestRequest(providerIdent, m, protocol, metadata)
+func (cl *Ingest) IndexContent(ctx context.Context, providerID, privateKey string, m multihash.Multihash, protocol uint64, metadata []byte) error {
+	data, err := models.MakeIngestRequest(providerID, privateKey, m, protocol, metadata)
 	if err != nil {
 		return err
 	}

--- a/api/v0/ingest/models/ingest_request.go
+++ b/api/v0/ingest/models/ingest_request.go
@@ -55,13 +55,17 @@ func (r *IngestRequest) MarshalRecord() ([]byte, error) {
 }
 
 // MakeIngestRequest creates a signed IngestRequest and marshals it into bytes
-func MakeIngestRequest(providerIdent config.Identity, m multihash.Multihash, protocol uint64, metadata []byte) ([]byte, error) {
-	providerID, privKey, err := providerIdent.Decode()
+func MakeIngestRequest(providerID, privateKey string, m multihash.Multihash, protocol uint64, metadata []byte) ([]byte, error) {
+	providerIdent := config.Identity{
+		PeerID:  providerID,
+		PrivKey: privateKey,
+	}
+	peerID, privKey, err := providerIdent.Decode()
 	if err != nil {
 		return nil, err
 	}
 
-	value := indexer.MakeValue(providerID, protocol, metadata)
+	value := indexer.MakeValue(peerID, protocol, metadata)
 
 	req := &IngestRequest{
 		Multihash: m,

--- a/api/v0/ingest/models/ingest_request_test.go
+++ b/api/v0/ingest/models/ingest_request_test.go
@@ -17,7 +17,7 @@ func TestIngestRequest(t *testing.T) {
 
 	metadata := []byte("hello")
 
-	data, err := MakeIngestRequest(providerIdent, mhs[0], 0, metadata)
+	data, err := MakeIngestRequest(providerIdent.PeerID, providerIdent.PrivKey, mhs[0], 0, metadata)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/v0/ingest/models/register_request.go
+++ b/api/v0/ingest/models/register_request.go
@@ -11,8 +11,12 @@ import (
 
 // MakeRegisterRequest creates a signed peer.PeerRecord as a register request
 // and marshals this into bytes
-func MakeRegisterRequest(providerIdent config.Identity, addrs []string) ([]byte, error) {
-	providerID, privKey, err := providerIdent.Decode()
+func MakeRegisterRequest(providerID, privateKey string, addrs []string) ([]byte, error) {
+	providerIdent := config.Identity{
+		PeerID:  providerID,
+		PrivKey: privateKey,
+	}
+	peerID, privKey, err := providerIdent.Decode()
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +30,7 @@ func MakeRegisterRequest(providerIdent config.Identity, addrs []string) ([]byte,
 	}
 
 	rec := peer.NewPeerRecord()
-	rec.PeerID = providerID
+	rec.PeerID = peerID
 	rec.Addrs = maddrs
 
 	return makeRequestEnvelop(rec, privKey)

--- a/api/v0/ingest/models/register_request_test.go
+++ b/api/v0/ingest/models/register_request_test.go
@@ -14,7 +14,7 @@ var providerIdent = config.Identity{
 func TestRegisterRequest(t *testing.T) {
 	addrs := []string{"/ip4/127.0.0.1/tcp/9999"}
 
-	data, err := MakeRegisterRequest(providerIdent, addrs)
+	data, err := MakeRegisterRequest(providerIdent.PeerID, providerIdent.PrivKey, addrs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +26,7 @@ func TestRegisterRequest(t *testing.T) {
 
 	seq0 := peerRec.Seq
 
-	data, err = MakeRegisterRequest(providerIdent, addrs)
+	data, err = MakeRegisterRequest(providerIdent.PeerID, providerIdent.PrivKey, addrs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/register.go
+++ b/command/register.go
@@ -29,11 +29,11 @@ func registerCommand(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = client.Register(cctx.Context, cfg.Identity, cctx.StringSlice("provider-addr"))
+	err = client.Register(cctx.Context, cfg.Identity.PeerID, cfg.Identity.PrivKey, cctx.StringSlice("addr"))
 	if err != nil {
 		return fmt.Errorf("failed to register providers: %s", err)
 	}
 
-	fmt.Println("Registered provider", cfg.Identity.PeerID, "at indexer", cctx.String("indexer-host"))
+	fmt.Println("Registered provider", cfg.Identity.PeerID, "at indexer", cctx.String("indexer"))
 	return nil
 }

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -81,7 +81,7 @@ func init() {
 }
 
 func TestRegisterProvider(t *testing.T) {
-	data, err := models.MakeRegisterRequest(ident, nil)
+	data, err := models.MakeRegisterRequest(ident.PeerID, ident.PrivKey, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestIndexContent(t *testing.T) {
 	}
 	metadata := []byte("hello world")
 
-	data, err := models.MakeIngestRequest(ident, m, 0, metadata)
+	data, err := models.MakeIngestRequest(ident.PeerID, ident.PrivKey, m, 0, metadata)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -88,7 +88,7 @@ func RegisterProviderTest(t *testing.T, c client.Ingest, providerIdent config.Id
 	defer cancel()
 
 	t.Log("registering provider")
-	err := c.Register(ctx, providerIdent, addrs)
+	err := c.Register(ctx, providerIdent.PeerID, providerIdent.PrivKey, addrs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,14 +106,14 @@ func RegisterProviderTest(t *testing.T, c client.Ingest, providerIdent config.Id
 	t.Log("registering provider with bad signature")
 	badIdent := providerIdent
 	badIdent.PeerID = "12D3KooWBckWLKiYoUX4k3HTrbrSe4DD5SPNTKgP6vKTva1NaXXX"
-	err = c.Register(ctx, badIdent, addrs)
+	err = c.Register(ctx, badIdent.PeerID, badIdent.PrivKey, addrs)
 	if err == nil {
 		t.Fatal("expected bad signature error")
 	}
 
 	// Test error if context canceled
 	cancel()
-	err = c.Register(ctx, providerIdent, addrs)
+	err = c.Register(ctx, providerIdent.PeerID, providerIdent.PrivKey, addrs)
 	if err == nil {
 		t.Fatal("expected send to failed due to canceled context")
 	}
@@ -163,7 +163,7 @@ func IndexContent(t *testing.T, cl client.Ingest, providerIdent config.Identity,
 
 	metadata := []byte("hello")
 
-	err = cl.IndexContent(ctx, providerIdent, mhs[0], 0, metadata)
+	err = cl.IndexContent(ctx, providerIdent.PeerID, providerIdent.PrivKey, mhs[0], 0, metadata)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Fix Register to use intrinsic and model data types only
- Fix IndexContent to use intrinsic and model data types only