### PR TITLE
Supply ContextID to indexer as part of Value

### DIFF
--- a/api/v0/admin/client/http/client.go
+++ b/api/v0/admin/client/http/client.go
@@ -1,0 +1,115 @@
+package adminhttpclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/filecoin-project/storetheindex/internal/httpclient"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+var log = logging.Logger("adminhttpclient")
+
+const (
+	adminPort = 3002
+)
+
+// Client is an http client for the indexer finder API,
+type Client struct {
+	c       *http.Client
+	baseURL string
+}
+
+// New creates a new admin HTTP client.
+func New(baseURL string, options ...httpclient.Option) (*Client, error) {
+	u, c, err := httpclient.New(baseURL, "", adminPort, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		c:       c,
+		baseURL: u.String(),
+	}, nil
+}
+
+// ImportFromManifest processes entries from manifest and imports them into the
+// indexer.
+func (c *Client) ImportFromManifest(ctx context.Context, dir string, provID peer.ID, contextID string) error {
+	u := c.baseURL + path.Join("/import", "manifest", provID.String(), base64.RawURLEncoding.EncodeToString([]byte(contextID)))
+	req, err := c.newUploadRequest(dir, u)
+	if err != nil {
+		return err
+	}
+	resp, err := c.c.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// Handle failed requests
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("importing from manifest failed: %v", http.StatusText(resp.StatusCode))
+	}
+	log.Infow("Success")
+	return nil
+}
+
+// ImportFromCidList process entries from a cidlist and imprts it into the
+// indexer.
+func (c *Client) ImportFromCidList(ctx context.Context, dir string, provID peer.ID, contextID string) error {
+	u := c.baseURL + path.Join("/import", "cidlist", provID.String(), base64.RawURLEncoding.EncodeToString([]byte(contextID)))
+	req, err := c.newUploadRequest(dir, u)
+	if err != nil {
+		return err
+	}
+	resp, err := c.c.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// Handle failed requests
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("importing from cidlist failed: %v", http.StatusText(resp.StatusCode))
+	}
+	log.Infow("Success")
+	return nil
+}
+
+func (c *Client) newUploadRequest(dir string, uri string) (*http.Request, error) {
+	file, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filepath.Base(dir))
+	if err != nil {
+		return nil, err
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return nil, err
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", uri, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req, nil
+}

--- a/api/v0/finder/model/model_test.go
+++ b/api/v0/finder/model/model_test.go
@@ -18,7 +18,8 @@ func TestMarshal(t *testing.T) {
 		t.Fatal(err)
 	}
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
-	v := indexer.MakeValue(p, 0, []byte(mhs[0]))
+	ctxID := []byte("test-context-id")
+	v := indexer.MakeValue(p, ctxID, 0, []byte(mhs[0]))
 
 	// Masrhal request and check e2e
 	t.Log("e2e marshalling request")

--- a/api/v0/ingest/client/http/ingest.go
+++ b/api/v0/ingest/client/http/ingest.go
@@ -103,8 +103,8 @@ func (c *Client) GetProvider(ctx context.Context, providerID peer.ID) (*model.Pr
 	return &providerInfo, nil
 }
 
-func (c *Client) IndexContent(ctx context.Context, providerID peer.ID, privateKey p2pcrypto.PrivKey, m multihash.Multihash, protocol uint64, metadata []byte, addrs []string) error {
-	data, err := model.MakeIngestRequest(providerID, privateKey, m, protocol, metadata, addrs)
+func (c *Client) IndexContent(ctx context.Context, providerID peer.ID, privateKey p2pcrypto.PrivKey, m multihash.Multihash, contextID []byte, protocol uint64, metadata []byte, addrs []string) error {
+	data, err := model.MakeIngestRequest(providerID, privateKey, m, contextID, protocol, metadata, addrs)
 	if err != nil {
 		return err
 	}

--- a/api/v0/ingest/client/interface.go
+++ b/api/v0/ingest/client/interface.go
@@ -14,5 +14,5 @@ type Ingest interface {
 	GetProvider(ctx context.Context, providerID peer.ID) (*model.ProviderInfo, error)
 	ListProviders(ctx context.Context) ([]*model.ProviderInfo, error)
 	Register(ctx context.Context, providerID peer.ID, privateKey crypto.PrivKey, addrs []string) error
-	IndexContent(ctx context.Context, providerID peer.ID, privateKey crypto.PrivKey, m multihash.Multihash, protocol uint64, metadata []byte, addrs []string) error
+	IndexContent(ctx context.Context, providerID peer.ID, privateKey crypto.PrivKey, m multihash.Multihash, contextID []byte, protocol uint64, metadata []byte, addrs []string) error
 }

--- a/api/v0/ingest/client/libp2p/client.go
+++ b/api/v0/ingest/client/libp2p/client.go
@@ -104,8 +104,8 @@ func (c *Client) Register(ctx context.Context, providerID peer.ID, privateKey p2
 	return nil
 }
 
-func (c *Client) IndexContent(ctx context.Context, providerID peer.ID, privateKey p2pcrypto.PrivKey, m multihash.Multihash, protocol uint64, metadata []byte, addrs []string) error {
-	data, err := model.MakeIngestRequest(providerID, privateKey, m, protocol, metadata, addrs)
+func (c *Client) IndexContent(ctx context.Context, providerID peer.ID, privateKey p2pcrypto.PrivKey, m multihash.Multihash, contextID []byte, protocol uint64, metadata []byte, addrs []string) error {
+	data, err := model.MakeIngestRequest(providerID, privateKey, m, contextID, protocol, metadata, addrs)
 	if err != nil {
 		return err
 	}

--- a/api/v0/ingest/model/ingest_request.go
+++ b/api/v0/ingest/model/ingest_request.go
@@ -56,10 +56,10 @@ func (r *IngestRequest) MarshalRecord() ([]byte, error) {
 }
 
 // MakeIngestRequest creates a signed IngestRequest and marshals it into bytes
-func MakeIngestRequest(providerID peer.ID, privateKey crypto.PrivKey, m multihash.Multihash, protocol uint64, metadata []byte, addrs []string) ([]byte, error) {
+func MakeIngestRequest(providerID peer.ID, privateKey crypto.PrivKey, m multihash.Multihash, contextID []byte, protocol uint64, metadata []byte, addrs []string) ([]byte, error) {
 	req := &IngestRequest{
 		Multihash: m,
-		Value:     indexer.MakeValue(providerID, protocol, metadata),
+		Value:     indexer.MakeValue(providerID, contextID, protocol, metadata),
 		Addrs:     addrs,
 		Seq:       peer.TimestampSeq(),
 	}

--- a/api/v0/ingest/model/ingest_request_test.go
+++ b/api/v0/ingest/model/ingest_request_test.go
@@ -21,8 +21,9 @@ func TestIngestRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ctxID := []byte("test-context-id")
 	address := "/ip4/127.0.0.1/tcp/7777"
-	data, err := MakeIngestRequest(peerID, privKey, mhs[0], 0, metadata, []string{address})
+	data, err := MakeIngestRequest(peerID, privKey, mhs[0], ctxID, 0, metadata, []string{address})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +33,7 @@ func TestIngestRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	value := indexer.MakeValue(peerID, 0, metadata)
+	value := indexer.MakeValue(peerID, ctxID, 0, metadata)
 
 	if !ingReq.Value.Equal(value) {
 		t.Fatal("value in request not same as original")

--- a/api/v0/ingest/schema/gen.go
+++ b/api/v0/ingest/schema/gen.go
@@ -84,6 +84,8 @@ func main() {
 		schema.SpawnStructField("Signature", "Bytes", false, false),
 		// Entries with a link to the list of CIDs
 		schema.SpawnStructField("Entries", "Link", false, false),
+		// Context ID for entries.
+		schema.SpawnStructField("ContextID", "Bytes", false, false),
 		// Metadata for entries.
 		schema.SpawnStructField("Metadata", "Bytes", false, false),
 		// IsRm or Put?

--- a/api/v0/ingest/schema/ipldsch_satisfaction.go
+++ b/api/v0/ingest/schema/ipldsch_satisfaction.go
@@ -23,6 +23,9 @@ func (n _Advertisement) FieldSignature() Bytes {
 func (n _Advertisement) FieldEntries() Link {
 	return &n.Entries
 }
+func (n _Advertisement) FieldContextID() Bytes {
+	return &n.ContextID
+}
 func (n _Advertisement) FieldMetadata() Bytes {
 	return &n.Metadata
 }
@@ -70,6 +73,7 @@ var (
 	fieldName__Advertisement_Addresses  = _String{"Addresses"}
 	fieldName__Advertisement_Signature  = _String{"Signature"}
 	fieldName__Advertisement_Entries    = _String{"Entries"}
+	fieldName__Advertisement_ContextID  = _String{"ContextID"}
 	fieldName__Advertisement_Metadata   = _String{"Metadata"}
 	fieldName__Advertisement_IsRm       = _String{"IsRm"}
 )
@@ -94,6 +98,8 @@ func (n Advertisement) LookupByString(key string) (datamodel.Node, error) {
 		return &n.Signature, nil
 	case "Entries":
 		return &n.Entries, nil
+	case "ContextID":
+		return &n.ContextID, nil
 	case "Metadata":
 		return &n.Metadata, nil
 	case "IsRm":
@@ -125,7 +131,7 @@ type _Advertisement__MapItr struct {
 }
 
 func (itr *_Advertisement__MapItr) Next() (k datamodel.Node, v datamodel.Node, _ error) {
-	if itr.idx >= 7 {
+	if itr.idx >= 8 {
 		return nil, nil, datamodel.ErrIteratorOverread{}
 	}
 	switch itr.idx {
@@ -149,9 +155,12 @@ func (itr *_Advertisement__MapItr) Next() (k datamodel.Node, v datamodel.Node, _
 		k = &fieldName__Advertisement_Entries
 		v = &itr.n.Entries
 	case 5:
+		k = &fieldName__Advertisement_ContextID
+		v = &itr.n.ContextID
+	case 6:
 		k = &fieldName__Advertisement_Metadata
 		v = &itr.n.Metadata
-	case 6:
+	case 7:
 		k = &fieldName__Advertisement_IsRm
 		v = &itr.n.IsRm
 	default:
@@ -161,14 +170,14 @@ func (itr *_Advertisement__MapItr) Next() (k datamodel.Node, v datamodel.Node, _
 	return
 }
 func (itr *_Advertisement__MapItr) Done() bool {
-	return itr.idx >= 7
+	return itr.idx >= 8
 }
 
 func (Advertisement) ListIterator() datamodel.ListIterator {
 	return nil
 }
 func (Advertisement) Length() int64 {
-	return 7
+	return 8
 }
 func (Advertisement) IsAbsent() bool {
 	return false
@@ -235,6 +244,7 @@ type _Advertisement__Assembler struct {
 	ca_Addresses  _List_String__Assembler
 	ca_Signature  _Bytes__Assembler
 	ca_Entries    _Link__Assembler
+	ca_ContextID  _Bytes__Assembler
 	ca_Metadata   _Bytes__Assembler
 	ca_IsRm       _Bool__Assembler
 }
@@ -247,6 +257,7 @@ func (na *_Advertisement__Assembler) reset() {
 	na.ca_Addresses.reset()
 	na.ca_Signature.reset()
 	na.ca_Entries.reset()
+	na.ca_ContextID.reset()
 	na.ca_Metadata.reset()
 	na.ca_IsRm.reset()
 }
@@ -257,9 +268,10 @@ var (
 	fieldBit__Advertisement_Addresses   = 1 << 2
 	fieldBit__Advertisement_Signature   = 1 << 3
 	fieldBit__Advertisement_Entries     = 1 << 4
-	fieldBit__Advertisement_Metadata    = 1 << 5
-	fieldBit__Advertisement_IsRm        = 1 << 6
-	fieldBits__Advertisement_sufficient = 0 + 1<<1 + 1<<2 + 1<<3 + 1<<4 + 1<<5 + 1<<6
+	fieldBit__Advertisement_ContextID   = 1 << 5
+	fieldBit__Advertisement_Metadata    = 1 << 6
+	fieldBit__Advertisement_IsRm        = 1 << 7
+	fieldBits__Advertisement_sufficient = 0 + 1<<1 + 1<<2 + 1<<3 + 1<<4 + 1<<5 + 1<<6 + 1<<7
 )
 
 func (na *_Advertisement__Assembler) BeginMap(int64) (datamodel.MapAssembler, error) {
@@ -404,7 +416,7 @@ func (ma *_Advertisement__Assembler) valueFinishTidy() bool {
 	case 5:
 		switch ma.cm {
 		case schema.Maybe_Value:
-			ma.ca_Metadata.w = nil
+			ma.ca_ContextID.w = nil
 			ma.cm = schema.Maybe_Absent
 			ma.state = maState_initial
 			return true
@@ -412,6 +424,16 @@ func (ma *_Advertisement__Assembler) valueFinishTidy() bool {
 			return false
 		}
 	case 6:
+		switch ma.cm {
+		case schema.Maybe_Value:
+			ma.ca_Metadata.w = nil
+			ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
+	case 7:
 		switch ma.cm {
 		case schema.Maybe_Value:
 			ma.ca_IsRm.w = nil
@@ -491,13 +513,23 @@ func (ma *_Advertisement__Assembler) AssembleEntry(k string) (datamodel.NodeAsse
 		ma.ca_Entries.w = &ma.w.Entries
 		ma.ca_Entries.m = &ma.cm
 		return &ma.ca_Entries, nil
+	case "ContextID":
+		if ma.s&fieldBit__Advertisement_ContextID != 0 {
+			return nil, datamodel.ErrRepeatedMapKey{Key: &fieldName__Advertisement_ContextID}
+		}
+		ma.s += fieldBit__Advertisement_ContextID
+		ma.state = maState_midValue
+		ma.f = 5
+		ma.ca_ContextID.w = &ma.w.ContextID
+		ma.ca_ContextID.m = &ma.cm
+		return &ma.ca_ContextID, nil
 	case "Metadata":
 		if ma.s&fieldBit__Advertisement_Metadata != 0 {
 			return nil, datamodel.ErrRepeatedMapKey{Key: &fieldName__Advertisement_Metadata}
 		}
 		ma.s += fieldBit__Advertisement_Metadata
 		ma.state = maState_midValue
-		ma.f = 5
+		ma.f = 6
 		ma.ca_Metadata.w = &ma.w.Metadata
 		ma.ca_Metadata.m = &ma.cm
 		return &ma.ca_Metadata, nil
@@ -507,7 +539,7 @@ func (ma *_Advertisement__Assembler) AssembleEntry(k string) (datamodel.NodeAsse
 		}
 		ma.s += fieldBit__Advertisement_IsRm
 		ma.state = maState_midValue
-		ma.f = 6
+		ma.f = 7
 		ma.ca_IsRm.w = &ma.w.IsRm
 		ma.ca_IsRm.m = &ma.cm
 		return &ma.ca_IsRm, nil
@@ -568,10 +600,14 @@ func (ma *_Advertisement__Assembler) AssembleValue() datamodel.NodeAssembler {
 		ma.ca_Entries.m = &ma.cm
 		return &ma.ca_Entries
 	case 5:
+		ma.ca_ContextID.w = &ma.w.ContextID
+		ma.ca_ContextID.m = &ma.cm
+		return &ma.ca_ContextID
+	case 6:
 		ma.ca_Metadata.w = &ma.w.Metadata
 		ma.ca_Metadata.m = &ma.cm
 		return &ma.ca_Metadata
-	case 6:
+	case 7:
 		ma.ca_IsRm.w = &ma.w.IsRm
 		ma.ca_IsRm.m = &ma.cm
 		return &ma.ca_IsRm
@@ -607,6 +643,9 @@ func (ma *_Advertisement__Assembler) Finish() error {
 		}
 		if ma.s&fieldBit__Advertisement_Entries == 0 {
 			err.Missing = append(err.Missing, "Entries")
+		}
+		if ma.s&fieldBit__Advertisement_ContextID == 0 {
+			err.Missing = append(err.Missing, "ContextID")
 		}
 		if ma.s&fieldBit__Advertisement_Metadata == 0 {
 			err.Missing = append(err.Missing, "Metadata")
@@ -692,13 +731,21 @@ func (ka *_Advertisement__KeyAssembler) AssignString(k string) error {
 		ka.state = maState_expectValue
 		ka.f = 4
 		return nil
+	case "ContextID":
+		if ka.s&fieldBit__Advertisement_ContextID != 0 {
+			return datamodel.ErrRepeatedMapKey{Key: &fieldName__Advertisement_ContextID}
+		}
+		ka.s += fieldBit__Advertisement_ContextID
+		ka.state = maState_expectValue
+		ka.f = 5
+		return nil
 	case "Metadata":
 		if ka.s&fieldBit__Advertisement_Metadata != 0 {
 			return datamodel.ErrRepeatedMapKey{Key: &fieldName__Advertisement_Metadata}
 		}
 		ka.s += fieldBit__Advertisement_Metadata
 		ka.state = maState_expectValue
-		ka.f = 5
+		ka.f = 6
 		return nil
 	case "IsRm":
 		if ka.s&fieldBit__Advertisement_IsRm != 0 {
@@ -706,7 +753,7 @@ func (ka *_Advertisement__KeyAssembler) AssignString(k string) error {
 		}
 		ka.s += fieldBit__Advertisement_IsRm
 		ka.state = maState_expectValue
-		ka.f = 6
+		ka.f = 7
 		return nil
 	default:
 		return schema.ErrInvalidKey{TypeName: "schema.Advertisement", Key: &_String{k}}
@@ -743,6 +790,7 @@ var (
 	fieldName__Advertisement_Addresses_serial  = _String{"Addresses"}
 	fieldName__Advertisement_Signature_serial  = _String{"Signature"}
 	fieldName__Advertisement_Entries_serial    = _String{"Entries"}
+	fieldName__Advertisement_ContextID_serial  = _String{"ContextID"}
 	fieldName__Advertisement_Metadata_serial   = _String{"Metadata"}
 	fieldName__Advertisement_IsRm_serial       = _String{"IsRm"}
 )
@@ -766,6 +814,8 @@ func (n *_Advertisement__Repr) LookupByString(key string) (datamodel.Node, error
 		return n.Signature.Representation(), nil
 	case "Entries":
 		return n.Entries.Representation(), nil
+	case "ContextID":
+		return n.ContextID.Representation(), nil
 	case "Metadata":
 		return n.Metadata.Representation(), nil
 	case "IsRm":
@@ -798,7 +848,7 @@ type _Advertisement__ReprMapItr struct {
 
 func (itr *_Advertisement__ReprMapItr) Next() (k datamodel.Node, v datamodel.Node, _ error) {
 advance:
-	if itr.idx >= 7 {
+	if itr.idx >= 8 {
 		return nil, nil, datamodel.ErrIteratorOverread{}
 	}
 	switch itr.idx {
@@ -822,9 +872,12 @@ advance:
 		k = &fieldName__Advertisement_Entries_serial
 		v = itr.n.Entries.Representation()
 	case 5:
+		k = &fieldName__Advertisement_ContextID_serial
+		v = itr.n.ContextID.Representation()
+	case 6:
 		k = &fieldName__Advertisement_Metadata_serial
 		v = itr.n.Metadata.Representation()
-	case 6:
+	case 7:
 		k = &fieldName__Advertisement_IsRm_serial
 		v = itr.n.IsRm.Representation()
 	default:
@@ -834,13 +887,13 @@ advance:
 	return
 }
 func (itr *_Advertisement__ReprMapItr) Done() bool {
-	return itr.idx >= 7
+	return itr.idx >= 8
 }
 func (_Advertisement__Repr) ListIterator() datamodel.ListIterator {
 	return nil
 }
 func (rn *_Advertisement__Repr) Length() int64 {
-	l := 7
+	l := 8
 	if rn.PreviousID.m == schema.Maybe_Absent {
 		l--
 	}
@@ -911,6 +964,7 @@ type _Advertisement__ReprAssembler struct {
 	ca_Addresses  _List_String__ReprAssembler
 	ca_Signature  _Bytes__ReprAssembler
 	ca_Entries    _Link__ReprAssembler
+	ca_ContextID  _Bytes__ReprAssembler
 	ca_Metadata   _Bytes__ReprAssembler
 	ca_IsRm       _Bool__ReprAssembler
 }
@@ -923,6 +977,7 @@ func (na *_Advertisement__ReprAssembler) reset() {
 	na.ca_Addresses.reset()
 	na.ca_Signature.reset()
 	na.ca_Entries.reset()
+	na.ca_ContextID.reset()
 	na.ca_Metadata.reset()
 	na.ca_IsRm.reset()
 }
@@ -1079,6 +1134,15 @@ func (ma *_Advertisement__ReprAssembler) valueFinishTidy() bool {
 		default:
 			return false
 		}
+	case 7:
+		switch ma.cm {
+		case schema.Maybe_Value:
+			ma.cm = schema.Maybe_Absent
+			ma.state = maState_initial
+			return true
+		default:
+			return false
+		}
 	default:
 		panic("unreachable")
 	}
@@ -1150,13 +1214,23 @@ func (ma *_Advertisement__ReprAssembler) AssembleEntry(k string) (datamodel.Node
 		ma.ca_Entries.w = &ma.w.Entries
 		ma.ca_Entries.m = &ma.cm
 		return &ma.ca_Entries, nil
+	case "ContextID":
+		if ma.s&fieldBit__Advertisement_ContextID != 0 {
+			return nil, datamodel.ErrRepeatedMapKey{Key: &fieldName__Advertisement_ContextID_serial}
+		}
+		ma.s += fieldBit__Advertisement_ContextID
+		ma.state = maState_midValue
+		ma.f = 5
+		ma.ca_ContextID.w = &ma.w.ContextID
+		ma.ca_ContextID.m = &ma.cm
+		return &ma.ca_ContextID, nil
 	case "Metadata":
 		if ma.s&fieldBit__Advertisement_Metadata != 0 {
 			return nil, datamodel.ErrRepeatedMapKey{Key: &fieldName__Advertisement_Metadata_serial}
 		}
 		ma.s += fieldBit__Advertisement_Metadata
 		ma.state = maState_midValue
-		ma.f = 5
+		ma.f = 6
 		ma.ca_Metadata.w = &ma.w.Metadata
 		ma.ca_Metadata.m = &ma.cm
 		return &ma.ca_Metadata, nil
@@ -1166,7 +1240,7 @@ func (ma *_Advertisement__ReprAssembler) AssembleEntry(k string) (datamodel.Node
 		}
 		ma.s += fieldBit__Advertisement_IsRm
 		ma.state = maState_midValue
-		ma.f = 6
+		ma.f = 7
 		ma.ca_IsRm.w = &ma.w.IsRm
 		ma.ca_IsRm.m = &ma.cm
 		return &ma.ca_IsRm, nil
@@ -1229,10 +1303,14 @@ func (ma *_Advertisement__ReprAssembler) AssembleValue() datamodel.NodeAssembler
 		ma.ca_Entries.m = &ma.cm
 		return &ma.ca_Entries
 	case 5:
+		ma.ca_ContextID.w = &ma.w.ContextID
+		ma.ca_ContextID.m = &ma.cm
+		return &ma.ca_ContextID
+	case 6:
 		ma.ca_Metadata.w = &ma.w.Metadata
 		ma.ca_Metadata.m = &ma.cm
 		return &ma.ca_Metadata
-	case 6:
+	case 7:
 		ma.ca_IsRm.w = &ma.w.IsRm
 		ma.ca_IsRm.m = &ma.cm
 		return &ma.ca_IsRm
@@ -1268,6 +1346,9 @@ func (ma *_Advertisement__ReprAssembler) Finish() error {
 		}
 		if ma.s&fieldBit__Advertisement_Entries == 0 {
 			err.Missing = append(err.Missing, "Entries")
+		}
+		if ma.s&fieldBit__Advertisement_ContextID == 0 {
+			err.Missing = append(err.Missing, "ContextID")
 		}
 		if ma.s&fieldBit__Advertisement_Metadata == 0 {
 			err.Missing = append(err.Missing, "Metadata")
@@ -1353,13 +1434,21 @@ func (ka *_Advertisement__ReprKeyAssembler) AssignString(k string) error {
 		ka.state = maState_expectValue
 		ka.f = 4
 		return nil
+	case "ContextID":
+		if ka.s&fieldBit__Advertisement_ContextID != 0 {
+			return datamodel.ErrRepeatedMapKey{Key: &fieldName__Advertisement_ContextID_serial}
+		}
+		ka.s += fieldBit__Advertisement_ContextID
+		ka.state = maState_expectValue
+		ka.f = 5
+		return nil
 	case "Metadata":
 		if ka.s&fieldBit__Advertisement_Metadata != 0 {
 			return datamodel.ErrRepeatedMapKey{Key: &fieldName__Advertisement_Metadata_serial}
 		}
 		ka.s += fieldBit__Advertisement_Metadata
 		ka.state = maState_expectValue
-		ka.f = 5
+		ka.f = 6
 		return nil
 	case "IsRm":
 		if ka.s&fieldBit__Advertisement_IsRm != 0 {
@@ -1367,7 +1456,7 @@ func (ka *_Advertisement__ReprKeyAssembler) AssignString(k string) error {
 		}
 		ka.s += fieldBit__Advertisement_IsRm
 		ka.state = maState_expectValue
-		ka.f = 6
+		ka.f = 7
 		return nil
 	}
 	return schema.ErrInvalidKey{TypeName: "schema.Advertisement.Repr", Key: &_String{k}}

--- a/api/v0/ingest/schema/ipldsch_types.go
+++ b/api/v0/ingest/schema/ipldsch_types.go
@@ -62,6 +62,7 @@ type _Advertisement struct {
 	Addresses  _List_String
 	Signature  _Bytes
 	Entries    _Link
+	ContextID  _Bytes
 	Metadata   _Bytes
 	IsRm       _Bool
 }

--- a/api/v0/ingest/schema/utils.go
+++ b/api/v0/ingest/schema/utils.go
@@ -99,13 +99,14 @@ func NewAdvertisement(
 	signKey crypto.PrivKey,
 	previousID Link_Advertisement,
 	entries ipld.Link,
+	contextID []byte,
 	metadata []byte,
 	isRm bool,
 	provider string,
 	addrs []string) (Advertisement, error) {
 
 	// Create advertisement
-	return newAdvertisement(signKey, previousID, entries, metadata, isRm, provider, addrs)
+	return newAdvertisement(signKey, previousID, entries, contextID, metadata, isRm, provider, addrs)
 
 }
 
@@ -116,13 +117,14 @@ func NewAdvertisementWithLink(
 	signKey crypto.PrivKey,
 	previousID Link_Advertisement,
 	entries ipld.Link,
+	contextID []byte,
 	metadata []byte,
 	isRm bool,
 	provider string,
 	addrs []string) (Advertisement, Link_Advertisement, error) {
 
 	// Create advertisement
-	adv, err := newAdvertisement(signKey, previousID, entries, metadata, isRm, provider, addrs)
+	adv, err := newAdvertisement(signKey, previousID, entries, contextID, metadata, isRm, provider, addrs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -153,6 +155,7 @@ func NewAdvertisementWithFakeSig(
 	signKey crypto.PrivKey,
 	previousID Link_Advertisement,
 	entries ipld.Link,
+	contextID []byte,
 	metadata []byte,
 	isRm bool,
 	provider string,
@@ -165,6 +168,7 @@ func NewAdvertisementWithFakeSig(
 			Provider:   _String{x: provider},
 			Addresses:  GoToIpldStrings(addrs),
 			Entries:    _Link{x: entries},
+			ContextID:  _Bytes{x: contextID},
 			Metadata:   _Bytes{x: metadata},
 			IsRm:       _Bool{x: isRm},
 		}
@@ -174,6 +178,7 @@ func NewAdvertisementWithFakeSig(
 			Provider:   _String{x: provider},
 			Addresses:  GoToIpldStrings(addrs),
 			Entries:    _Link{x: entries},
+			ContextID:  _Bytes{x: contextID},
 			Metadata:   _Bytes{x: metadata},
 			IsRm:       _Bool{x: isRm},
 		}
@@ -196,6 +201,7 @@ func newAdvertisement(
 	signKey crypto.PrivKey,
 	previousID Link_Advertisement,
 	entries ipld.Link,
+	contextID []byte,
 	metadata []byte,
 	isRm bool,
 	provider string,
@@ -208,6 +214,7 @@ func newAdvertisement(
 			Provider:   _String{x: provider},
 			Addresses:  GoToIpldStrings(addrs),
 			Entries:    _Link{x: entries},
+			ContextID:  _Bytes{x: contextID},
 			Metadata:   _Bytes{x: metadata},
 			IsRm:       _Bool{x: isRm},
 		}
@@ -217,6 +224,7 @@ func newAdvertisement(
 			Provider:   _String{x: provider},
 			Addresses:  GoToIpldStrings(addrs),
 			Entries:    _Link{x: entries},
+			ContextID:  _Bytes{x: contextID},
 			Metadata:   _Bytes{x: metadata},
 			IsRm:       _Bool{x: isRm},
 		}

--- a/api/v0/ingest/schema/utils_test.go
+++ b/api/v0/ingest/schema/utils_test.go
@@ -43,14 +43,15 @@ func genCidsAndAdv(t *testing.T, lsys ipld.LinkSystem,
 	previous Link_Advertisement) ([]mh.Multihash, ipld.Link, Advertisement, Link_Advertisement) {
 
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	ctxID := []byte("test-context-id")
 	addr := "/ip4/127.0.0.1/tcp/9999"
 	mhs, _ := util.RandomMultihashes(10)
-	val := indexer.MakeValue(p, 0, mhs[0])
+	val := indexer.MakeValue(p, ctxID, 0, mhs[0])
 	cidsLnk, err := NewListOfMhs(lsys, mhs)
 	if err != nil {
 		t.Fatal(err)
 	}
-	adv, advLnk, err := NewAdvertisementWithLink(lsys, priv, previous, cidsLnk, val.Metadata, false, p.String(), []string{addr})
+	adv, advLnk, err := NewAdvertisementWithLink(lsys, priv, previous, cidsLnk, val.ContextID, val.Metadata, false, p.String(), []string{addr})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/go-indexer-core/cache"
 	"github.com/filecoin-project/go-indexer-core/cache/radixcache"
 	"github.com/filecoin-project/go-indexer-core/engine"
-	"github.com/filecoin-project/go-indexer-core/store"
 	"github.com/filecoin-project/go-indexer-core/store/pogreb"
 	"github.com/filecoin-project/go-indexer-core/store/storethehash"
 	"github.com/filecoin-project/storetheindex/config"
@@ -286,7 +286,7 @@ func daemonCommand(cctx *cli.Context) error {
 	return finalErr
 }
 
-func createValueStore(dir, storeType string) (store.Interface, error) {
+func createValueStore(dir, storeType string) (indexer.Interface, error) {
 	err := checkWritable(dir)
 	if err != nil {
 		return nil, err

--- a/command/flags.go
+++ b/command/flags.go
@@ -74,6 +74,12 @@ var importFlags = []cli.Flag{
 		Required: true,
 	},
 	&cli.StringFlag{
+		Name:     "contextid",
+		Usage:    "Context ID of data imported",
+		Aliases:  []string{"ctxid"},
+		Required: true,
+	},
+	&cli.StringFlag{
 		Name:     "metadata",
 		Usage:    "Bytes of opaque metadata corresponding to protocol 0",
 		Aliases:  []string{"m"},

--- a/command/import.go
+++ b/command/import.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	httpclient "github.com/filecoin-project/storetheindex/api/v0/finder/client/http"
-	peer "github.com/libp2p/go-libp2p-core/peer"
+	httpclient "github.com/filecoin-project/storetheindex/api/v0/admin/client/http"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/urfave/cli/v2"
 )
 
@@ -57,7 +57,7 @@ func importListCmd(cctx *cli.Context) error {
 	// TODO: Should there be a timeout?  Since this may take a long time, it
 	// would make sense that the request should complete immediately with a
 	// redirect to a URL where the status can be polled for.
-	return cl.ImportFromCidList(context.Background(), dir, p)
+	return cl.ImportFromCidList(context.Background(), dir, p, cctx.String("contextid"))
 }
 
 func importCarCmd(c *cli.Context) error {
@@ -81,5 +81,5 @@ func importManifestCmd(cctx *cli.Context) error {
 	// TODO: Should there be a timeout?  Since this may take a long time, it
 	// would make sense that the request should complete immediately with a
 	// redirect to a URL where the status can be polled for.
-	return cl.ImportFromManifest(context.Background(), dir, p)
+	return cl.ImportFromManifest(context.Background(), dir, p, cctx.String("contextid"))
 }

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.1.5
+	github.com/filecoin-project/go-indexer-core v0.2.0
 	github.com/filecoin-project/go-legs v0.0.0-20210922204025-c6f68b62ab16
-	github.com/gammazero/keymutex v0.0.0-20210923135229-c799050360da
+	github.com/gammazero/keymutex v0.0.0-20211002043844-c7ebad3e5479
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.4
 	github.com/ipfs/go-cid v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/filecoin-project/go-data-transfer v1.6.1-0.20210608092034-e4f40bc3a68
 github.com/filecoin-project/go-data-transfer v1.6.1-0.20210608092034-e4f40bc3a685/go.mod h1:We59IRN/nAgBSzgm3enBz4UeWNlsdqvTaJdvSbuOfL8=
 github.com/filecoin-project/go-ds-versioning v0.1.0 h1:y/X6UksYTsK8TLCI7rttCKEvl8btmWxyFMEeeWGUxIQ=
 github.com/filecoin-project/go-ds-versioning v0.1.0/go.mod h1:mp16rb4i2QPmxBnmanUx8i/XANp+PFCCJWiAb+VW4/s=
-github.com/filecoin-project/go-indexer-core v0.1.5 h1:VaXywH7bXM9AVnqVRnIOOT8KrXFlqj6tA340sjGvJeM=
-github.com/filecoin-project/go-indexer-core v0.1.5/go.mod h1:DpPaHit14dYCKn1VnDRIsazzTfbvHLQvqyRYtJTFJIU=
+github.com/filecoin-project/go-indexer-core v0.2.0 h1:I3mtrTLH6aXOkbxsjRKv3rn8tLgoa6vIYl8XuBNRDik=
+github.com/filecoin-project/go-indexer-core v0.2.0/go.mod h1:CsD+HUiCB+lwL+mxXPKQCsqoA9fezXTheU7IjsFohCU=
 github.com/filecoin-project/go-legs v0.0.0-20210922204025-c6f68b62ab16 h1:xFiCa75M7kjr9/AfaVvFNjJKsMgtIP25g+DXKx4Ub7A=
 github.com/filecoin-project/go-legs v0.0.0-20210922204025-c6f68b62ab16/go.mod h1:qLH/nW+bQoOmnLG4eGU36vubv0MmAezQ2Y2FQBa1hM8=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
@@ -207,9 +207,8 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gammazero/keymutex v0.0.0-20210923122432-72239b58243f/go.mod h1:qtzWCCLMisQUmVa4dvqHVgwfh4BP2YB7JxNDGXnsKrs=
-github.com/gammazero/keymutex v0.0.0-20210923135229-c799050360da h1:uFDO8TO6/4/VkGWnezyZ6N1RflB9gy1VSpqd4/7ITzo=
-github.com/gammazero/keymutex v0.0.0-20210923135229-c799050360da/go.mod h1:qtzWCCLMisQUmVa4dvqHVgwfh4BP2YB7JxNDGXnsKrs=
+github.com/gammazero/keymutex v0.0.0-20211002043844-c7ebad3e5479 h1:lCqfYOAqlMRixZ/t6MB7Khu1YSTrEE4GEIsiF0qNSdY=
+github.com/gammazero/keymutex v0.0.0-20211002043844-c7ebad3e5479/go.mod h1:qtzWCCLMisQUmVa4dvqHVgwfh4BP2YB7JxNDGXnsKrs=
 github.com/gammazero/radixtree v0.2.5 h1:muPQ4eEgCkUymFWPiVQRuXOQv4IhWg8YXH2r71MoqPM=
 github.com/gammazero/radixtree v0.2.5/go.mod h1:VPqqCDZ3YZZxAzUUsIF/ytFBigVWV7JIV1Stld8hri0=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -316,7 +316,7 @@ func (i *legIngester) putLatestSync(peerID peer.ID, c cid.Cid) error {
 	if c == cid.Undef {
 		return nil
 	}
-	stats.RecordWithOptions(context.Background(),
+	_ = stats.RecordWithOptions(context.Background(),
 		stats.WithTags(tag.Insert(metrics.Method, "libp2p2")),
 		stats.WithMeasurements(metrics.IngestChange.M(1)))
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -289,12 +289,13 @@ func publishRandomIndexAndAdv(t *testing.T, pub legs.LegPublisher, lsys ipld.Lin
 	priv, _, err := test.RandTestKeyPair(crypto.Ed25519, 256)
 	require.NoError(t, err)
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	ctxID := []byte("test-context-id")
 	addrs := []string{"/ip4/127.0.0.1/tcp/9999"}
-	val := indexer.MakeValue(p, 0, mhs[0])
+	val := indexer.MakeValue(p, ctxID, 0, mhs[0])
 	mhsLnk, mhs := newRandomLinkedList(t, lsys, 3)
-	_, advLnk, err := schema.NewAdvertisementWithLink(lsys, priv, nil, mhsLnk, val.Metadata, false, p.String(), addrs)
+	_, advLnk, err := schema.NewAdvertisementWithLink(lsys, priv, nil, mhsLnk, val.ContextID, val.Metadata, false, p.String(), addrs)
 	if fakeSig {
-		_, advLnk, err = schema.NewAdvertisementWithFakeSig(lsys, priv, nil, mhsLnk, val.Metadata, false, p.String(), addrs)
+		_, advLnk, err = schema.NewAdvertisementWithFakeSig(lsys, priv, nil, mhsLnk, val.ContextID, val.Metadata, false, p.String(), addrs)
 	}
 	require.NoError(t, err)
 	lnk, err := advLnk.AsLink()

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -2,12 +2,11 @@ package ingest
 
 import (
 	"bytes"
-	"encoding/base64"
 	"io"
 	"net/http"
 
 	"github.com/filecoin-project/go-indexer-core"
-	schema "github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	"github.com/filecoin-project/storetheindex/internal/syserr"
 	"github.com/ipfs/go-cid"
@@ -17,7 +16,8 @@ import (
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
-	peer "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multihash"
 )
 
 func dsKey(k string) datastore.Key {
@@ -226,6 +226,10 @@ func (i *legIngester) processEntries(adCid cid.Cid, p peer.ID, nentries ipld.Nod
 		return err
 	}
 	// Fetch data of interest.
+	contextID, err := ad.FieldContextID().AsBytes()
+	if err != nil {
+		return err
+	}
 	metadata, err := ad.FieldMetadata().AsBytes()
 	if err != nil {
 		return err
@@ -246,6 +250,14 @@ func (i *legIngester) processEntries(adCid cid.Cid, p peer.ID, nentries ipld.Nod
 		log.Errorf("Error decoding entries: %s", err)
 		return err
 	}
+
+	const batchSize = 64
+	putChan := make(chan multihash.Multihash, batchSize)
+	removeChan := make(chan multihash.Multihash, batchSize)
+	value := indexer.MakeValue(p, contextID, 0, metadata)
+	errChan := batchIndexerEntries(batchSize, putChan, removeChan, value, i.indexer)
+
+	var count int
 	nchunk := nb.Build().(schema.EntryChunk)
 	entries := nchunk.FieldEntries()
 	// Iterate over all entries and ingest them
@@ -255,27 +267,36 @@ func (i *legIngester) processEntries(adCid cid.Cid, p peer.ID, nentries ipld.Nod
 		h, err := cnode.AsBytes()
 		if err != nil {
 			log.Errorf("Error decoding an entry from the ingestion list: %s", err)
+			close(putChan)
+			close(removeChan)
 			return err
 		}
-		val := indexer.MakeValue(p, 0, metadata)
 		if isRm {
 			// TODO: Remove will change once we change the syncing process
 			// because we may not receive the list of CIDs to remove and we'll
 			// have to use a routine that looks for the CIDs for a specific
 			// key.
-			if _, err := i.indexer.Remove(h, val); err != nil {
-				log.Errorf("Error removing entry from indexer: %s", err)
+			select {
+			case removeChan <- h:
+			case err = <-errChan:
 				return err
 			}
-
 		} else {
-			if _, err := i.indexer.Put(h, val); err != nil {
-				log.Errorf("Error putting entry in indexer: %s", err)
+			select {
+			case putChan <- h:
+			case err = <-errChan:
 				return err
 			}
 		}
-		log.Debugw("Processed entry", "multihash", base64.StdEncoding.EncodeToString(h))
+		count++
 	}
+	close(putChan)
+	close(removeChan)
+	err = <-errChan
+	if err != nil {
+		return err
+	}
+	log.Debugw("Processed entries", "count", count)
 
 	// If there is a next link, update the mapping so we know the AdID
 	// it is related to.
@@ -291,6 +312,86 @@ func (i *legIngester) processEntries(adCid cid.Cid, p peer.ID, nentries ipld.Nod
 	}
 
 	return nil
+}
+
+// batchIndexerEntries starts a goroutine that reads multihashes from two input
+// channels, putChan and removeChan.  The goroutine collects these into
+// separate slices, storing up to batchSize elements.  When a slice is at
+// capacity, a Put or Remove request is made to the indexer core.  This
+// function returns an error channel that returns an error if one occurs during
+// Put or Remove, which also indicates the goroutine has exited (and will no
+// longer read its input channels).
+//
+// The goroutine exits when both the input channels are closed.  It closes the
+// error channel to indicate completion.
+func batchIndexerEntries(batchSize int, putChan, removeChan <-chan multihash.Multihash, value indexer.Value, idxr indexer.Interface) <-chan error {
+	errChan := make(chan error, 1)
+
+	go func() {
+		defer close(errChan)
+		puts := make([]multihash.Multihash, 0, batchSize)
+		removes := make([]multihash.Multihash, 0, batchSize)
+		for {
+			select {
+			case m, open := <-putChan:
+				if !open {
+					if len(puts) != 0 {
+						// Process any remaining puts
+						if err := idxr.Put(value, puts...); err != nil {
+							errChan <- err
+							log.Errorf("Error putting entries in indexer: %s", err)
+							return
+						}
+					}
+					if removeChan == nil {
+						// All input channels closed
+						return
+					}
+					putChan = nil
+					continue
+				}
+				puts = append(puts, m)
+				if len(puts) == batchSize {
+					// Process full batch of puts
+					if err := idxr.Put(value, puts...); err != nil {
+						errChan <- err
+						log.Errorf("Error putting entries in indexer: %s", err)
+						return
+					}
+					puts = puts[:0]
+				}
+			case m, open := <-removeChan:
+				if !open {
+					if len(removes) != 0 {
+						// Process any remaining removes
+						if err := idxr.Remove(value, removes...); err != nil {
+							log.Errorf("Error removing entries from indexer: %s", err)
+							errChan <- err
+							return
+						}
+					}
+					if putChan == nil {
+						// All input channels closed
+						return
+					}
+					removeChan = nil
+					continue
+				}
+				removes = append(removes, m)
+				if len(removes) == batchSize {
+					// Process full batch of removes
+					if err := idxr.Remove(value, removes...); err != nil {
+						errChan <- err
+						log.Errorf("Error removing entries from indexer: %s", err)
+						return
+					}
+					removes = removes[:0]
+				}
+			}
+		}
+	}()
+
+	return errChan
 }
 
 func putCidToAdMapping(ds datastore.Batching, lnk ipld.Link, adCid cid.Cid) error {

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -44,8 +44,8 @@ func New(ctx context.Context, listen string, indexer indexer.Interface, ingester
 
 	// Set protocol handlers
 	// Import routes
-	r.HandleFunc("/import/manifest/{minerid}", h.importManifest).Methods("POST")
-	r.HandleFunc("/import/cidlist/{minerid}", h.importCidList).Methods("POST")
+	r.HandleFunc("/import/manifest/{minerid}/{contextid}", h.importManifest).Methods("POST")
+	r.HandleFunc("/import/cidlist/{minerid}/{contextid}", h.importCidList).Methods("POST")
 
 	// Admin routes
 	r.HandleFunc("/healthcheck", h.healthCheckHandler).Methods("GET")

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -70,7 +70,7 @@ func InitRegistry(t *testing.T) *registry.Registry {
 
 // PopulateIndex with some multihashes
 func PopulateIndex(ind indexer.Interface, mhs []multihash.Multihash, v indexer.Value, t *testing.T) {
-	err := ind.PutMany(mhs, v)
+	err := ind.Put(v, mhs...)
 	if err != nil {
 		t.Fatal("Error putting multihashes: ", err)
 	}
@@ -99,7 +99,8 @@ func FindIndexTest(ctx context.Context, t *testing.T, c client.Finder, ind index
 	if err != nil {
 		t.Fatal(err)
 	}
-	v := indexer.MakeValue(p, 0, []byte(mhs[0]))
+	ctxID := []byte("test-context-id")
+	v := indexer.MakeValue(p, ctxID, 0, []byte(mhs[0]))
 	PopulateIndex(ind, mhs[:10], v, t)
 
 	a, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/9999")

--- a/server/ingest/http/handler.go
+++ b/server/ingest/http/handler.go
@@ -167,18 +167,13 @@ func (h *httpHandler) IndexContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ok, err := h.ingestHandler.IndexContent(body)
+	err = h.ingestHandler.IndexContent(body)
 	if err != nil {
 		httpserver.HandleError(w, err, "ingest")
 		return
 	}
 
-	if ok {
-		log.Info("indexed new content")
-	}
-
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintln(w, "new:", ok)
 }
 
 func getProviderID(r *http.Request) (peer.ID, error) {

--- a/server/ingest/libp2p/handler.go
+++ b/server/ingest/libp2p/handler.go
@@ -89,11 +89,7 @@ func (h *libp2pHandler) HandleMessage(ctx context.Context, msgPeer peer.ID, msgb
 
 func (h *libp2pHandler) DiscoverProvider(ctx context.Context, p peer.ID, msg *pb.IngestMessage) ([]byte, error) {
 	err := h.ingestHandler.DiscoverProvider(msg.GetData())
-	if err != nil {
-		return nil, err
-	}
-
-	return nil, nil
+	return nil, err
 }
 
 func (h *libp2pHandler) ListProviders(ctx context.Context, p peer.ID, msg *pb.IngestMessage) ([]byte, error) {
@@ -116,7 +112,7 @@ func (h *libp2pHandler) GetProvider(ctx context.Context, p peer.ID, msg *pb.Inge
 
 	data, err := h.ingestHandler.GetProvider(providerID)
 	if err != nil {
-		log.Error("cannot get provider", "err", err)
+		log.Errorw("cannot get provider", "err", err)
 		return nil, syserr.New(nil, http.StatusInternalServerError)
 	}
 
@@ -129,11 +125,7 @@ func (h *libp2pHandler) GetProvider(ctx context.Context, p peer.ID, msg *pb.Inge
 
 func (h *libp2pHandler) RegisterProvider(ctx context.Context, p peer.ID, msg *pb.IngestMessage) ([]byte, error) {
 	err := h.ingestHandler.RegisterProvider(msg.GetData())
-	if err != nil {
-		return nil, err
-	}
-
-	return nil, nil
+	return nil, err
 }
 
 func (h *libp2pHandler) RemoveProvider(ctx context.Context, p peer.ID, msg *pb.IngestMessage) ([]byte, error) {
@@ -141,14 +133,6 @@ func (h *libp2pHandler) RemoveProvider(ctx context.Context, p peer.ID, msg *pb.I
 }
 
 func (h *libp2pHandler) IndexContent(ctx context.Context, p peer.ID, msg *pb.IngestMessage) ([]byte, error) {
-	ok, err := h.ingestHandler.IndexContent(msg.GetData())
-	if err != nil {
-		return nil, err
-	}
-
-	if ok {
-		log.Info("indexed content")
-	}
-
-	return nil, nil
+	err := h.ingestHandler.IndexContent(msg.GetData())
+	return nil, err
 }

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -66,7 +66,7 @@ func InitRegistry(t *testing.T, trustedID string) *registry.Registry {
 
 // PopulateIndex with some multihashes
 func PopulateIndex(ind indexer.Interface, mhs []multihash.Multihash, v indexer.Value, t *testing.T) {
-	err := ind.PutMany(mhs, v)
+	err := ind.Put(v, mhs...)
 	if err != nil {
 		t.Fatal("Error putting multihashes: ", err)
 	}
@@ -161,9 +161,10 @@ func IndexContent(t *testing.T, cl client.Ingest, providerID peer.ID, privateKey
 		t.Fatal(err)
 	}
 
+	contextID := []byte("test-context-id")
 	metadata := []byte("hello")
 
-	err = cl.IndexContent(ctx, providerID, privateKey, mhs[0], 0, metadata, nil)
+	err = cl.IndexContent(ctx, providerID, privateKey, mhs[0], contextID, 0, metadata, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +180,7 @@ func IndexContent(t *testing.T, cl client.Ingest, providerID peer.ID, privateKey
 		t.Fatal("no content values returned")
 	}
 
-	expectValue := indexer.MakeValue(providerID, 0, metadata)
+	expectValue := indexer.MakeValue(providerID, contextID, 0, metadata)
 	ok = false
 	for i := range vals {
 		if vals[i].Equal(expectValue) {
@@ -201,10 +202,11 @@ func IndexContentNewAddr(t *testing.T, cl client.Ingest, providerID peer.ID, pri
 		t.Fatal(err)
 	}
 
+	ctxID := []byte("test-context-id")
 	metadata := []byte("hello")
 	addrs := []string{newAddr}
 
-	err = cl.IndexContent(ctx, providerID, privateKey, mhs[0], 0, metadata, addrs)
+	err = cl.IndexContent(ctx, providerID, privateKey, mhs[0], ctxID, 0, metadata, addrs)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* Advertisements now contain a ContextID that serves as the provider's key to metadata
* storetheindex uses ContextID from advertisement to compose value to index
* Read content linked from advertisement and store in indexer asynchronously to reading from provider
* Move admin client methods out of finder client