### PR TITLE
Allow multiple ads in a chain to have the same entries CID

### DIFF
--- a/internal/ingest/linksystem_test.go
+++ b/internal/ingest/linksystem_test.go
@@ -1,0 +1,59 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+)
+
+func TestCidToAdMapping(t *testing.T) {
+	ctx := context.Background()
+	ds := datastore.NewMapDatastore()
+
+	adCid1, err := cid.Decode("baguqeeqq7oiy5nts7qzhefwhpokkzxmzaq")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adCid2, err := cid.Decode("baguqeeqqhtvkwigrelprmtqqqrdy32pqc4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entCid, err := cid.Decode("baguqeeqqf2zgykyxbm4e3bmdudylddza4y")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test writing entry CID with multiple ad CIDs.
+	err = putCidToAdMapping(ctx, ds, entCid, adCid1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = putCidToAdMapping(ctx, ds, entCid, adCid2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test reading back each ad CID for the entry CID.
+	adCid, err := getCidToAdMapping(ctx, ds, entCid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adCid != adCid2 {
+		t.Fatal("wrong ad cid returned from first get")
+	}
+	adCid, err = getCidToAdMapping(ctx, ds, entCid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adCid != adCid1 {
+		t.Fatal("wrong ad cid returned from second get")
+	}
+
+	// Test that entry CID to ad CID is deleted after last read.
+	_, err = getCidToAdMapping(ctx, ds, entCid)
+	if err == nil {
+		t.Fatal("expected error for deleted mapping")
+	}
+}


### PR DESCRIPTION
Multiple ad in a chain of advertisements may have the same entries CID.  This caused reverse mapping of entries CID to ad CID, for the first ad received to get stepped on by the same mapping for the sencond ad received having that same entries CID.  This fixes this by maintaining a mapping of entries CID to a stack of ad CIDs.