### PR TITLE
Support advertisement to update metadata only

### DIFF
--- a/api/v0/ingest/schema/utils.go
+++ b/api/v0/ingest/schema/utils.go
@@ -15,6 +15,11 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
+// NoEntries is a special value used to explicitly indicate that an
+// advertisement does not have any entries, and serves to remove content by context ID,
+// update metadata, or update provider addresses.
+var NoEntries cidlink.Link
+
 // Linkproto is the ipld.LinkProtocol used for the ingestion protocol.
 // Refer to it if you have encoding questions.
 var Linkproto = cidlink.LinkPrototype{
@@ -27,6 +32,15 @@ var Linkproto = cidlink.LinkPrototype{
 }
 
 var mhCode = multihash.Names["sha2-256"]
+
+func init() {
+	// Define NoEntries as the CID of a sha256 hash of nil.
+	m, err := multihash.Sum(nil, multihash.SHA2_256, 32)
+	if err != nil {
+		panic(err)
+	}
+	NoEntries = cidlink.Link{Cid: cid.NewCidV0(m)}
+}
 
 // LinkContextKey used to propagate link info through the linkSystem context
 type LinkContextKey string


### PR DESCRIPTION
This PR also makes it possible to support advertisements for the removal of content by context ID as well as removal of content by individual multihashes.

A special cidLink value, `schema.NoEntries`, is used to indicate that an advertisement has no entries.  When this is used in a removal advertisement, there are no specific indexes to remove and all content with the matching context for the provider is removed.  If a removal advertisement has an entries link to actual entries, then the entries are retrieved from the provider and the individual multihashes within each entry are used to remove content.

If an advertisement uses the special `schema.NoEntries` value as its entry link, and the ad is not a not for removal, then the advertisement is used only to update the provider's metadata that has the matching context ID.