### PR TITLE
Make a number of fixes to the indexer commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,13 @@ BIN := storetheindex
 
 .PHONY: all build clean test
 
-all: build
+all: vet test build
 
-build: $(BIN)
+build:
+	go build -o $(BIN)
 
 docker: Dockerfile clean
 	docker build . --force-rm -f Dockerfile -t storetheindex:$(shell git rev-parse --short HEAD)
-
-$(BIN): vet test
-	go build -o $@
 
 lint:
 	golangci-lint run

--- a/api/v0/admin/client/http/client.go
+++ b/api/v0/admin/client/http/client.go
@@ -58,7 +58,12 @@ func (c *Client) ImportFromManifest(ctx context.Context, fileName string, provID
 
 	// Handle failed requests
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("importing from manifest failed: %v", http.StatusText(resp.StatusCode))
+		var errMsg string
+		body, err := io.ReadAll(resp.Body)
+		if err == nil && len(body) != 0 {
+			errMsg = ": " + string(body)
+		}
+		return fmt.Errorf("importing from manifest failed: %v%s", http.StatusText(resp.StatusCode), errMsg)
 	}
 	log.Infow("Success")
 	return nil
@@ -80,7 +85,12 @@ func (c *Client) ImportFromCidList(ctx context.Context, fileName string, provID 
 
 	// Handle failed requests
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("importing from cidlist failed: %v", http.StatusText(resp.StatusCode))
+		var errMsg string
+		body, err := io.ReadAll(resp.Body)
+		if err == nil && len(body) != 0 {
+			errMsg = ": " + string(body)
+		}
+		return fmt.Errorf("importing from cidlist failed: %v%s", http.StatusText(resp.StatusCode), errMsg)
 	}
 	log.Infow("Success")
 	return nil

--- a/api/v0/ingest/client/http/ingest.go
+++ b/api/v0/ingest/client/http/ingest.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 
@@ -160,14 +159,4 @@ func (c *Client) Register(ctx context.Context, providerID peer.ID, privateKey p2
 		return httpclient.ReadError(resp.StatusCode, body)
 	}
 	return nil
-}
-
-// Sync with a data provider up to latest ID
-func (c *Client) Sync(ctx context.Context, p peer.ID, m multihash.Multihash) error {
-	return errors.New("not implemented")
-}
-
-// Subscribe to advertisements of a specific provider in the pubsub channel
-func (c *Client) Subscribe(ctx context.Context, p peer.ID) error {
-	return errors.New("not implemented")
 }

--- a/api/v0/ingest/client/libp2p/client.go
+++ b/api/v0/ingest/client/libp2p/client.go
@@ -3,7 +3,6 @@ package p2pclient
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/filecoin-project/storetheindex/api/v0"
@@ -138,14 +137,4 @@ func (c *Client) sendRecv(ctx context.Context, req *pb.IngestMessage, expectRspT
 		return nil, fmt.Errorf("response type is not %s", expectRspType.String())
 	}
 	return resp.GetData(), nil
-}
-
-// Sync with a data provider up to latest ID
-func (c *Client) Sync(ctx context.Context, p peer.ID, m multihash.Multihash) error {
-	return errors.New("not implemented")
-}
-
-// Subscribe to advertisements of a specific provider in the pubsub channel
-func (c *Client) Subscribe(ctx context.Context, p peer.ID) error {
-	return errors.New("not implemented")
 }

--- a/command/flags.go
+++ b/command/flags.go
@@ -27,10 +27,10 @@ var cacheSizeFlag = &cli.Int64Flag{
 	Value:    -1,
 }
 
-var dirFlag = &cli.StringFlag{
-	Name:     "dir",
-	Usage:    "Source directory for import",
-	Aliases:  []string{"d"},
+var fileFlag = &cli.StringFlag{
+	Name:     "file",
+	Usage:    "Source file for import",
+	Aliases:  []string{"f"},
 	Required: true,
 }
 
@@ -40,6 +40,13 @@ var logLevelFlag = &cli.StringFlag{
 	EnvVars:  []string{"GOLOG_LOG_LEVEL"},
 	Value:    "info",
 	Required: false,
+}
+
+var providerFlag = &cli.StringFlag{
+	Name:     "provider",
+	Usage:    "Provider's peer ID to interact with",
+	Aliases:  []string{"p"},
+	Required: true,
 }
 
 var daemonFlags = []cli.Flag{
@@ -54,14 +61,14 @@ var daemonFlags = []cli.Flag{
 }
 
 var findFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:     "cid",
-		Usage:    "Specify cid to use as indexer key",
+	&cli.StringSliceFlag{
+		Name:     "mh",
+		Usage:    "Specify multihash to use as indexer key, multiple OK",
 		Required: false,
 	},
-	&cli.StringFlag{
-		Name:     "mh",
-		Usage:    "Specify multihash to use as indexer key",
+	&cli.StringSliceFlag{
+		Name:     "cid",
+		Usage:    "Specify CID to use as indexer key, multiple OK",
 		Required: false,
 	},
 	indexerHostFlag,
@@ -75,16 +82,11 @@ var findFlags = []cli.Flag{
 }
 
 var importFlags = []cli.Flag{
+	providerFlag,
 	&cli.StringFlag{
-		Name:     "provider",
-		Usage:    "Provider of the data imported",
-		Aliases:  []string{"prov"},
-		Required: true,
-	},
-	&cli.StringFlag{
-		Name:     "contextid",
+		Name:     "ctxtid",
 		Usage:    "Context ID of data imported",
-		Aliases:  []string{"ctxid"},
+		Aliases:  []string{"c"},
 		Required: true,
 	},
 	&cli.StringFlag{
@@ -93,17 +95,12 @@ var importFlags = []cli.Flag{
 		Aliases:  []string{"m"},
 		Required: false,
 	},
-	dirFlag,
+	fileFlag,
 	indexerHostFlag,
 }
 
 var ingestFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:     "provider",
-		Usage:    "Provider to interact with",
-		Aliases:  []string{"prov"},
-		Required: true,
-	},
+	providerFlag,
 	indexerHostFlag,
 }
 
@@ -170,7 +167,7 @@ var registerFlags = []cli.Flag{
 }
 
 var syntheticFlags = []cli.Flag{
-	dirFlag,
+	fileFlag,
 	&cli.StringFlag{
 		Name:     "type",
 		Usage:    "Type of synthetic load to generate (manifest, cidlist, car)",

--- a/command/flags.go
+++ b/command/flags.go
@@ -84,7 +84,7 @@ var findFlags = []cli.Flag{
 var importFlags = []cli.Flag{
 	providerFlag,
 	&cli.StringFlag{
-		Name:     "ctxtid",
+		Name:     "ctxid",
 		Usage:    "Context ID of data imported",
 		Aliases:  []string{"c"},
 		Required: true,

--- a/command/import.go
+++ b/command/import.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -53,17 +52,19 @@ func importListCmd(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	dir := cctx.String("file")
+	fileName := cctx.String("file")
 
-	fmt.Println("Starting to import from cidlist file")
-	// TODO: Should there be a timeout?  Since this may take a long time, it
-	// would make sense that the request should complete immediately with a
-	// redirect to a URL where the status can be polled for.
-	return cl.ImportFromCidList(context.Background(), dir, p, cctx.String("contextid"))
+	fmt.Println("Telling indexer to import cidlist file:", fileName)
+	err = cl.ImportFromCidList(cctx.Context, fileName, p, []byte(cctx.String("ctxid")), []byte(cctx.String("metadata")))
+	if err != nil {
+		return fmt.Errorf("Error from indexer: %s", err)
+	}
+	fmt.Println("Indexer imported manifest file")
+	return nil
 }
 
 func importCarCmd(c *cli.Context) error {
-	//fmt.Println("Starting to import from CAR file")
+	//fmt.Println("Telling indexer to import manifest file:", fileName)
 	return errors.New("importing from car not implemented yet")
 }
 
@@ -77,11 +78,16 @@ func importManifestCmd(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	dir := cctx.String("file")
+	fileName := cctx.String("file")
 
-	fmt.Println("Starting to import from manifest file")
+	fmt.Println("Telling indexer to import manifest file:", fileName)
 	// TODO: Should there be a timeout?  Since this may take a long time, it
 	// would make sense that the request should complete immediately with a
 	// redirect to a URL where the status can be polled for.
-	return cl.ImportFromManifest(context.Background(), dir, p, cctx.String("contextid"))
+	err = cl.ImportFromManifest(cctx.Context, fileName, p, []byte(cctx.String("ctxid")), []byte(cctx.String("metadata")))
+	if err != nil {
+		return fmt.Errorf("Error from indexer: %s", err)
+	}
+	fmt.Println("Indexer imported manifest file")
+	return nil
 }

--- a/command/import.go
+++ b/command/import.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	httpclient "github.com/filecoin-project/storetheindex/api/v0/admin/client/http"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -29,6 +30,7 @@ var importManifest = &cli.Command{
 	Flags:  importFlags,
 	Action: importManifestCmd,
 }
+
 var ImportCmd = &cli.Command{
 	Name:  "import",
 	Usage: "Imports data to indexer from different sources",
@@ -42,7 +44,7 @@ var ImportCmd = &cli.Command{
 func importListCmd(cctx *cli.Context) error {
 	// NOTE: Importing manually from CLI only supported for http protocol
 	// for now. This feature is mainly for testing purposes
-	cl, err := httpclient.New(cctx.String("indexer-host"))
+	cl, err := httpclient.New(cctx.String("indexer"))
 	if err != nil {
 		return err
 	}
@@ -51,9 +53,9 @@ func importListCmd(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	dir := cctx.String("dir")
+	dir := cctx.String("file")
 
-	log.Infow("Starting to import from cidlist file")
+	fmt.Println("Starting to import from cidlist file")
 	// TODO: Should there be a timeout?  Since this may take a long time, it
 	// would make sense that the request should complete immediately with a
 	// redirect to a URL where the status can be polled for.
@@ -61,12 +63,12 @@ func importListCmd(cctx *cli.Context) error {
 }
 
 func importCarCmd(c *cli.Context) error {
-	//log.Infow("Starting to import from CAR file")
+	//fmt.Println("Starting to import from CAR file")
 	return errors.New("importing from car not implemented yet")
 }
 
 func importManifestCmd(cctx *cli.Context) error {
-	cl, err := httpclient.New(cctx.String("indexer-host"))
+	cl, err := httpclient.New(cctx.String("indexer"))
 	if err != nil {
 		return err
 	}
@@ -75,9 +77,9 @@ func importManifestCmd(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	dir := cctx.String("dir")
+	dir := cctx.String("file")
 
-	log.Infow("Starting to import from manifest file")
+	fmt.Println("Starting to import from manifest file")
 	// TODO: Should there be a timeout?  Since this may take a long time, it
 	// would make sense that the request should complete immediately with a
 	// redirect to a URL where the status can be polled for.

--- a/command/import.go
+++ b/command/import.go
@@ -57,7 +57,7 @@ func importListCmd(cctx *cli.Context) error {
 	fmt.Println("Telling indexer to import cidlist file:", fileName)
 	err = cl.ImportFromCidList(cctx.Context, fileName, p, []byte(cctx.String("ctxid")), []byte(cctx.String("metadata")))
 	if err != nil {
-		return fmt.Errorf("Error from indexer: %s", err)
+		return err
 	}
 	fmt.Println("Indexer imported manifest file")
 	return nil
@@ -86,7 +86,7 @@ func importManifestCmd(cctx *cli.Context) error {
 	// redirect to a URL where the status can be polled for.
 	err = cl.ImportFromManifest(cctx.Context, fileName, p, []byte(cctx.String("ctxid")), []byte(cctx.String("metadata")))
 	if err != nil {
-		return fmt.Errorf("Error from indexer: %s", err)
+		return err
 	}
 	fmt.Println("Indexer imported manifest file")
 	return nil

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -28,17 +28,17 @@ func TestInit(t *testing.T) {
 	badAddr := "ip3/127.0.0.1/tcp/9999"
 	err := app.RunContext(ctx, []string{"storetheindex", "init", "-listen-admin", badAddr})
 	if err == nil {
-		log.Fatal("expected error")
+		t.Fatal("expected error")
 	}
 
 	err = app.RunContext(ctx, []string{"storetheindex", "init", "-listen-finder", badAddr})
 	if err == nil {
-		log.Fatal("expected error")
+		t.Fatal("expected error")
 	}
 
 	err = app.RunContext(ctx, []string{"storetheindex", "init", "-listen-ingest", badAddr})
 	if err == nil {
-		log.Fatal("expected error")
+		t.Fatal("expected error")
 	}
 
 	goodAddr := "/ip4/127.0.0.1/tcp/7777"
@@ -54,12 +54,12 @@ func TestInit(t *testing.T) {
 	}
 	err = app.RunContext(ctx, args)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	cfg, err := config.Load("")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	if cfg.Addresses.Finder != goodAddr {

--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -3,16 +3,13 @@ package config
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 )
 
 const (
-	defaultMinimumPeers     = 4
-	defaultBootstrapPeriod  = 30 * time.Second
-	defaulConnectionTimeout = defaultBootstrapPeriod / 3
+	defaultMinimumPeers = 4
 )
 
 // defaultBootstrapAddresses are the hardcoded bootstrap addresses.

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -2,7 +2,7 @@ package config
 
 const (
 	defaultIngestPubSubTopic = "indexer/ingest"
-	defaultStoreBatchSize    = 64
+	defaultStoreBatchSize    = 256
 )
 
 // Ingest tracks the configuration related to the ingestion protocol.

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -164,7 +164,8 @@ func TestEndToEndWithReferenceProvider(t *testing.T) {
 	err = os.Chdir("index-provider/cmd/provider")
 	qt.Assert(t, err, qt.IsNil)
 	e.run("go", "install")
-	os.Chdir(cwd)
+	err = os.Chdir(cwd)
+	qt.Assert(t, err, qt.IsNil)
 
 	e.run(provider, "init")
 	cfg, err := config.Load(filepath.Join(e.dir, ".index-provider", "config"))

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -10,7 +10,8 @@ import (
 	"github.com/filecoin-project/storetheindex/internal/syserr"
 )
 
-// New creates a base URL and a new http.Client
+// New creates a base URL and a new http.Client.  The default port is only used
+// if baseURL does not contain a port.
 func New(baseURL, resource string, defaultPort int, options ...Option) (*url.URL, *http.Client, error) {
 	if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
 		baseURL = "http://" + baseURL

--- a/internal/importer/cidlist.go
+++ b/internal/importer/cidlist.go
@@ -3,11 +3,15 @@ package importer
 import (
 	"bufio"
 	"context"
+	"errors"
 	"io"
 
 	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/multiformats/go-multihash"
 )
+
+var log = logging.Logger("indexer/importer")
 
 // ReadCids reads cids from an io.Reader and output their multihashes on a
 // channel.  Malformed cids are ignored.  ReadCids is meant to be called in a
@@ -17,25 +21,37 @@ func ReadCids(ctx context.Context, in io.Reader, out chan<- multihash.Multihash,
 	defer close(out)
 	defer close(done)
 
+	var badEntryCount, entryCount int
 	r := bufio.NewReader(in)
 	for {
 		line, err := r.ReadString('\n')
 		if err != nil {
 			if err != io.EOF {
 				done <- err
+				return
 			}
-			return
+			break
 		}
 		c, err := cid.Decode(line)
 		if err != nil || !c.Defined() {
+			badEntryCount++
 			// Ignore malformed CIDs
 			continue
 		}
 		select {
 		case out <- c.Hash():
+			entryCount++
 		case <-ctx.Done():
 			done <- ctx.Err()
 			return
 		}
 	}
+	if badEntryCount != 0 {
+		log.Errorf("Skipped %d bad cid entries", badEntryCount)
+	}
+	if entryCount == 0 {
+		done <- errors.New("no entries imported")
+		return
+	}
+	log.Infof("Imported %d cid entries", entryCount)
 }

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -2,9 +2,12 @@ package adminserver
 
 import (
 	"context"
-	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/storetheindex/internal/importer"
@@ -27,6 +30,8 @@ func newHandler(ctx context.Context, indexer indexer.Interface, ingester ingest.
 		ingester: ingester,
 	}
 }
+
+const importBatchSize = 64
 
 // ----- ingest handlers -----
 
@@ -107,29 +112,33 @@ func (h *adminHandler) importManifest(w http.ResponseWriter, r *http.Request) {
 	// TODO: This code is the same for all import handlers.
 	// We probably can take it out to its own function to deduplicate.
 	vars := mux.Vars(r)
-	provID, ok := decodeProviderID(vars["minerid"], w)
+	provID, ok := decodeProviderID(vars["provider"], w)
 	if !ok {
 		return
 	}
-	contextID, err := base64.RawURLEncoding.DecodeString(vars["contextid"])
+
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		msg := "Cannot decode context ID"
-		log.Errorw(msg, "err", err)
-		http.Error(w, msg, http.StatusBadRequest)
+		log.Errorw("failed reading import cidlist request", "err", err)
+		http.Error(w, "", http.StatusBadRequest)
 		return
 	}
-	log.Infow("Import manifest for provider", "miner", provID.String())
-	file, _, err := r.FormFile("file")
+
+	fileName, contextID, metadata, err := getParams(body)
 	if err != nil {
-		msg := "Cannot read file"
-		log.Error(msg)
-		http.Error(w, msg, http.StatusBadRequest)
+		log.Error(err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	file, err := os.Open(fileName)
+	if err != nil {
+		log.Errorw("Cannot open cidlist file", "err", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 	defer file.Close()
 
-	const batchSize = 64
-	out := make(chan multihash.Multihash, batchSize)
+	out := make(chan multihash.Multihash, importBatchSize)
 	errOut := make(chan error, 1)
 	ctx, cancel := context.WithCancel(h.ctx)
 	defer cancel()
@@ -138,9 +147,9 @@ func (h *adminHandler) importManifest(w http.ResponseWriter, r *http.Request) {
 	value := indexer.Value{
 		ProviderID:    provID,
 		ContextID:     contextID,
-		MetadataBytes: nil, // TODO: redesign into endpoints that take metadata too
+		MetadataBytes: metadata,
 	}
-	batchErr := batchIndexerEntries(batchSize, out, value, h.indexer)
+	batchErr := batchIndexerEntries(importBatchSize, out, value, h.indexer)
 	err = <-batchErr
 	if err != nil {
 		log.Errorf("Error putting entries in indexer: %s", err)
@@ -150,7 +159,7 @@ func (h *adminHandler) importManifest(w http.ResponseWriter, r *http.Request) {
 
 	err = <-errOut
 	if err != nil {
-		log.Error("Error reading manifest", "err", err)
+		log.Errorw("Error reading manifest", "err", err)
 		http.Error(w, fmt.Sprintf("error reading manifest: %s", err), http.StatusBadRequest)
 		return
 	}
@@ -159,31 +168,62 @@ func (h *adminHandler) importManifest(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func getParams(data []byte) (string, []byte, []byte, error) {
+	var params map[string][]byte
+	err := json.Unmarshal(data, &params)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("cannot unmarshal import cidlist params: %s", err)
+	}
+	fileName, ok := params["file"]
+	if !ok {
+		return "", nil, nil, errors.New("missing file in request")
+	}
+	contextID, ok := params["context_id"]
+	if !ok {
+		return "", nil, nil, errors.New("missing context_id in request")
+	}
+	metadata, ok := params["metadata"]
+	if !ok {
+		return "", nil, nil, errors.New("missing metadata in request")
+	}
+
+	return string(fileName), contextID, metadata, nil
+}
+
 func (h *adminHandler) importCidList(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	provID, ok := decodeProviderID(vars["minerid"], w)
+	provID, ok := decodeProviderID(vars["provider"], w)
 	if !ok {
 		return
 	}
-	contextID, err := base64.RawURLEncoding.DecodeString(vars["contextid"])
+	log.Infow("Import multihash list for provider", "provider", provID.String())
+
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		msg := "Cannot decode context ID"
-		log.Errorw(msg, "err", err)
-		http.Error(w, msg, http.StatusBadRequest)
+		log.Errorw("failed reading import cidlist request", "err", err)
+		http.Error(w, "", http.StatusBadRequest)
 		return
 	}
-	log.Infow("Import multihash list for provider", "miner", provID.String())
-	file, _, err := r.FormFile("file")
+
+	fileName, contextID, metadata, err := getParams(body)
 	if err != nil {
-		msg := "Cannot read file"
-		log.Error(msg)
-		http.Error(w, msg, http.StatusBadRequest)
+		log.Error(err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	fmt.Println("file:", fileName)
+	fmt.Println("contextID:", contextID)
+	fmt.Println("metadata:", metadata)
+
+	file, err := os.Open(fileName)
+	if err != nil {
+		log.Errorw("Cannot open cidlist file", "err", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 	defer file.Close()
 
-	const batchSize = 64
-	out := make(chan multihash.Multihash, batchSize)
+	out := make(chan multihash.Multihash, importBatchSize)
 	errOut := make(chan error, 1)
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
@@ -192,9 +232,9 @@ func (h *adminHandler) importCidList(w http.ResponseWriter, r *http.Request) {
 	value := indexer.Value{
 		ProviderID:    provID,
 		ContextID:     contextID,
-		MetadataBytes: nil, // TODO: redesign into endpoints that take metadata too
+		MetadataBytes: metadata,
 	}
-	batchErr := batchIndexerEntries(batchSize, out, value, h.indexer)
+	batchErr := batchIndexerEntries(importBatchSize, out, value, h.indexer)
 	err = <-batchErr
 	if err != nil {
 		log.Errorf("Error putting entries in indexer: %s", err)
@@ -204,7 +244,7 @@ func (h *adminHandler) importCidList(w http.ResponseWriter, r *http.Request) {
 
 	err = <-errOut
 	if err != nil {
-		log.Error("Error reading CID list", "err", err)
+		log.Errorw("Error reading CID list", "err", err)
 		http.Error(w, fmt.Sprintf("error reading cid list: %s", err), http.StatusBadRequest)
 		return
 	}

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -44,7 +44,8 @@ func (h *adminHandler) subscribe(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := "Cannot subscribe to provider"
 		log.Errorw(msg, "err", err)
-		http.Error(w, msg, http.StatusInternalServerError)
+		http.Error(w, msg, http.StatusBadGateway)
+		return
 	}
 
 	// Return OK
@@ -65,7 +66,8 @@ func (h *adminHandler) unsubscribe(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := "Cannot unsubscribe to provider"
 		log.Errorw(msg, "err", err)
-		http.Error(w, msg, http.StatusInternalServerError)
+		http.Error(w, msg, http.StatusBadGateway)
+		return
 	}
 
 	// Return OK
@@ -91,7 +93,8 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := "Cannot sync with provider"
 		log.Errorw(msg, "err", err)
-		http.Error(w, msg, http.StatusInternalServerError)
+		http.Error(w, msg, http.StatusBadGateway)
+		return
 	}
 
 	// Return (202) Accepted

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -45,8 +45,8 @@ func New(ctx context.Context, listen string, indexer indexer.Interface, ingester
 
 	// Set protocol handlers
 	// Import routes
-	r.HandleFunc("/import/manifest/{minerid}/{contextid}", h.importManifest).Methods("POST")
-	r.HandleFunc("/import/cidlist/{minerid}/{contextid}", h.importCidList).Methods("POST")
+	r.HandleFunc("/import/manifest/{provider}", h.importManifest).Methods("POST")
+	r.HandleFunc("/import/cidlist/{provider}", h.importCidList).Methods("POST")
 
 	// Admin routes
 	r.HandleFunc("/healthcheck", h.healthCheckHandler).Methods("GET")

--- a/test/load/README.md
+++ b/test/load/README.md
@@ -1,32 +1,30 @@
 # Load tests
 
 ### Start a daemon
-To run load tests over `storetheindex` we need to first run the node in the infrastructure:
-- Start a `storetheindex` daemon:
+To run load tests over `storetheindex` we need to first initialize and run the indexer daemon:
+- Initialize and start a `storetheindex` daemon:
 ```
-./storetheindex daemon --storage <persistence> -e 0.0.0.0:3000 --cachesize <cache_size> --dir <data-dir>
+export STORETHEINDEX_PATH=/tmp/sti_test
+./storetheindex init
+./storetheindex daemon --cachesize <cache_size> --dir <data-dir>
 ```
 - Import cid data into the indexer:
 ```
-./storetheindex import cidlist --dir ./utils/load/cids.data --provider 12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA --metadata <metadata> -e 127.0.0.1:3000
+./storetheindex import cidlist --file ./test/load/cids.data --provider 12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA --metadata <metadata>
 ``` 
 
 ### Run the test
 We can then start the load tests client. The load test script has `locust` and `numpy` as dependencies. Be sure that you have `python3` installed
 and that you `pip install locust numpy`.
 
-- A test run with 4 workers and a master client can be easily run through the `./run.sh` script. This script starts the client workers. To configure the
-test run and visualize the results go to locust UI at `http://localhost:8089`.
-- Locust can also be run from the CLI, and to stress test a single endpoint we can also use [this tool](https://github.com/rakyll/hey), which can be run
-using:
+- A test run with 4 workers and a master client can be easily run through the `./run.sh` script. This script starts the client workers. To configure the test run and visualize the results go to locust UI at `http://localhost:8089`.
+- Locust can also be run from the CLI. To stress test a single endpoint, [this tool](https://github.com/rakyll/hey) can be run using:
 ```
 ./hey_linux_amd64 -m GET -z <test-duration> -c <concurrent_clients> <endpoint>/cid/bafkreigxvijvpvmt7xnk2nxzudha22jf7fawi2vbjpsnh7cejagquq6z4y
 
 # Example
-./hey_linux_amd64 -m GET -z 30s -c 10000 http://18.169.134.123:3000/cid/bafkreigxvijvpvmt7xnk2nxzudha22jf7fawi2vbjpsnh7cejagquq6z4y
+./hey_linux_amd64 -m GET -z 30s -c 10000 http://127.0.0.1:3000/cid/bafkreigxvijvpvmt7xnk2nxzudha22jf7fawi2vbjpsnh7cejagquq6z4y
 ```
 
 ### File Descriptor Limit
-When trying to run a huge load over the node, the local client may reach the OS file descriptor limit (even if this is set to the maximum limit allowed).
-To send more load to the node the load generation needs to be distributed in different machines.
-
+When trying to run a huge load over the node, the local client may reach the OS file descriptor limit (even if this is set to the maximum limit allowed). To send more load to the node, the load generation needs to be distributed over multiple machines.


### PR DESCRIPTION
The storetheindex commands needed a number of fixes for errors and inconsistencies.  The changes include the following:
- Makefile build target builds without running tests.
- Remove unused endpoints from `ingest` client.
- Add `Sync`, `Subscribe`, and `Unsubscribe` to admin client.
- Add comment about specifying port to http client.
- Admin client needed to return after http.Error
- Return proper error on sync failure.
- Fix misnamed command flags in `import` command.
- Used admin client in `ingest` command.
- Only `daemon` command should write to log.
- Fix progress output in `synthetic` command.
- Fix error handling in init test.
- The `find` command takes multiple `--cid` and `--mh` flags.