### PR TITLE
Limit the depth of recursion when syncing advertisement entries

### DIFF
--- a/api/v0/finder/model/model_test.go
+++ b/api/v0/finder/model/model_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"bytes"
+	"math/rand"
 	"testing"
 
 	"github.com/filecoin-project/storetheindex/api/v0"
@@ -13,9 +14,11 @@ import (
 
 const testProtoID = 0x300000
 
+var rng = rand.New(rand.NewSource(1413))
+
 func TestMarshal(t *testing.T) {
 	// Generate some multihashes and populate indexer
-	mhs := util.RandomMultihashes(3)
+	mhs := util.RandomMultihashes(3, rng)
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	ctxID := []byte("test-context-id")
 	metadata := v0.Metadata{

--- a/api/v0/ingest/model/ingest_request_test.go
+++ b/api/v0/ingest/model/ingest_request_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"bytes"
+	"math/rand"
 	"testing"
 
 	"github.com/filecoin-project/storetheindex/api/v0"
@@ -11,8 +12,10 @@ import (
 	"github.com/libp2p/go-libp2p-core/test"
 )
 
+var rng = rand.New(rand.NewSource(1413))
+
 func TestIngestRequest(t *testing.T) {
-	mhs := util.RandomMultihashes(1)
+	mhs := util.RandomMultihashes(1, rng)
 
 	metadata := v0.Metadata{
 		Data: []byte("hello"),

--- a/api/v0/ingest/schema/utils_test.go
+++ b/api/v0/ingest/schema/utils_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"bytes"
 	"io"
+	"math/rand"
 	"testing"
 
 	v0 "github.com/filecoin-project/storetheindex/api/v0"
@@ -17,6 +18,8 @@ import (
 	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 )
+
+var rng = rand.New(rand.NewSource(1413))
 
 func mkLinkSystem(ds datastore.Batching) ipld.LinkSystem {
 	lsys := cidlink.DefaultLinkSystem()
@@ -41,7 +44,7 @@ func mkLinkSystem(ds datastore.Batching) ipld.LinkSystem {
 const protocolID = 0x300000
 
 func genCidsAndAdv(t *testing.T, lsys ipld.LinkSystem, priv crypto.PrivKey, previous Link_Advertisement) ([]multihash.Multihash, ipld.Link, Advertisement, Link_Advertisement) {
-	mhs := util.RandomMultihashes(10)
+	mhs := util.RandomMultihashes(10, rng)
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	ctxID := []byte("test-context-id")
 	metadata := v0.Metadata{
@@ -88,7 +91,7 @@ func TestChainAdvertisements(t *testing.T) {
 func TestLinkedList(t *testing.T) {
 	dstore := datastore.NewMapDatastore()
 	lsys := mkLinkSystem(dstore)
-	mhs := util.RandomMultihashes(10)
+	mhs := util.RandomMultihashes(10, rng)
 	lnk1, ch1, err := NewLinkedListOfMhs(lsys, mhs, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -1,6 +1,10 @@
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+)
 
 // Ingest tracks the configuration related to the ingestion protocol.
 type Ingest struct {
@@ -16,14 +20,19 @@ type Ingest struct {
 	// or a chain of advertisement entries.  The value is an integer string
 	// ending in "s", "m", "h" for seconds. minutes, hours.
 	SyncTimeout Duration
+
+	// The recursion depth limit when syncing advertisement entries.
+	// The value -1 means no limit. Defaults to 400.
+	EntriesDepthLimit int64
 }
 
 // NewIngest returns Ingest with values set to their defaults.
 func NewIngest() Ingest {
 	return Ingest{
-		PubSubTopic:    "/indexer/ingest/mainnet",
-		StoreBatchSize: 256,
-		SyncTimeout:    Duration(2 * time.Hour),
+		PubSubTopic:       "/indexer/ingest/mainnet",
+		StoreBatchSize:    256,
+		SyncTimeout:       Duration(2 * time.Hour),
+		EntriesDepthLimit: 400,
 	}
 }
 
@@ -40,4 +49,16 @@ func (c *Ingest) populateUnset() {
 	if c.SyncTimeout == 0 {
 		c.SyncTimeout = def.SyncTimeout
 	}
+	if c.EntriesDepthLimit == 0 {
+		c.EntriesDepthLimit = def.EntriesDepthLimit
+	}
+}
+
+// EntriesRecursionLimit returns the recursion limit of advertisement entries.
+// See Ingest.EntriesDepthLimit
+func (c *Ingest) EntriesRecursionLimit() selector.RecursionLimit {
+	if c.EntriesDepthLimit == -1 {
+		return selector.RecursionLimitNone()
+	}
+	return selector.RecursionLimitDepth(c.EntriesDepthLimit)
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -126,7 +126,9 @@ func TestSync(t *testing.T) {
 		// Check that latest sync recorded in datastore
 		lcid, err = i.getLatestSync(pubHost.ID())
 		require.NoError(t, err)
-		require.Equal(t, lcid, c1)
+		requireTrueEventually(t, func() bool {
+			return c1.Equals(lcid)
+		}, testRetryInterval, testRetryTimeout, "Expected %s but got %s", c1, lcid)
 	case <-ctx.Done():
 		t.Fatal("sync timeout")
 	}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -20,7 +20,6 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/multicodec"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
-	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multihash"
 	"go.opencensus.io/stats"
@@ -407,10 +406,8 @@ func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid,
 		defer cancel()
 	}
 	startTime := time.Now()
-	// Fully traverse the entries, because:
-	//  * if the head is not persisted locally there is a chance we do not have it.
-	//  * chain of entries as specified by EntryChunk schema only contain entries.
-	_, err = ing.sub.Sync(ctx, from, entriesCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
+	// Traverse entries based on the entries selector that limits recursion depth.
+	_, err = ing.sub.Sync(ctx, from, entriesCid, ing.entriesSel, nil)
 	if err != nil {
 		log.Errorw("Failed to sync", "err", err)
 		return

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -27,6 +28,8 @@ const (
 	providerID = "12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA"
 	protocolID = 0x300000
 )
+
+var rng = rand.New(rand.NewSource(1413))
 
 //InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
@@ -83,7 +86,7 @@ func populateIndex(ind indexer.Interface, mhs []multihash.Multihash, v indexer.V
 
 func FindIndexTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
 	// Generate some multihashes and populate indexer
-	mhs := util.RandomMultihashes(15)
+	mhs := util.RandomMultihashes(15, rng)
 	p, err := peer.Decode(providerID)
 	if err != nil {
 		t.Fatal(err)

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"math/rand"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +24,8 @@ import (
 )
 
 const testProtocolID = 0x300000
+
+var rng = rand.New(rand.NewSource(1413))
 
 //InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
@@ -120,7 +123,7 @@ func IndexContent(t *testing.T, cl client.Ingest, providerID peer.ID, privateKey
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mhs := util.RandomMultihashes(1)
+	mhs := util.RandomMultihashes(1, rng)
 
 	contextID := []byte("test-context-id")
 	metadata := v0.Metadata{
@@ -170,7 +173,7 @@ func IndexContentNewAddr(t *testing.T, cl client.Ingest, providerID peer.ID, pri
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mhs := util.RandomMultihashes(1)
+	mhs := util.RandomMultihashes(1, rng)
 
 	ctxID := []byte("test-context-id")
 	metadata := v0.Metadata{
@@ -203,7 +206,7 @@ func IndexContentFail(t *testing.T, cl client.Ingest, providerID peer.ID, privat
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mhs := util.RandomMultihashes(1)
+	mhs := util.RandomMultihashes(1, rng)
 
 	contextID := make([]byte, schema.MaxContextIDLen+1)
 	metadata := v0.Metadata{

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -2,25 +2,23 @@ package util
 
 import (
 	"math/rand"
-	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
 )
 
-func RandomMultihashes(n int) []multihash.Multihash {
+func RandomMultihashes(n int, rng *rand.Rand) []multihash.Multihash {
 	prefix := cid.Prefix{
 		Version:  1,
 		Codec:    cid.Raw,
 		MhType:   multihash.SHA2_256,
 		MhLength: -1, // default length
 	}
-	prng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	mhashes := make([]multihash.Multihash, n)
 	for i := 0; i < n; i++ {
 		b := make([]byte, 10*n+16)
-		prng.Read(b)
+		rng.Read(b)
 		c, err := prefix.Sum(b)
 		if err != nil {
 			panic(err.Error())


### PR DESCRIPTION
Add a configuration value that allows limiting the recursion depth when
syncing the advertisement entries with default value of 400. The default
of 400 in conjunction with default chunk size of 16384 in index-provider
would accommodate a default total of 6,553,600 multihashes, which seems
like a reasonably large number.