### PR TITLE
Selectively sync advertisements then entries only if absent

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -240,6 +240,7 @@ func retryWithTimeout(t *testing.T, timeout time.Duration, timeBetweenRetries ti
 
 	var errs []error
 	// Loop until context is done
+	timer := time.NewTimer(timeBetweenRetries)
 	for {
 		err := retryableFn()
 		if err == nil {
@@ -251,7 +252,8 @@ func retryWithTimeout(t *testing.T, timeout time.Duration, timeBetweenRetries ti
 		case <-ctx.Done():
 			t.Fatalf("hit timeout while retrying. Errs seen: %s", errs)
 			return
-		case <-time.After(timeBetweenRetries):
+		case <-timer.C:
+			timer.Reset(timeBetweenRetries)
 		}
 	}
 }


### PR DESCRIPTION
Configure the background leg sync to only sync advertisement chain. Sync
entries separately via storage hook by first checking if they are
present already.

Note that the semantics of explicit Sync is changed by this commit where
Sync returns when the advertisement is synced _excluding_ entries.

Change ingest tests to assert that expected multihashes are indexed
eventually. Remove evil `time.Sleep`s where possible in existing tests.

Fixes #136