### PR TITLE
Update to latest go-legs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.6
-	github.com/filecoin-project/go-legs v0.0.0-20211125094504-5fdf15090c48
+	github.com/filecoin-project/go-legs v0.0.0-20211130223251-403a83b8d02d
 	github.com/frankban/quicktest v1.14.0
 	github.com/gammazero/keymutex v0.0.2
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.0 h1:y/X6UksYTsK8TLCI7rttCKEvl
 github.com/filecoin-project/go-ds-versioning v0.1.0/go.mod h1:mp16rb4i2QPmxBnmanUx8i/XANp+PFCCJWiAb+VW4/s=
 github.com/filecoin-project/go-indexer-core v0.2.6 h1:3Pt5+ZG20G5R1VF2eS0sawhqKCzc8cVb/WJ4fEeruZg=
 github.com/filecoin-project/go-indexer-core v0.2.6/go.mod h1:wW5Ab0gJXL2vT4iEMbPUfPs773iMc86Q8GtfSEqmu3Y=
-github.com/filecoin-project/go-legs v0.0.0-20211125094504-5fdf15090c48 h1:oQuuDozTZRjcrHV1kdPY5KsXEGASIPtFLA0wvql9F7Y=
-github.com/filecoin-project/go-legs v0.0.0-20211125094504-5fdf15090c48/go.mod h1:g32LVimhcYPte22LK8XslKqLBem54QxuMQmkrzbAyEI=
+github.com/filecoin-project/go-legs v0.0.0-20211130223251-403a83b8d02d h1:XkQCY9/r5oXT24f6CLBjAZf6N/oxTQgW/h4Oe032BDE=
+github.com/filecoin-project/go-legs v0.0.0-20211130223251-403a83b8d02d/go.mod h1:vQZ2nk8STtOoC/fhfBYNj4kL9l3/HSmeFls+G6UgJrU=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=


### PR DESCRIPTION
This is backwards compatible with a provider that uses an older version of go-legs, because the latest go-legs can still decode messages that do not include the address data.  It just means that the provider and indexer must be directly connected, until the provider also using the latest go-legs.