### PR TITLE
register the views

### DIFF
--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -53,13 +53,14 @@ var log = logging.Logger("metrics")
 
 // Start creates an HTTP router for serving metric info
 func Start() http.Handler {
+	view.Register(DefaultViews...)
 	registry, ok := promclient.DefaultRegisterer.(*promclient.Registry)
 	if !ok {
 		log.Warnf("failed to export default prometheus registry; some metrics will be unavailable; unexpected type: %T", promclient.DefaultRegisterer)
 	}
 	exporter, err := prometheus.NewExporter(prometheus.Options{
 		Registry:  registry,
-		Namespace: "lotus",
+		Namespace: "storetheindex",
 	})
 	if err != nil {
 		log.Errorf("could not create the prometheus stats exporter: %v", err)


### PR DESCRIPTION
This is what is running to create this 

https://protocollabs.grafana.net/d/pPROWOD7z/providers?orgId=1


The metrics don't appear until they are first used, but as soon as you index something you see them. 

```
▶ indexer-reference-provider index -i localhost  -a /ip4/3.143.149.162/tcp/3103 -cid QmPNHBy5h7f19yJDt7ip9TvmMRbqmYsa6aetkrsc1ghjLB -meta "demo-data"
OK Indexed content
▶ curl -s localhost:3002/metrics | grep store
# HELP storetheindex_provider_count Number of know (registered) providers
# TYPE storetheindex_provider_count counter
storetheindex_provider_count 1

```