### PR TITLE
Remove indexed content by context ID

### DIFF
--- a/api/v0/ingest/model/provider_info.go
+++ b/api/v0/ingest/model/provider_info.go
@@ -7,22 +7,21 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-// ProviderData aggregates provider-related data that wants to
-// be added in a response
+// ProviderData describes a provider.
 type ProviderInfo struct {
-	AddrInfo      peer.AddrInfo
-	LastIndex     cid.Cid `json:",omitempty"`
-	LastIndexTime string  `json:",omitempty"`
+	AddrInfo              peer.AddrInfo
+	LastAdvertisement     cid.Cid `json:",omitempty"`
+	LastAdvertisementTime string  `json:",omitempty"`
 }
 
-func MakeProviderInfo(addrInfo peer.AddrInfo, lastIndex cid.Cid, lastIndexTime time.Time) ProviderInfo {
+func MakeProviderInfo(addrInfo peer.AddrInfo, lastAd cid.Cid, lastAdTime time.Time) ProviderInfo {
 	pinfo := ProviderInfo{
-		AddrInfo:  addrInfo,
-		LastIndex: lastIndex,
+		AddrInfo:          addrInfo,
+		LastAdvertisement: lastAd,
 	}
 
-	if lastIndex.Defined() {
-		pinfo.LastIndexTime = iso8601(lastIndexTime)
+	if lastAd != cid.Undef && !lastAdTime.IsZero() {
+		pinfo.LastAdvertisementTime = iso8601(lastAdTime)
 	}
 	return pinfo
 }

--- a/api/v0/ingest/schema/utils.go
+++ b/api/v0/ingest/schema/utils.go
@@ -167,27 +167,18 @@ func NewAdvertisementWithFakeSig(
 		return nil, nil, err
 	}
 
-	var ad Advertisement
-	if previousID != nil {
-		ad = &_Advertisement{
-			PreviousID: _Link_Advertisement__Maybe{m: schema.Maybe_Value, v: *previousID},
-			Provider:   _String{x: provider},
-			Addresses:  GoToIpldStrings(addrs),
-			Entries:    _Link{x: entries},
-			ContextID:  _Bytes{x: contextID},
-			Metadata:   _Bytes{x: encMetadata},
-			IsRm:       _Bool{x: isRm},
-		}
+	ad := &_Advertisement{
+		Provider:  _String{x: provider},
+		Addresses: GoToIpldStrings(addrs),
+		Entries:   _Link{x: entries},
+		ContextID: _Bytes{x: contextID},
+		Metadata:  _Bytes{x: encMetadata},
+		IsRm:      _Bool{x: isRm},
+	}
+	if previousID == nil {
+		ad.PreviousID = _Link_Advertisement__Maybe{m: schema.Maybe_Absent}
 	} else {
-		ad = &_Advertisement{
-			PreviousID: _Link_Advertisement__Maybe{m: schema.Maybe_Absent},
-			Provider:   _String{x: provider},
-			Addresses:  GoToIpldStrings(addrs),
-			Entries:    _Link{x: entries},
-			ContextID:  _Bytes{x: contextID},
-			Metadata:   _Bytes{x: encMetadata},
-			IsRm:       _Bool{x: isRm},
-		}
+		ad.PreviousID = _Link_Advertisement__Maybe{m: schema.Maybe_Value, v: *previousID}
 	}
 
 	// Add signature
@@ -218,27 +209,18 @@ func newAdvertisement(
 		return nil, err
 	}
 
-	var ad Advertisement
-	if previousID != nil {
-		ad = &_Advertisement{
-			PreviousID: _Link_Advertisement__Maybe{m: schema.Maybe_Value, v: *previousID},
-			Provider:   _String{x: provider},
-			Addresses:  GoToIpldStrings(addrs),
-			Entries:    _Link{x: entries},
-			ContextID:  _Bytes{x: contextID},
-			Metadata:   _Bytes{x: encMetadata},
-			IsRm:       _Bool{x: isRm},
-		}
+	ad := &_Advertisement{
+		Provider:  _String{x: provider},
+		Addresses: GoToIpldStrings(addrs),
+		Entries:   _Link{x: entries},
+		ContextID: _Bytes{x: contextID},
+		Metadata:  _Bytes{x: encMetadata},
+		IsRm:      _Bool{x: isRm},
+	}
+	if previousID == nil {
+		ad.PreviousID = _Link_Advertisement__Maybe{m: schema.Maybe_Absent}
 	} else {
-		ad = &_Advertisement{
-			PreviousID: _Link_Advertisement__Maybe{m: schema.Maybe_Absent},
-			Provider:   _String{x: provider},
-			Addresses:  GoToIpldStrings(addrs),
-			Entries:    _Link{x: entries},
-			ContextID:  _Bytes{x: contextID},
-			Metadata:   _Bytes{x: encMetadata},
-			IsRm:       _Bool{x: isRm},
-		}
+		ad.PreviousID = _Link_Advertisement__Maybe{m: schema.Maybe_Value, v: *previousID}
 	}
 
 	// Sign advertisement

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -77,7 +77,8 @@ func (e *e2eTestRunner) start(prog string, args ...string) *exec.Cmd {
 					close(e.indexerReady)
 				}
 			case "provider":
-				if strings.Contains(line, "Connected successfully to peer") {
+				line = strings.ToLower(line)
+				if strings.Contains(line, "connected to peer successfully") {
 					close(e.providerHasPeer)
 				} else if strings.Contains(line, "admin http server listening") {
 					close(e.providerReady)
@@ -108,10 +109,7 @@ func (e *e2eTestRunner) stop(cmd *exec.Cmd, timeout time.Duration) {
 		err := cmd.Process.Kill()
 		qt.Assert(e.t, err, qt.IsNil)
 	case err := <-waitErr:
-		_ = err
-		// TODO: uncomment once the daemons stop with ^C without erroring.
-		// See: https://github.com/filecoin-project/indexer-reference-provider/issues/61
-		// qt.Assert(e.t, err, qt.IsNil)
+		qt.Assert(e.t, err, qt.IsNil)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.2.3
+	github.com/filecoin-project/go-indexer-core v0.2.4
 	github.com/filecoin-project/go-legs v0.0.0-20211013165050-9ab325b6d2eb
 	github.com/frankban/quicktest v1.14.0
 	github.com/gammazero/keymutex v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/filecoin-project/go-data-transfer v1.10.1 h1:YQNLwhizxkdfFxegAyrnn3l7
 github.com/filecoin-project/go-data-transfer v1.10.1/go.mod h1:CSDMCrPK2lVGodNB1wPEogjFvM9nVGyiL1GNbBRTSdw=
 github.com/filecoin-project/go-ds-versioning v0.1.0 h1:y/X6UksYTsK8TLCI7rttCKEvl8btmWxyFMEeeWGUxIQ=
 github.com/filecoin-project/go-ds-versioning v0.1.0/go.mod h1:mp16rb4i2QPmxBnmanUx8i/XANp+PFCCJWiAb+VW4/s=
-github.com/filecoin-project/go-indexer-core v0.2.3 h1:kaUL2r8CuihK53lhmtCScffb7Bzs+N1yRGpwvxzCN+U=
-github.com/filecoin-project/go-indexer-core v0.2.3/go.mod h1:MSe5aRWmfRB+5syR4yDV+OApgJU+MUJ4rl9VUuzwCfc=
+github.com/filecoin-project/go-indexer-core v0.2.4 h1:90vvxoBeNZN+h4W+vZ+VsoxKaDBr/bfZJJNByapGeM0=
+github.com/filecoin-project/go-indexer-core v0.2.4/go.mod h1:MSe5aRWmfRB+5syR4yDV+OApgJU+MUJ4rl9VUuzwCfc=
 github.com/filecoin-project/go-legs v0.0.0-20211013165050-9ab325b6d2eb h1:MtGtPWYwdCtfRDJnsnaZmI2guxZ5Tw6c/Dkq8j5kqaI=
 github.com/filecoin-project/go-legs v0.0.0-20211013165050-9ab325b6d2eb/go.mod h1:lKwBnslfNGG7JnsP9uQZl3yK7f74fit1MyHcwuuOP3k=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=

--- a/internal/handler/ingest_handler.go
+++ b/internal/handler/ingest_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/model"
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	"github.com/filecoin-project/storetheindex/internal/syserr"
+	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -68,7 +69,7 @@ func (h *IngestHandler) ListProviders() ([]byte, error) {
 
 	responses := make([]model.ProviderInfo, len(infos))
 	for i := range infos {
-		responses[i] = model.MakeProviderInfo(infos[i].AddrInfo, infos[i].LastIndex, infos[i].LastIndexTime)
+		responses[i] = model.MakeProviderInfo(infos[i].AddrInfo, infos[i].LastAdvertisement, infos[i].LastAdvertisementTime)
 	}
 
 	return json.Marshal(responses)
@@ -80,7 +81,7 @@ func (h *IngestHandler) GetProvider(providerID peer.ID) ([]byte, error) {
 		return nil, nil
 	}
 
-	rsp := model.MakeProviderInfo(info.AddrInfo, info.LastIndex, info.LastIndexTime)
+	rsp := model.MakeProviderInfo(info.AddrInfo, info.LastAdvertisement, info.LastAdvertisementTime)
 
 	return json.Marshal(&rsp)
 }
@@ -99,7 +100,7 @@ func (h *IngestHandler) IndexContent(data []byte) error {
 	}
 
 	// Register provider if not registered, or update addreses if already registered
-	err = h.registry.RegisterOrUpdate(ingReq.ProviderID, ingReq.Addrs)
+	err = h.registry.RegisterOrUpdate(ingReq.ProviderID, ingReq.Addrs, cid.Undef)
 	if err != nil {
 		return err
 	}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -104,7 +104,8 @@ func NewLegIngester(ctx context.Context, cfg config.Ingest, h host.Host,
 	return li, nil
 }
 
-// metricsUpdate periodically updates certains metrics
+// metricsUpdate periodically updates metrics.  This goroutine exits when the
+// sigUpdate channel is closed, when Close is called.
 func (li *legIngester) metricsUpdater() {
 	var hasUpdate bool
 	t := time.NewTimer(time.Minute)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -55,6 +55,7 @@ type legIngester struct {
 	sublk *keymutex.KeyMutex
 
 	batchSize int
+	sigUpdate chan struct{}
 }
 
 // subscriber datastructure for a peer.
@@ -91,37 +92,70 @@ func NewLegIngester(ctx context.Context, cfg config.Ingest, h host.Host,
 		subs:      make(map[peer.ID]*subscriber),
 		sublk:     keymutex.New(0),
 		batchSize: cfg.StoreBatchSize,
+		sigUpdate: make(chan struct{}, 1),
 	}
 
 	// Register storage hook to index data as we receive it.
 	lms.GraphSync().RegisterIncomingBlockHook(li.storageHook())
 	log.Debugf("LegIngester started and all hooks and linksystem registered")
+
+	go li.metricsUpdater()
+
 	return li, nil
 }
 
+// metricsUpdate periodically updates certains metrics
+func (li *legIngester) metricsUpdater() {
+	var hasUpdate bool
+	t := time.NewTimer(time.Minute)
+
+	for {
+		select {
+		case _, ok := <-li.sigUpdate:
+			if !ok {
+				return
+			}
+			hasUpdate = true
+		case <-t.C:
+			if hasUpdate {
+				// Update value store size metric after sync.
+				size, err := li.indexer.Size()
+				if err != nil {
+					log.Errorf("Error getting indexer value store size: %s", err)
+					return
+				}
+				stats.Record(context.Background(), coremetrics.StoreSize.M(size))
+				hasUpdate = false
+			}
+			t.Reset(time.Minute)
+		}
+	}
+}
+
 // Sync with a data provider up to latest ID.
-func (i *legIngester) Sync(ctx context.Context, peerID peer.ID, opts ...SyncOption) (<-chan multihash.Multihash, error) {
+func (li *legIngester) Sync(ctx context.Context, peerID peer.ID, opts ...SyncOption) (<-chan multihash.Multihash, error) {
 	log.Debugf("Syncing with peer %s", peerID)
 	// Check latest sync for provider.
-	c, err := i.getLatestAdvID(ctx, peerID)
+	c, err := li.getLatestAdvID(ctx, peerID)
 	if err != nil {
 		log.Errorf("Error getting latest advertisement for sync: %s", err)
 		return nil, err
 	}
 
-	// Check if we already have the advertisement.
-	adv, err := i.ds.Get(datastore.NewKey(c.String()))
+	// Check if the advertisement is already stored.
+	adv, err := li.ds.Get(datastore.NewKey(c.String()))
 	if err != nil && err != datastore.ErrNotFound {
 		log.Errorf("Error fetching advertisement from datastore: %s", err)
 		return nil, err
 	}
-	// If we have the advertisement do nothing, we already synced
+	// Advertisement already stored; do nothing, already synced.
 	if adv != nil {
 		log.Debugf("Alredy synced with provider %s", peerID)
 		return nil, nil
 	}
+
 	// Get subscriber for peer or create a new one
-	sub, err := i.newPeerSubscriber(ctx, peerID)
+	sub, err := li.newPeerSubscriber(ctx, peerID)
 	if err != nil {
 		log.Errorf("Error getting a subscriber instance for provider: %s", err)
 		return nil, err
@@ -151,12 +185,12 @@ func (i *legIngester) Sync(ctx context.Context, peerID peer.ID, opts ...SyncOpti
 	// Listen when the sync is done to update latestSync and notify the
 	// channel. No need to pass ctx here, because if ctx is canceled, then
 	// watcher is closed.
-	go i.listenSyncUpdate(peerID, watcher, cncl, out)
+	go li.listenSyncUpdate(peerID, watcher, cncl, out)
 	return out, nil
 }
 
-func (i *legIngester) getLatestAdvID(ctx context.Context, peerID peer.ID) (cid.Cid, error) {
-	client, err := i.newClient(ctx, i.host, peerID)
+func (li *legIngester) getLatestAdvID(ctx context.Context, peerID peer.ID) (cid.Cid, error) {
+	client, err := li.newClient(ctx, li.host, peerID)
 	if err != nil {
 		log.Errorf("Error creating new libp2p provider client in ingester: %s", err)
 		return cid.Undef, err
@@ -171,10 +205,10 @@ func (i *legIngester) getLatestAdvID(ctx context.Context, peerID peer.ID) (cid.C
 }
 
 // Subscribe to advertisements of a specific provider in the pubsub channel.
-func (i *legIngester) Subscribe(ctx context.Context, peerID peer.ID) error {
+func (li *legIngester) Subscribe(ctx context.Context, peerID peer.ID) error {
 	log.Infow("Subscribing to advertisement pub-sub channel", "host_id", peerID)
 	sctx, cancel := context.WithCancel(ctx)
-	sub, err := i.newPeerSubscriber(sctx, peerID)
+	sub, err := li.newPeerSubscriber(sctx, peerID)
 	if err != nil {
 		log.Errorf("Error getting a subscriber instance for provider: %s", err)
 		cancel()
@@ -193,20 +227,20 @@ func (i *legIngester) Subscribe(ctx context.Context, peerID peer.ID) error {
 	sub.cncl = cancelFunc(cncl, cancel)
 
 	// Listen updates persist latestSync when sync is done.
-	go i.listenSubUpdates(sub)
+	go li.listenSubUpdates(sub)
 	return nil
 }
 
-func (i *legIngester) listenSubUpdates(sub *subscriber) {
+func (li *legIngester) listenSubUpdates(sub *subscriber) {
 	for c := range sub.watcher {
 		// Persist the latest sync
-		if err := i.putLatestSync(sub.peerID, c); err != nil {
+		if err := li.putLatestSync(sub.peerID, c); err != nil {
 			log.Errorf("Error persisting latest sync: %s", err)
 		}
 	}
 }
 
-func (i *legIngester) listenSyncUpdate(peerID peer.ID, watcher <-chan cid.Cid, cncl context.CancelFunc, out chan<- multihash.Multihash) {
+func (li *legIngester) listenSyncUpdate(peerID peer.ID, watcher <-chan cid.Cid, cncl context.CancelFunc, out chan<- multihash.Multihash) {
 	defer func() {
 		cncl()
 		close(out)
@@ -218,31 +252,24 @@ func (i *legIngester) listenSyncUpdate(peerID peer.ID, watcher <-chan cid.Cid, c
 	c, ok := <-watcher
 	if ok {
 		// Persist the latest sync
-		err := i.putLatestSync(peerID, c)
+		err := li.putLatestSync(peerID, c)
 		if err != nil {
 			log.Errorf("Error persisting latest sync: %s", err)
 		}
 		out <- c.Hash()
 
-		// Update value store size metric after sync.
-		size, err := i.indexer.Size()
-		if err != nil {
-			log.Errorf("Error getting indexer value store size: %s", err)
-			return
-		}
-		stats.Record(context.Background(),
-			metrics.SyncLatency.M(coremetrics.MsecSince(startTime)),
-			coremetrics.StoreSize.M(size))
+		stats.Record(context.Background(), metrics.SyncLatency.M(coremetrics.MsecSince(startTime)))
+		li.sigUpdate <- struct{}{}
 	}
 }
 
 // Unsubscribe to stop listening to advertisement from a specific provider.
-func (i *legIngester) Unsubscribe(ctx context.Context, peerID peer.ID) error {
+func (li *legIngester) Unsubscribe(ctx context.Context, peerID peer.ID) error {
 	log.Debugf("Unsubscribing from provider %s", peerID)
-	i.sublk.Lock(string(peerID))
-	defer i.sublk.Unlock(string(peerID))
+	li.sublk.Lock(string(peerID))
+	defer li.sublk.Unlock(string(peerID))
 	// Check if subscriber exists.
-	sub, ok := i.subs[peerID]
+	sub, ok := li.subs[peerID]
 	if !ok {
 		log.Infof("Not subscribed to provider %s. Nothing to do", peerID)
 		// If not we have nothing to do.
@@ -256,24 +283,24 @@ func (i *legIngester) Unsubscribe(ctx context.Context, peerID peer.ID) error {
 		sub.cncl()
 	}
 	// Delete from map
-	delete(i.subs, peerID)
+	delete(li.subs, peerID)
 	log.Infof("Unsubscribed from provider %s successfully", peerID)
 
 	return nil
 }
 
 // Creates a new subscriber for a peer according to its latest sync.
-func (i *legIngester) newPeerSubscriber(ctx context.Context, peerID peer.ID) (*subscriber, error) {
-	i.sublk.Lock(string(peerID))
-	defer i.sublk.Unlock(string(peerID))
-	sub, ok := i.subs[peerID]
+func (li *legIngester) newPeerSubscriber(ctx context.Context, peerID peer.ID) (*subscriber, error) {
+	li.sublk.Lock(string(peerID))
+	defer li.sublk.Unlock(string(peerID))
+	sub, ok := li.subs[peerID]
 	// If there is already a subscriber for the peer, do nothing.
 	if ok {
 		return sub, nil
 	}
 
 	// See if we already synced with this peer.
-	c, err := i.getLatestSync(peerID)
+	c, err := li.getLatestSync(peerID)
 	if err != nil {
 		return nil, err
 	}
@@ -284,10 +311,10 @@ func (i *legIngester) newPeerSubscriber(ctx context.Context, peerID peer.ID) (*s
 	// If not synced start a brand new subscriber
 	var ls legs.LegSubscriber
 	if c == cid.Undef {
-		ls, err = i.lms.NewSubscriber(legs.FilterPeerPolicy(peerID))
+		ls, err = li.lms.NewSubscriber(legs.FilterPeerPolicy(peerID))
 	} else {
 		// If yes, start a partially synced subscriber.
-		ls, err = i.lms.NewSubscriberPartiallySynced(legs.FilterPeerPolicy(peerID), c)
+		ls, err = li.lms.NewSubscriberPartiallySynced(legs.FilterPeerPolicy(peerID), c)
 	}
 	if err != nil {
 		return nil, err
@@ -296,25 +323,27 @@ func (i *legIngester) newPeerSubscriber(ctx context.Context, peerID peer.ID) (*s
 		peerID: peerID,
 		ls:     ls,
 	}
-	i.subs[peerID] = sub
+	li.subs[peerID] = sub
 	return sub, nil
 }
 
-func (i *legIngester) Close(ctx context.Context) error {
+func (li *legIngester) Close(ctx context.Context) error {
 	// Unsubscribe from all peers
-	for k := range i.subs {
-		err := i.Unsubscribe(ctx, k)
+	for k := range li.subs {
+		err := li.Unsubscribe(ctx, k)
 		if err != nil {
 			return err
 		}
 	}
 	// Close leg transport.
-	return i.lms.Close(ctx)
+	err := li.lms.Close(ctx)
+	close(li.sigUpdate)
+	return err
 }
 
 // Get the latest cid synced for the peer.
-func (i *legIngester) getLatestSync(peerID peer.ID) (cid.Cid, error) {
-	b, err := i.ds.Get(datastore.NewKey(syncPrefix + peerID.String()))
+func (li *legIngester) getLatestSync(peerID peer.ID) (cid.Cid, error) {
+	b, err := li.ds.Get(datastore.NewKey(syncPrefix + peerID.String()))
 	if err != nil {
 		if err == datastore.ErrNotFound {
 			return cid.Undef, nil
@@ -326,7 +355,7 @@ func (i *legIngester) getLatestSync(peerID peer.ID) (cid.Cid, error) {
 }
 
 // Tracks latest sync for a specific peer.
-func (i *legIngester) putLatestSync(peerID peer.ID, c cid.Cid) error {
+func (li *legIngester) putLatestSync(peerID peer.ID, c cid.Cid) error {
 	// Do not save if empty CIDs are received. Closing the channel
 	// may lead to receiving empty CIDs.
 	if c == cid.Undef {
@@ -336,7 +365,7 @@ func (i *legIngester) putLatestSync(peerID peer.ID, c cid.Cid) error {
 		stats.WithTags(tag.Insert(metrics.Method, "libp2p2")),
 		stats.WithMeasurements(metrics.IngestChange.M(1)))
 
-	return i.ds.Put(datastore.NewKey(syncPrefix+peerID.String()), c.Bytes())
+	return li.ds.Put(datastore.NewKey(syncPrefix+peerID.String()), c.Bytes())
 }
 
 // cancelfunc for subscribers. Combines context cancel and LegSubscriber

--- a/server/finder/http/options.go
+++ b/server/finder/http/options.go
@@ -10,7 +10,7 @@ const (
 	apiReadTimeout  = 30 * time.Second
 )
 
-// Options is a structure containing all the options that can be used when constructing an http server
+// serverConfig is a structure containing all the options that can be used when constructing an http server
 type serverConfig struct {
 	apiWriteTimeout time.Duration
 	apiReadTimeout  time.Duration
@@ -27,7 +27,7 @@ var serverDefaults = func(o *serverConfig) error {
 	return nil
 }
 
-// apply applies the given options to this Option
+// apply applies the given options to this config
 func (c *serverConfig) apply(opts ...ServerOption) error {
 	err := serverDefaults(c)
 	if err != nil {


### PR DESCRIPTION
When a remove advertisement does not contain a list of entries, then remove all entries that have the context ID specified by the advertisement.

Other changes included:
- Update last advertisement in registry
- Record last contact time for each provider in registry (in prep for polling)
- Periodically update storage size metric
- Simplify batch update logic (only need to do remove or put, not both)
- Do not use "i" as the name of a receiver
- Provider info API returns LastAdvertisement instead of LastIndex
- Misc. code cleanup