### PR TITLE
Add command to list provider information

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -115,6 +115,10 @@ var ingestReloadPolicyFlags = []cli.Flag{
 	indexerHostFlag,
 }
 
+var ingestProvidersFlags = []cli.Flag{
+	indexerHostFlag,
+}
+
 var ingestSyncFlags = []cli.Flag{
 	peerFlag,
 	indexerHostFlag,

--- a/command/ingest.go
+++ b/command/ingest.go
@@ -40,7 +40,7 @@ var reload = &cli.Command{
 
 var providers = &cli.Command{
 	Name:   "providers",
-	Usage:  "Shown information about known providers",
+	Usage:  "Show information about known providers",
 	Flags:  ingestProvidersFlags,
 	Action: providersCmd,
 }

--- a/command/ingest.go
+++ b/command/ingest.go
@@ -146,8 +146,6 @@ func providersCmd(cctx *cli.Context) error {
 	for _, pinfo := range provs {
 		fmt.Println("Provider", pinfo.AddrInfo.ID)
 		fmt.Println("    Addresses:", pinfo.AddrInfo.Addrs)
-		//for _, addr := range pinfo.AddrInfo.Addrs {
-		//	fmt.Print(addr.String())
 		fmt.Println("    LastAdvertisement:", pinfo.LastAdvertisement)
 		fmt.Println("    LastAdvertisementTime:", pinfo.LastAdvertisementTime)
 	}


### PR DESCRIPTION
List current information about registered providers.  Example:
```
./storetheindex ingest providers --indexer 18.116.210.184

Provider 12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ
    Addresses: [/ip4/192.168.0.109/tcp/45399]
    LastAdvertisement: baguqeeqql7kdkkburx32mv6nc7uhsqdfjy
    LastAdvertisementTime: 2022-01-24T16:31:56Z
Provider 12D3KooWNUC8jEwuwH464tCEDfk1Y8SdaUZ7mJgjBU9NfjpBrghq
    Addresses: [/ip4/3.143.149.162/tcp/3103]
    LastAdvertisement: baguqeeqqufvyqiuqyfwtguwo2tg2o66myi
    LastAdvertisementTime: 2022-01-25T19:14:16Z
```