### PR TITLE
Use new indexer.Metadata type

### DIFF
--- a/api/v0/finder/model/model.go
+++ b/api/v0/finder/model/model.go
@@ -17,13 +17,14 @@ type FindRequest struct {
 	Multihashes []multihash.Multihash
 }
 
+// ProviderResult is a one of possibly multiple results when looking up a
+// provider of indexed context.
 type ProviderResult struct {
-	// ContextID identifies the metadata that is part of this value
+	// ContextID identifies the metadata that is part of this value.
 	ContextID []byte
-	// Metadata is serialized data that provides information about retrieving
-	// data, for the indexed CID, from the identified provider.
-	Metadata []byte `json:",omitempty"`
-	// Privider is the peer ID of the provider and its multiaddrs
+	// Metadata contains information for the provider to use to retrieve data.
+	Metadata indexer.Metadata
+	// Privider is the peer ID of the provider and its multiaddrs.
 	Provider peer.AddrInfo
 }
 
@@ -46,7 +47,7 @@ func (pr ProviderResult) Equal(other ProviderResult) bool {
 	if !bytes.Equal(pr.ContextID, other.ContextID) {
 		return false
 	}
-	if !bytes.Equal(pr.Metadata, other.Metadata) {
+	if !pr.Metadata.Equal(other.Metadata) {
 		return false
 	}
 	if pr.Provider.ID != other.Provider.ID {
@@ -56,9 +57,11 @@ func (pr ProviderResult) Equal(other ProviderResult) bool {
 }
 
 func ProviderResultFromValue(value indexer.Value, addrs []multiaddr.Multiaddr) ProviderResult {
+	metadata, _ := indexer.DecodeMetadata(value.MetadataBytes)
+
 	return ProviderResult{
 		ContextID: value.ContextID,
-		Metadata:  value.Metadata,
+		Metadata:  metadata,
 		Provider: peer.AddrInfo{
 			ID:    value.ProviderID,
 			Addrs: addrs,

--- a/api/v0/finder/model/model_test.go
+++ b/api/v0/finder/model/model_test.go
@@ -19,7 +19,8 @@ func TestMarshal(t *testing.T) {
 	}
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	ctxID := []byte("test-context-id")
-	v := indexer.MakeValue(p, ctxID, 0, []byte(mhs[0]))
+	metadata := indexer.Metadata{0, []byte(mhs[0])}
+	v := indexer.Value{p, ctxID, metadata.Encode()}
 
 	// Masrhal request and check e2e
 	t.Log("e2e marshalling request")
@@ -48,9 +49,14 @@ func TestMarshal(t *testing.T) {
 		MultihashResults: make([]MultihashResult, 0),
 	}
 
+	metadata, err = indexer.DecodeMetadata(v.MetadataBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	providerResult := ProviderResult{
 		ContextID: v.ContextID,
-		Metadata:  v.Metadata,
+		Metadata:  metadata,
 		Provider: peer.AddrInfo{
 			ID:    p,
 			Addrs: []ma.Multiaddr{m1},

--- a/api/v0/ingest/client/http/ingest.go
+++ b/api/v0/ingest/client/http/ingest.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/model"
 	httpclient "github.com/filecoin-project/storetheindex/internal/httpclient"
 	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
@@ -103,8 +104,8 @@ func (c *Client) GetProvider(ctx context.Context, providerID peer.ID) (*model.Pr
 	return &providerInfo, nil
 }
 
-func (c *Client) IndexContent(ctx context.Context, providerID peer.ID, privateKey p2pcrypto.PrivKey, m multihash.Multihash, contextID []byte, protocol uint64, metadata []byte, addrs []string) error {
-	data, err := model.MakeIngestRequest(providerID, privateKey, m, contextID, protocol, metadata, addrs)
+func (c *Client) IndexContent(ctx context.Context, providerID peer.ID, privateKey p2pcrypto.PrivKey, m multihash.Multihash, contextID []byte, metadata indexer.Metadata, addrs []string) error {
+	data, err := model.MakeIngestRequest(providerID, privateKey, m, contextID, metadata, addrs)
 	if err != nil {
 		return err
 	}

--- a/api/v0/ingest/client/interface.go
+++ b/api/v0/ingest/client/interface.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/model"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -14,5 +15,5 @@ type Ingest interface {
 	GetProvider(ctx context.Context, providerID peer.ID) (*model.ProviderInfo, error)
 	ListProviders(ctx context.Context) ([]*model.ProviderInfo, error)
 	Register(ctx context.Context, providerID peer.ID, privateKey crypto.PrivKey, addrs []string) error
-	IndexContent(ctx context.Context, providerID peer.ID, privateKey crypto.PrivKey, m multihash.Multihash, contextID []byte, protocol uint64, metadata []byte, addrs []string) error
+	IndexContent(ctx context.Context, providerID peer.ID, privateKey crypto.PrivKey, m multihash.Multihash, contextID []byte, metadata indexer.Metadata, addrs []string) error
 }

--- a/api/v0/ingest/client/libp2p/client.go
+++ b/api/v0/ingest/client/libp2p/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/storetheindex/api/v0"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/model"
 	pb "github.com/filecoin-project/storetheindex/api/v0/ingest/pb"
@@ -104,8 +105,8 @@ func (c *Client) Register(ctx context.Context, providerID peer.ID, privateKey p2
 	return nil
 }
 
-func (c *Client) IndexContent(ctx context.Context, providerID peer.ID, privateKey p2pcrypto.PrivKey, m multihash.Multihash, contextID []byte, protocol uint64, metadata []byte, addrs []string) error {
-	data, err := model.MakeIngestRequest(providerID, privateKey, m, contextID, protocol, metadata, addrs)
+func (c *Client) IndexContent(ctx context.Context, providerID peer.ID, privateKey p2pcrypto.PrivKey, m multihash.Multihash, contextID []byte, metadata indexer.Metadata, addrs []string) error {
+	data, err := model.MakeIngestRequest(providerID, privateKey, m, contextID, metadata, addrs)
 	if err != nil {
 		return err
 	}

--- a/api/v0/ingest/model/ingest_request.go
+++ b/api/v0/ingest/model/ingest_request.go
@@ -56,12 +56,16 @@ func (r *IngestRequest) MarshalRecord() ([]byte, error) {
 }
 
 // MakeIngestRequest creates a signed IngestRequest and marshals it into bytes
-func MakeIngestRequest(providerID peer.ID, privateKey crypto.PrivKey, m multihash.Multihash, contextID []byte, protocol uint64, metadata []byte, addrs []string) ([]byte, error) {
+func MakeIngestRequest(providerID peer.ID, privateKey crypto.PrivKey, m multihash.Multihash, contextID []byte, metadata indexer.Metadata, addrs []string) ([]byte, error) {
 	req := &IngestRequest{
 		Multihash: m,
-		Value:     indexer.MakeValue(providerID, contextID, protocol, metadata),
-		Addrs:     addrs,
-		Seq:       peer.TimestampSeq(),
+		Value: indexer.Value{
+			ProviderID:    providerID,
+			ContextID:     contextID,
+			MetadataBytes: metadata.Encode(),
+		},
+		Addrs: addrs,
+		Seq:   peer.TimestampSeq(),
 	}
 
 	return makeRequestEnvelop(req, privateKey)

--- a/api/v0/ingest/model/ingest_request_test.go
+++ b/api/v0/ingest/model/ingest_request_test.go
@@ -14,7 +14,9 @@ func TestIngestRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	metadata := []byte("hello")
+	metadata := indexer.Metadata{
+		Data: []byte("hello"),
+	}
 
 	peerID, privKey, err := providerIdent.Decode()
 	if err != nil {
@@ -23,7 +25,7 @@ func TestIngestRequest(t *testing.T) {
 
 	ctxID := []byte("test-context-id")
 	address := "/ip4/127.0.0.1/tcp/7777"
-	data, err := MakeIngestRequest(peerID, privKey, mhs[0], ctxID, 0, metadata, []string{address})
+	data, err := MakeIngestRequest(peerID, privKey, mhs[0], ctxID, metadata, []string{address})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +35,7 @@ func TestIngestRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	value := indexer.MakeValue(peerID, ctxID, 0, metadata)
+	value := indexer.Value{peerID, ctxID, metadata.Encode()}
 
 	if !ingReq.Value.Equal(value) {
 		t.Fatal("value in request not same as original")

--- a/api/v0/ingest/schema/gen.go
+++ b/api/v0/ingest/schema/gen.go
@@ -78,7 +78,7 @@ func main() {
 		schema.SpawnStructField("PreviousID", "Link_Advertisement", true, false),
 		// Provider ID of the advertisement.
 		schema.SpawnStructField("Provider", "String", false, false),
-		// Addresses, as list of multiaddr strings, to use for content retrieval
+		// Addresses, as list of multiaddr strings, to use for content retrieval.
 		schema.SpawnStructField("Addresses", "List_String", false, false),
 		// Advertisement signature.
 		schema.SpawnStructField("Signature", "Bytes", false, false),
@@ -86,7 +86,7 @@ func main() {
 		schema.SpawnStructField("Entries", "Link", false, false),
 		// Context ID for entries.
 		schema.SpawnStructField("ContextID", "Bytes", false, false),
-		// Metadata for entries.
+		// Serialized indexer.Metadata for all entries in advertisement.
 		schema.SpawnStructField("Metadata", "Bytes", false, false),
 		// IsRm or Put?
 		schema.SpawnStructField("IsRm", "Bool", false, false),

--- a/api/v0/ingest/schema/utils.go
+++ b/api/v0/ingest/schema/utils.go
@@ -4,13 +4,14 @@ package schema
 import (
 	"context"
 
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/schema"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/multiformats/go-multicodec"
-	mh "github.com/multiformats/go-multihash"
+	"github.com/multiformats/go-multihash"
 )
 
 // Linkproto is the ipld.LinkProtocol used for the ingestion protocol.
@@ -24,7 +25,7 @@ var Linkproto = cidlink.LinkPrototype{
 	},
 }
 
-var mhCode = mh.Names["sha2-256"]
+var mhCode = multihash.Names["sha2-256"]
 
 // LinkContextKey used to propagate link info through the linkSystem context
 type LinkContextKey string
@@ -39,7 +40,7 @@ const (
 	IsAdKey = LinkContextKey("isAdLink")
 )
 
-func mhsToBytes(mhs []mh.Multihash) []_Bytes {
+func mhsToBytes(mhs []multihash.Multihash) []_Bytes {
 	out := make([]_Bytes, len(mhs))
 	for i := range mhs {
 		out[i] = _Bytes{x: mhs[i]}
@@ -66,19 +67,19 @@ func (l Advertisement) LinkContext(ctx context.Context) ipld.LinkContext {
 
 // NewListOfMhs is a convenient method to create a new list of bytes
 // from a list of multihashes that may be consumed by a linksystem.
-func NewListOfMhs(lsys ipld.LinkSystem, mhs []mh.Multihash) (ipld.Link, error) {
+func NewListOfMhs(lsys ipld.LinkSystem, mhs []multihash.Multihash) (ipld.Link, error) {
 	cStr := &_List_Bytes{x: mhsToBytes(mhs)}
 	return lsys.Store(ipld.LinkContext{}, Linkproto, cStr)
 }
 
 // NewListBytesFromMhs converts multihashes to a list of bytes
-func NewListBytesFromMhs(mhs []mh.Multihash) List_Bytes {
+func NewListBytesFromMhs(mhs []multihash.Multihash) List_Bytes {
 	return &_List_Bytes{x: mhsToBytes(mhs)}
 }
 
 // NewLinkedListOfMhs creates a new element of a linked list that
 // can be used to paginate large lists.
-func NewLinkedListOfMhs(lsys ipld.LinkSystem, mhs []mh.Multihash, next ipld.Link) (ipld.Link, EntryChunk, error) {
+func NewLinkedListOfMhs(lsys ipld.LinkSystem, mhs []multihash.Multihash, next ipld.Link) (ipld.Link, EntryChunk, error) {
 	cStr := &_EntryChunk{
 		Entries: _List_Bytes{x: mhsToBytes(mhs)},
 	}
@@ -100,7 +101,7 @@ func NewAdvertisement(
 	previousID Link_Advertisement,
 	entries ipld.Link,
 	contextID []byte,
-	metadata []byte,
+	metadata indexer.Metadata,
 	isRm bool,
 	provider string,
 	addrs []string) (Advertisement, error) {
@@ -118,7 +119,7 @@ func NewAdvertisementWithLink(
 	previousID Link_Advertisement,
 	entries ipld.Link,
 	contextID []byte,
-	metadata []byte,
+	metadata indexer.Metadata,
 	isRm bool,
 	provider string,
 	addrs []string) (Advertisement, Link_Advertisement, error) {
@@ -156,7 +157,7 @@ func NewAdvertisementWithFakeSig(
 	previousID Link_Advertisement,
 	entries ipld.Link,
 	contextID []byte,
-	metadata []byte,
+	metadata indexer.Metadata,
 	isRm bool,
 	provider string,
 	addrs []string) (Advertisement, Link_Advertisement, error) {
@@ -169,7 +170,7 @@ func NewAdvertisementWithFakeSig(
 			Addresses:  GoToIpldStrings(addrs),
 			Entries:    _Link{x: entries},
 			ContextID:  _Bytes{x: contextID},
-			Metadata:   _Bytes{x: metadata},
+			Metadata:   _Bytes{x: metadata.Encode()},
 			IsRm:       _Bool{x: isRm},
 		}
 	} else {
@@ -179,7 +180,7 @@ func NewAdvertisementWithFakeSig(
 			Addresses:  GoToIpldStrings(addrs),
 			Entries:    _Link{x: entries},
 			ContextID:  _Bytes{x: contextID},
-			Metadata:   _Bytes{x: metadata},
+			Metadata:   _Bytes{x: metadata.Encode()},
 			IsRm:       _Bool{x: isRm},
 		}
 	}
@@ -202,7 +203,7 @@ func newAdvertisement(
 	previousID Link_Advertisement,
 	entries ipld.Link,
 	contextID []byte,
-	metadata []byte,
+	metadata indexer.Metadata,
 	isRm bool,
 	provider string,
 	addrs []string) (Advertisement, error) {
@@ -215,7 +216,7 @@ func newAdvertisement(
 			Addresses:  GoToIpldStrings(addrs),
 			Entries:    _Link{x: entries},
 			ContextID:  _Bytes{x: contextID},
-			Metadata:   _Bytes{x: metadata},
+			Metadata:   _Bytes{x: metadata.Encode()},
 			IsRm:       _Bool{x: isRm},
 		}
 	} else {
@@ -225,7 +226,7 @@ func newAdvertisement(
 			Addresses:  GoToIpldStrings(addrs),
 			Entries:    _Link{x: entries},
 			ContextID:  _Bytes{x: contextID},
-			Metadata:   _Bytes{x: metadata},
+			Metadata:   _Bytes{x: metadata.Encode()},
 			IsRm:       _Bool{x: isRm},
 		}
 	}

--- a/api/v0/ingest/schema/utils_test.go
+++ b/api/v0/ingest/schema/utils_test.go
@@ -12,7 +12,7 @@ import (
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/test"
-	mh "github.com/multiformats/go-multihash"
+	"github.com/multiformats/go-multihash"
 
 	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -38,20 +38,17 @@ func mkLinkSystem(ds datastore.Batching) ipld.LinkSystem {
 	return lsys
 }
 
-func genCidsAndAdv(t *testing.T, lsys ipld.LinkSystem,
-	priv crypto.PrivKey,
-	previous Link_Advertisement) ([]mh.Multihash, ipld.Link, Advertisement, Link_Advertisement) {
-
+func genCidsAndAdv(t *testing.T, lsys ipld.LinkSystem, priv crypto.PrivKey, previous Link_Advertisement) ([]multihash.Multihash, ipld.Link, Advertisement, Link_Advertisement) {
+	mhs, _ := util.RandomMultihashes(10)
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	ctxID := []byte("test-context-id")
+	metadata := indexer.Metadata{0, mhs[0]}
 	addr := "/ip4/127.0.0.1/tcp/9999"
-	mhs, _ := util.RandomMultihashes(10)
-	val := indexer.MakeValue(p, ctxID, 0, mhs[0])
 	cidsLnk, err := NewListOfMhs(lsys, mhs)
 	if err != nil {
 		t.Fatal(err)
 	}
-	adv, advLnk, err := NewAdvertisementWithLink(lsys, priv, previous, cidsLnk, val.ContextID, val.Metadata, false, p.String(), []string{addr})
+	adv, advLnk, err := NewAdvertisementWithLink(lsys, priv, previous, cidsLnk, ctxID, metadata, false, p.String(), []string{addr})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.2.0
+	github.com/filecoin-project/go-indexer-core v0.2.1
 	github.com/filecoin-project/go-legs v0.0.0-20210922204025-c6f68b62ab16
 	github.com/gammazero/keymutex v0.0.0-20211002043844-c7ebad3e5479
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/filecoin-project/go-data-transfer v1.6.1-0.20210608092034-e4f40bc3a68
 github.com/filecoin-project/go-data-transfer v1.6.1-0.20210608092034-e4f40bc3a685/go.mod h1:We59IRN/nAgBSzgm3enBz4UeWNlsdqvTaJdvSbuOfL8=
 github.com/filecoin-project/go-ds-versioning v0.1.0 h1:y/X6UksYTsK8TLCI7rttCKEvl8btmWxyFMEeeWGUxIQ=
 github.com/filecoin-project/go-ds-versioning v0.1.0/go.mod h1:mp16rb4i2QPmxBnmanUx8i/XANp+PFCCJWiAb+VW4/s=
-github.com/filecoin-project/go-indexer-core v0.2.0 h1:I3mtrTLH6aXOkbxsjRKv3rn8tLgoa6vIYl8XuBNRDik=
-github.com/filecoin-project/go-indexer-core v0.2.0/go.mod h1:CsD+HUiCB+lwL+mxXPKQCsqoA9fezXTheU7IjsFohCU=
+github.com/filecoin-project/go-indexer-core v0.2.1 h1:FPswgEvxwnhQvUv6sVo8A6iSZfjZePvPMDrVP8Wwcxo=
+github.com/filecoin-project/go-indexer-core v0.2.1/go.mod h1:7W28PVPHx5afq1HKUJUPPK2q5hP0aUppoEBOobXDghg=
 github.com/filecoin-project/go-legs v0.0.0-20210922204025-c6f68b62ab16 h1:xFiCa75M7kjr9/AfaVvFNjJKsMgtIP25g+DXKx4Ub7A=
 github.com/filecoin-project/go-legs v0.0.0-20210922204025-c6f68b62ab16/go.mod h1:qLH/nW+bQoOmnLG4eGU36vubv0MmAezQ2Y2FQBa1hM8=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -290,12 +290,12 @@ func publishRandomIndexAndAdv(t *testing.T, pub legs.LegPublisher, lsys ipld.Lin
 	require.NoError(t, err)
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	ctxID := []byte("test-context-id")
+	metadata := indexer.Metadata{0, mhs[0]}
 	addrs := []string{"/ip4/127.0.0.1/tcp/9999"}
-	val := indexer.MakeValue(p, ctxID, 0, mhs[0])
 	mhsLnk, mhs := newRandomLinkedList(t, lsys, 3)
-	_, advLnk, err := schema.NewAdvertisementWithLink(lsys, priv, nil, mhsLnk, val.ContextID, val.Metadata, false, p.String(), addrs)
+	_, advLnk, err := schema.NewAdvertisementWithLink(lsys, priv, nil, mhsLnk, ctxID, metadata, false, p.String(), addrs)
 	if fakeSig {
-		_, advLnk, err = schema.NewAdvertisementWithFakeSig(lsys, priv, nil, mhsLnk, val.ContextID, val.Metadata, false, p.String(), addrs)
+		_, advLnk, err = schema.NewAdvertisementWithFakeSig(lsys, priv, nil, mhsLnk, ctxID, metadata, false, p.String(), addrs)
 	}
 	require.NoError(t, err)
 	lnk, err := advLnk.AsLink()

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -230,7 +230,7 @@ func (i *legIngester) processEntries(adCid cid.Cid, p peer.ID, nentries ipld.Nod
 	if err != nil {
 		return err
 	}
-	metadata, err := ad.FieldMetadata().AsBytes()
+	metadataBytes, err := ad.FieldMetadata().AsBytes()
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,14 @@ func (i *legIngester) processEntries(adCid cid.Cid, p peer.ID, nentries ipld.Nod
 		return err
 	}
 
-	value := indexer.MakeValue(p, contextID, 0, metadata)
+	// Check for valud metadata
+	_, err = indexer.DecodeMetadata(metadataBytes)
+	if err != nil {
+		log.Errorf("Error decoding metadata: %s", err)
+		return err
+	}
+
+	value := indexer.Value{p, contextID, metadataBytes}
 
 	var putChan, removeChan chan multihash.Multihash
 	var errChan <-chan error

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -132,7 +132,7 @@ func (h *adminHandler) importManifest(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	go importer.ReadManifest(ctx, file, out, errOut)
 
-	value := indexer.MakeValue(provID, contextID, 0, nil)
+	value := indexer.Value{provID, contextID, indexer.Metadata{}.Encode()}
 	batchErr := batchIndexerEntries(batchSize, out, value, h.indexer)
 	err = <-batchErr
 	if err != nil {
@@ -182,7 +182,7 @@ func (h *adminHandler) importCidList(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	go importer.ReadCids(ctx, file, out, errOut)
 
-	value := indexer.MakeValue(provID, contextID, 0, nil)
+	value := indexer.Value{provID, contextID, indexer.Metadata{}.Encode()}
 	batchErr := batchIndexerEntries(batchSize, out, value, h.indexer)
 	err = <-batchErr
 	if err != nil {

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -100,7 +100,8 @@ func FindIndexTest(ctx context.Context, t *testing.T, c client.Finder, ind index
 		t.Fatal(err)
 	}
 	ctxID := []byte("test-context-id")
-	v := indexer.MakeValue(p, ctxID, 0, []byte(mhs[0]))
+	metadata := indexer.Metadata{0, []byte(mhs[0])}
+	v := indexer.Value{p, ctxID, metadata.Encode()}
 	PopulateIndex(ind, mhs[:10], v, t)
 
 	a, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/9999")

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -117,14 +117,14 @@ func TestIndexContent(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctxID := []byte("test-context-id")
-	metadata := []byte("hello world")
+	metadata := indexer.Metadata{0, []byte("hello world")}
 
 	peerID, privKey, err := ident.Decode()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	data, err := model.MakeIngestRequest(peerID, privKey, m, ctxID, 0, metadata, nil)
+	data, err := model.MakeIngestRequest(peerID, privKey, m, ctxID, metadata, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -162,9 +162,9 @@ func IndexContent(t *testing.T, cl client.Ingest, providerID peer.ID, privateKey
 	}
 
 	contextID := []byte("test-context-id")
-	metadata := []byte("hello")
+	metadata := indexer.Metadata{0, []byte("hello")}
 
-	err = cl.IndexContent(ctx, providerID, privateKey, mhs[0], contextID, 0, metadata, nil)
+	err = cl.IndexContent(ctx, providerID, privateKey, mhs[0], contextID, metadata, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,7 +180,7 @@ func IndexContent(t *testing.T, cl client.Ingest, providerID peer.ID, privateKey
 		t.Fatal("no content values returned")
 	}
 
-	expectValue := indexer.MakeValue(providerID, contextID, 0, metadata)
+	expectValue := indexer.Value{providerID, contextID, metadata.Encode()}
 	ok = false
 	for i := range vals {
 		if vals[i].Equal(expectValue) {
@@ -203,10 +203,10 @@ func IndexContentNewAddr(t *testing.T, cl client.Ingest, providerID peer.ID, pri
 	}
 
 	ctxID := []byte("test-context-id")
-	metadata := []byte("hello")
+	metadata := indexer.Metadata{0, []byte("hello")}
 	addrs := []string{newAddr}
 
-	err = cl.IndexContent(ctx, providerID, privateKey, mhs[0], ctxID, 0, metadata, addrs)
+	err = cl.IndexContent(ctx, providerID, privateKey, mhs[0], ctxID, metadata, addrs)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Instead of passing a protocol ID and a byte slice, or an ID encoded into a byte slice, storetheindex APIs use a `indexer.Metadata` type that has explicit `ProtocolID` and `Data` members.