### PR TITLE
Limit the recursion depth when syncing advertisements

### DIFF
--- a/config/ingest.go
+++ b/config/ingest.go
@@ -24,15 +24,20 @@ type Ingest struct {
 	// The recursion depth limit when syncing advertisement entries.
 	// The value -1 means no limit. Defaults to 400.
 	EntriesDepthLimit int64
+
+	// The recursion depth limit when syncing advertisements.
+	// The value -1 means no limit. Defaults to 400.
+	AdvertisementDepthLimit int64
 }
 
 // NewIngest returns Ingest with values set to their defaults.
 func NewIngest() Ingest {
 	return Ingest{
-		PubSubTopic:       "/indexer/ingest/mainnet",
-		StoreBatchSize:    256,
-		SyncTimeout:       Duration(2 * time.Hour),
-		EntriesDepthLimit: 400,
+		PubSubTopic:             "/indexer/ingest/mainnet",
+		StoreBatchSize:          256,
+		SyncTimeout:             Duration(2 * time.Hour),
+		EntriesDepthLimit:       400,
+		AdvertisementDepthLimit: 400,
 	}
 }
 
@@ -52,6 +57,9 @@ func (c *Ingest) populateUnset() {
 	if c.EntriesDepthLimit == 0 {
 		c.EntriesDepthLimit = def.EntriesDepthLimit
 	}
+	if c.AdvertisementDepthLimit == 0 {
+		c.AdvertisementDepthLimit = def.AdvertisementDepthLimit
+	}
 }
 
 // EntriesRecursionLimit returns the recursion limit of advertisement entries.
@@ -61,4 +69,13 @@ func (c *Ingest) EntriesRecursionLimit() selector.RecursionLimit {
 		return selector.RecursionLimitNone()
 	}
 	return selector.RecursionLimitDepth(c.EntriesDepthLimit)
+}
+
+// AdvertisementRecursionLimit returns the recursion limit of advertisements.
+// See Ingest.AdvertisementDepthLimit
+func (c *Ingest) AdvertisementRecursionLimit() selector.RecursionLimit {
+	if c.AdvertisementDepthLimit == -1 {
+		return selector.RecursionLimitNone()
+	}
+	return selector.RecursionLimitDepth(c.AdvertisementDepthLimit)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.7
-	github.com/filecoin-project/go-legs v0.2.3
+	github.com/filecoin-project/go-legs v0.2.4
 	github.com/frankban/quicktest v1.14.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.7 h1:D0egR6Q3Jkp5r4klxkdDQvjXeLx3cwZMKE55qop2xCI=
 github.com/filecoin-project/go-indexer-core v0.2.7/go.mod h1:6YD7KwDOQ+03DdAitviL7h1fksIU6a4j52yPnA/E1PU=
-github.com/filecoin-project/go-legs v0.2.3 h1:sNEUF+Cw4mpGp8hX4oZO/lIAiZpbJy55ih2GxXhj+V0=
-github.com/filecoin-project/go-legs v0.2.3/go.mod h1:mdNMISV/bWyZguFM7R4s0mxV1v6Vhda3BiAw9+jv5iE=
+github.com/filecoin-project/go-legs v0.2.4 h1:2U4Zg2NMO76YxMMFhAWscvDBatqOlbUYDNKB70cLNl4=
+github.com/filecoin-project/go-legs v0.2.4/go.mod h1:mdNMISV/bWyZguFM7R4s0mxV1v6Vhda3BiAw9+jv5iE=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -95,7 +95,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr *indexer.Engine, reg *regi
 
 	// Create and start pubsub subscriber.  This also registers the storage
 	// hook to index data as it is received.
-	sub, err := legs.NewSubscriber(h, ds, lsys, cfg.PubSubTopic, adSel, legs.AllowPeer(reg.Authorized), legs.BlockHook(ing.storageHook))
+	sub, err := legs.NewSubscriber(h, ds, lsys, cfg.PubSubTopic, adSel, legs.AllowPeer(reg.Authorized), legs.BlockHook(ing.storageHook), legs.SyncRecursionLimit(cfg.AdvertisementRecursionLimit()))
 	if err != nil {
 		log.Errorw("Failed to start pubsub subscriber", "err", err)
 		return nil, errors.New("ingester subscriber failed")


### PR DESCRIPTION
By default sync at most 400 unseed advertisements and expose ingest
config parameter to override it.