### PR TITLE
Recognize absolute paths in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-// Config is used to load storetheindex config files
+// Config is used to load config files.
 type Config struct {
 	Identity  Identity  // peer identity
 	Addresses Addresses // addresses to listen on
@@ -20,11 +20,11 @@ type Config struct {
 }
 
 const (
-	// DefaultPathName is the default config dir name
+	// DefaultPathName is the default config dir name.
 	DefaultPathName = ".storetheindex"
 	// DefaultPathRoot is the path to the default config dir location.
 	DefaultPathRoot = "~/" + DefaultPathName
-	// DefaultConfigFile is the filename of the configuration file
+	// DefaultConfigFile is the filename of the configuration file.
 	DefaultConfigFile = "config"
 	// EnvDir is the environment variable used to change the path root.
 	EnvDir = "STORETHEINDEX_PATH"
@@ -36,20 +36,24 @@ var (
 )
 
 // Filename returns the configuration file path given a configuration root
-// directory. If the configuration root directory is empty, use the default one
+// directory. If the configuration root directory is empty, use the default.
 func Filename(configRoot string) (string, error) {
 	return Path(configRoot, DefaultConfigFile)
 }
 
-// Marshal configuration with JSON
+// Marshal configuration with JSON.
 func Marshal(value interface{}) ([]byte, error) {
-	// need to prettyprint, hence MarshalIndent, instead of Encoder
+	// need to prettyprint, hence MarshalIndent, instead of Encoder.
 	return json.MarshalIndent(value, "", "  ")
 }
 
 // Path returns the config file path relative to the configuration root. If an
-// empty string is provided for `configRoot`, the default root is used.
+// empty string is provided for `configRoot`, the default root is used. If
+// configFile is an absolute path, then configRoot is ignored.
 func Path(configRoot, configFile string) (string, error) {
+	if filepath.IsAbs(configFile) {
+		return filepath.Clean(configFile), nil
+	}
 	if configRoot == "" {
 		var err error
 		configRoot, err = PathRoot()
@@ -60,7 +64,7 @@ func Path(configRoot, configFile string) (string, error) {
 	return filepath.Join(configRoot, configFile), nil
 }
 
-// PathRoot returns the default configuration root directory
+// PathRoot returns the default configuration root directory.
 func PathRoot() (string, error) {
 	dir := os.Getenv(EnvDir)
 	if dir != "" {
@@ -69,7 +73,7 @@ func PathRoot() (string, error) {
 	return homedir.Expand(DefaultPathRoot)
 }
 
-// Load reads the json-serialized config at the specified path
+// Load reads the json-serialized config at the specified path.
 func Load(filePath string) (*Config, error) {
 	var err error
 	if filePath == "" {
@@ -89,13 +93,14 @@ func Load(filePath string) (*Config, error) {
 	defer f.Close()
 
 	var cfg Config
-	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
+	if err = json.NewDecoder(f).Decode(&cfg); err != nil {
 		return nil, err
 	}
-	return &cfg, err
+
+	return &cfg, nil
 }
 
-// Save writes the json-serialized config to the specified path
+// Save writes the json-serialized config to the specified path.
 func (c *Config) Save(filePath string) error {
 	var err error
 	if filePath == "" {
@@ -124,7 +129,7 @@ func (c *Config) Save(filePath string) error {
 	return err
 }
 
-// String returns a pretty-printed json config
+// String returns a pretty-printed json config.
 func (c *Config) String() string {
 	b, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestPath(t *testing.T) {
+	const dir = "vstore"
+
+	var absdir string
+	if runtime.GOOS == "windows" {
+		absdir = "c:\\tmp\vstore"
+	} else {
+		absdir = "/tmp/vstore"
+	}
+
+	path, err := Path("", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configRoot, err := PathRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if path != filepath.Join(configRoot, dir) {
+		t.Fatalf("wrong path %s:", path)
+	}
+
+	path, err = Path("altroot", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Join("altroot", dir) {
+		t.Fatalf("wrong path %s:", path)
+	}
+
+	path, err = Path("altroot", absdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Clean(absdir) {
+		t.Fatalf("wrong path %s:", path)
+	}
+}

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -7,8 +7,10 @@ const (
 
 // Datastore tracks the configuration of the datastore.
 type Datastore struct {
-	// Type is the type of datastore
+	// Type is the type of datastore.
 	Type string
-	// Dir is the directory withing the config root where the datastore is kept
+	// Dir is the directory where the datastore is kept. If this is not an
+	// absolute path then the location is relative to the indexer repo
+	// directory.
 	Dir string
 }

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -6,12 +6,13 @@ const (
 	defaultValueStoreDir  = "valuestore"
 )
 
-// Indexer holds configuration for the indexer core
+// Indexer holds configuration for the indexer core.
 type Indexer struct {
-	// Maximum number of CIDs that cache can hold,0 to disable cache
+	// Maximum number of CIDs that cache can hold. Setting to 0 disables cache.
 	CacheSize int
-	// Directory withing config root where value store is kept
+	// Directory where value store is kept. If this is not an absolute path
+	// then the location is relative to the indexer repo directory.
 	ValueStoreDir string
-	// Type of value store to use
+	// Type of valuestore to use, such as "sti" or "pogreb".
 	ValueStoreType string
 }


### PR DESCRIPTION
This is needed to be able to have the valuestore and datastore located outside the storetheindex repo.