### PR TITLE
Do not separate provider addrs from indexer results

### DIFF
--- a/api/v0/finder/model/model.go
+++ b/api/v0/finder/model/model.go
@@ -1,11 +1,14 @@
 package model
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/filecoin-project/go-indexer-core"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 )
 
@@ -14,31 +17,66 @@ type FindRequest struct {
 	Multihashes []multihash.Multihash
 }
 
+type ProviderResult struct {
+	// ContextID identifies the metadata that is part of this value
+	ContextID []byte
+	// Metadata is serialized data that provides information about retrieving
+	// data, for the indexed CID, from the identified provider.
+	Metadata []byte `json:",omitempty"`
+	// Privider is the peer ID of the provider and its multiaddrs
+	Provider peer.AddrInfo
+}
+
 // MultihashResult aggregates all values for a single multihash.
 type MultihashResult struct {
-	Multihash multihash.Multihash
-	Values    []indexer.Value
+	Multihash       multihash.Multihash
+	ProviderResults []ProviderResult
 }
 
 // FindResponse used to answer client queries/requests
 type FindResponse struct {
 	MultihashResults []MultihashResult
-	Providers        []peer.AddrInfo
 	// NOTE: This feature is not enabled yet.
 	// Signature []byte	// Providers signature.
 }
 
-// MarshalReq serializes the request.
-// We currently JSON, we could use anything else.
-//NOTE: Consider using other serialization formats?
-// We could maybe use IPLD schemas instead of structs
-// for requests and response so we have any codec by design.
+// Equal compares ProviderResult values to determine if they are equal.  The
+// provider addresses are omitted from the comparison.
+func (pr ProviderResult) Equal(other ProviderResult) bool {
+	if !bytes.Equal(pr.ContextID, other.ContextID) {
+		return false
+	}
+	if !bytes.Equal(pr.Metadata, other.Metadata) {
+		return false
+	}
+	if pr.Provider.ID != other.Provider.ID {
+		return false
+	}
+	return true
+}
+
+func ProviderResultFromValue(value indexer.Value, addrs []multiaddr.Multiaddr) ProviderResult {
+	return ProviderResult{
+		ContextID: value.ContextID,
+		Metadata:  value.Metadata,
+		Provider: peer.AddrInfo{
+			ID:    value.ProviderID,
+			Addrs: addrs,
+		},
+	}
+}
+
+// MarshalReq serializes the request. Currently uses JSON, but could use
+// anything else.
+//
+// NOTE: Consider using other serialization formats?  We could maybe use IPLD
+// schemas instead of structs for requests and response so we have any codec by
+// design.
 func MarshalFindRequest(r *FindRequest) ([]byte, error) {
 	return json.Marshal(r)
 }
 
 // UnmarshalFindRequest de-serializes the request.
-// We currently JSON, we could use any other format.
 func UnmarshalFindRequest(b []byte) (*FindRequest, error) {
 	r := &FindRequest{}
 	err := json.Unmarshal(b, r)
@@ -57,10 +95,20 @@ func UnmarshalFindResponse(b []byte) (*FindResponse, error) {
 	return r, err
 }
 
+func (r *FindResponse) String() string {
+	var b strings.Builder
+	for i := range r.MultihashResults {
+		data, err := json.MarshalIndent(&r.MultihashResults[i], "", "  ")
+		if err != nil {
+			return err.Error()
+		}
+		b.Write(data)
+		b.WriteByte(0x0a)
+	}
+	return b.String()
+}
+
 // PrettyPrint a response for CLI output
 func (r *FindResponse) PrettyPrint() {
-	for i := range r.MultihashResults {
-		fmt.Println("Multihash:", r.MultihashResults[i].Multihash)
-		fmt.Println("Values:", r.MultihashResults[i].Values)
-	}
+	fmt.Println(r.String())
 }

--- a/internal/handler/finder_handler.go
+++ b/internal/handler/finder_handler.go
@@ -8,11 +8,12 @@ import (
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	"github.com/filecoin-project/storetheindex/internal/syserr"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 )
 
 // FinderHandler provides request handling functionality for the finder server
-// that is common to all protocols
+// that is common to all protocols.
 type FinderHandler struct {
 	indexer  indexer.Interface
 	registry *registry.Registry
@@ -25,12 +26,11 @@ func NewFinderHandler(indexer indexer.Interface, registry *registry.Registry) *F
 	}
 }
 
-// MakeFindResponse reads from indexer core to populate a response from a
-// list of multihashes.
+// MakeFindResponse reads from indexer core to populate a response from a list
+// of multihashes.
 func (h *FinderHandler) MakeFindResponse(mhashes []multihash.Multihash) (*model.FindResponse, error) {
 	results := make([]model.MultihashResult, 0, len(mhashes))
-	var providerResults []peer.AddrInfo
-	providerSeen := map[peer.ID]struct{}{}
+	provAddrs := map[peer.ID][]multiaddr.Multiaddr{}
 
 	for i := range mhashes {
 		values, found, err := h.indexer.Get(mhashes[i])
@@ -40,31 +40,39 @@ func (h *FinderHandler) MakeFindResponse(mhashes []multihash.Multihash) (*model.
 		if !found {
 			continue
 		}
-		// Add the result to the list of index results
-		results = append(results, model.MultihashResult{
-			Multihash: mhashes[i],
-			Values:    values,
-		})
 
-		// Lookup provider info for each unique provider
+		provResults := make([]model.ProviderResult, len(values))
 		for j := range values {
-			provID := values[j].ProviderID
-			if _, found = providerSeen[provID]; found {
-				continue
+			addrInfo := peer.AddrInfo{
+				ID: values[j].ProviderID,
 			}
-			providerSeen[provID] = struct{}{}
-
-			pinfo := h.registry.ProviderInfo(provID)
-			if pinfo == nil {
-				continue
+			// Lookup provider info for each unique provider, look in local map
+			// before going to registry.
+			addrs, ok := provAddrs[addrInfo.ID]
+			if !ok {
+				pinfo := h.registry.ProviderInfo(addrInfo.ID)
+				if pinfo != nil {
+					addrs = pinfo.AddrInfo.Addrs
+					provAddrs[addrInfo.ID] = addrs
+				}
 			}
+			addrInfo.Addrs = addrs
 
-			providerResults = append(providerResults, pinfo.AddrInfo)
+			provResults[j] = model.ProviderResult{
+				ContextID: values[j].ContextID,
+				Metadata:  values[j].Metadata,
+				Provider:  addrInfo,
+			}
 		}
+
+		// Add the result to the list of index results.
+		results = append(results, model.MultihashResult{
+			Multihash:       mhashes[i],
+			ProviderResults: provResults,
+		})
 	}
 
 	return &model.FindResponse{
 		MultihashResults: results,
-		Providers:        providerResults,
 	}, nil
 }


### PR DESCRIPTION
Instead of an indexer.Value, each result contains ProviderResult that has a ContextID, Metadata, and Provider.  The Provider is a peer.AddrInfo that contains the provider ID and its list of multiaddrs.

This fixes issue #89