### PR TITLE
Limit contextID length, and misc fixes

### DIFF
--- a/api/v0/ingest/schema/utils.go
+++ b/api/v0/ingest/schema/utils.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"context"
+	"errors"
 
 	v0 "github.com/filecoin-project/storetheindex/api/v0"
 	"github.com/ipfs/go-cid"
@@ -38,6 +39,8 @@ const (
 	// link belongs to. This is used to understand what callback to trigger
 	// in the linksystem when we come across a specific linkType.
 	IsAdKey = LinkContextKey("isAdLink")
+	// ContextID must not exceed this number of bytes.
+	MaxContextIDLen = 64
 )
 
 func mhsToBytes(mhs []multihash.Multihash) []_Bytes {
@@ -162,6 +165,10 @@ func NewAdvertisementWithFakeSig(
 	provider string,
 	addrs []string) (Advertisement, Link_Advertisement, error) {
 
+	if len(contextID) > MaxContextIDLen {
+		return nil, nil, errors.New("context id too long")
+	}
+
 	encMetadata, err := metadata.MarshalBinary()
 	if err != nil {
 		return nil, nil, err
@@ -203,6 +210,10 @@ func newAdvertisement(
 	isRm bool,
 	provider string,
 	addrs []string) (Advertisement, error) {
+
+	if len(contextID) > MaxContextIDLen {
+		return nil, errors.New("context id too long")
+	}
 
 	encMetadata, err := metadata.MarshalBinary()
 	if err != nil {

--- a/config/discovery.go
+++ b/config/discovery.go
@@ -12,8 +12,8 @@ import (
 type Discovery struct {
 	// Bootstrap is a Set of nodes to try to connect to at startup
 	Bootstrap []string
-	// LotusGateway is the address for a lotus gateway used to collect chain
-	// information when discovering providers
+	// LotusGateway is the host or host:port for a lotus gateway used to
+	// collect chain information when discovering providers
 	LotusGateway string
 	// Peers lists nodes to attempt to stay connected with
 	Peers []peer.AddrInfo

--- a/config/discovery.go
+++ b/config/discovery.go
@@ -13,7 +13,7 @@ type Discovery struct {
 	// Bootstrap is a Set of nodes to try to connect to at startup
 	Bootstrap []string
 	// LotusGateway is the host or host:port for a lotus gateway used to
-	// collect chain information when discovering providers
+	// verify providers on the blockchain.
 	LotusGateway string
 	// Peers lists nodes to attempt to stay connected with
 	Peers []peer.AddrInfo

--- a/config/policy.go
+++ b/config/policy.go
@@ -1,7 +1,13 @@
 package config
 
 // Policy configures which providers are allowed and blocked, and which allowed
-// providers require verification or are trusted
+// providers require verification or are trusted.
+//
+// Policy evaluation works like two gates that must be passed in order to be
+// allowed to index content.  The first gate is the "allow" gate that
+// determines whether a provider is allowd or not.  The second gate is the
+// "trust" gate that determines whether a provider is trusted or must be
+// verified on-chain to be authorized to index content.
 type Policy struct {
 	// Allow is either false or true, and determines whether a provider is
 	// allowed (true) or is blocked (false), by default.
@@ -11,8 +17,9 @@ type Policy struct {
 	// or trusted in order to register.
 	Except []string
 
-	// Trust is either false or true, and determines whether a provider can
-	// skip (true) on-chain verification or not (false), by default
+	// Trust is either false or true, and determines whether an allowed
+	// provider can skip (true) on-chain verification or not (false), by
+	// default.
 	Trust bool
 	// TrustExcept is a list of peer IDs that are exceptions to the trust
 	// action.  If Trust is false then all allowed providers must be

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.6
-	github.com/filecoin-project/go-legs v0.0.0-20211208100121-480bbe915b42
+	github.com/filecoin-project/go-legs v0.1.0
 	github.com/frankban/quicktest v1.14.0
 	github.com/gammazero/keymutex v0.0.2
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.0 h1:y/X6UksYTsK8TLCI7rttCKEvl
 github.com/filecoin-project/go-ds-versioning v0.1.0/go.mod h1:mp16rb4i2QPmxBnmanUx8i/XANp+PFCCJWiAb+VW4/s=
 github.com/filecoin-project/go-indexer-core v0.2.6 h1:3Pt5+ZG20G5R1VF2eS0sawhqKCzc8cVb/WJ4fEeruZg=
 github.com/filecoin-project/go-indexer-core v0.2.6/go.mod h1:wW5Ab0gJXL2vT4iEMbPUfPs773iMc86Q8GtfSEqmu3Y=
-github.com/filecoin-project/go-legs v0.0.0-20211208100121-480bbe915b42 h1:ln+nSDW+iLOH38lPAqNVFSveiI3mmc+SIFgXdrc5rIA=
-github.com/filecoin-project/go-legs v0.0.0-20211208100121-480bbe915b42/go.mod h1:HFp0jUZopkX9DW6FOmhHltVfEatfAcm3ZD6Z/kY4iNg=
+github.com/filecoin-project/go-legs v0.1.0 h1:Gj8h733zGNIWaZWiVSY0RQG8d4iVWyLpGpDMZZmjzEk=
+github.com/filecoin-project/go-legs v0.1.0/go.mod h1:HFp0jUZopkX9DW6FOmhHltVfEatfAcm3ZD6Z/kY4iNg=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=

--- a/internal/handler/ingest_handler.go
+++ b/internal/handler/ingest_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/model"
+	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	"github.com/filecoin-project/storetheindex/internal/syserr"
 	"github.com/ipfs/go-cid"
@@ -93,6 +94,10 @@ func (h *IngestHandler) IndexContent(data []byte) error {
 	ingReq, err := model.ReadIngestRequest(data)
 	if err != nil {
 		return fmt.Errorf("cannot read ingest request: %s", err)
+	}
+
+	if len(ingReq.ContextID) > schema.MaxContextIDLen {
+		return errors.New("context id too long")
 	}
 
 	if err = h.registry.CheckSequence(ingReq.ProviderID, ingReq.Seq); err != nil {

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -51,6 +51,6 @@ func ReadErrorFrom(status int, r io.Reader) error {
 }
 
 func ReadError(status int, body []byte) error {
-	se := syserr.New(errors.New(string(body)), status)
+	se := syserr.New(errors.New(strings.TrimSpace(string(body))), status)
 	return errors.New(se.Text())
 }

--- a/internal/lotus/discovery.go
+++ b/internal/lotus/discovery.go
@@ -44,12 +44,15 @@ type MinerInfo struct {
 
 // New creates a new lotus Discoverer
 func NewDiscoverer(gateway string) (*Discoverer, error) {
-	u, err := url.Parse(gateway)
-	if err != nil {
-		return nil, err
+	if gateway == "" {
+		return nil, errors.New("empty gateway")
 	}
-	u.Scheme = "https"
-	u.Path = "/rpc/v1"
+
+	u := url.URL{
+		Host:   gateway,
+		Scheme: "https",
+		Path:   "/rpc/v1",
+	}
 
 	return &Discoverer{
 		gatewayURL: u.String(),
@@ -63,7 +66,7 @@ func (d *Discoverer) Discover(ctx context.Context, peerID peer.ID, minerAddr str
 		return nil, fmt.Errorf("invalid provider filecoin address: %s", err)
 	}
 
-	jrpcClient := jrpc.NewClient("https://api.chain.love/rpc/v1")
+	jrpcClient := jrpc.NewClient(d.gatewayURL)
 
 	var ets ExpTipSet
 	err = jrpcClient.CallFor(&ets, "Filecoin.ChainHead")

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -210,7 +210,7 @@ func (r *Registry) Register(info *ProviderInfo) error {
 
 // Check if the provider is trusted by policy, or if it has been previously
 // verified and registered.
-func (r Registry) Authorized(providerID peer.ID) (bool, error) {
+func (r *Registry) Authorized(providerID peer.ID) (bool, error) {
 	if !r.policy.Allowed(providerID) {
 		return false, nil
 	}

--- a/server/ingest/http/protocol_test.go
+++ b/server/ingest/http/protocol_test.go
@@ -64,4 +64,6 @@ func TestRegisterProvider(t *testing.T) {
 	test.IndexContent(t, httpClient, peerID, privKey, ind)
 
 	test.IndexContentNewAddr(t, httpClient, peerID, privKey, ind, "/ip4/127.0.0.1/tcp/7777", reg)
+
+	test.IndexContentFail(t, httpClient, peerID, privKey, ind)
 }

--- a/server/ingest/libp2p/protocol_test.go
+++ b/server/ingest/libp2p/protocol_test.go
@@ -66,4 +66,6 @@ func TestRegisterProvider(t *testing.T) {
 	test.IndexContent(t, p2pClient, peerID, privKey, ind)
 
 	test.IndexContentNewAddr(t, p2pClient, peerID, privKey, ind, "/ip4/127.0.0.1/tcp/7777", reg)
+
+	test.IndexContentFail(t, p2pClient, peerID, privKey, ind)
 }


### PR DESCRIPTION
Want to limit contextID length sooner rather than later so that the indexer does not store content that is no longer updatable because the contextID becomes unacceptable in the future.

Fixes #112 