### PR TITLE
[e2e_test] Change pubsub topic name because indexprovider changed

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -180,7 +180,7 @@ func TestEndToEndWithReferenceProvider(t *testing.T) {
 	providerID := cfg.Identity.PeerID
 	t.Logf("Initialized provider ID: %s", providerID)
 
-	e.run(indexer, "init", "--store", "sth", "--pubsub-topic", "indexer/ingest", "--no-bootstrap")
+	e.run(indexer, "init", "--store", "sth", "--pubsub-topic", "/indexer/ingest/mainnet", "--no-bootstrap")
 	cfg, err = config.Load(filepath.Join(e.dir, ".storetheindex", "config"))
 	qt.Assert(t, err, qt.IsNil)
 	indexerID := cfg.Identity.PeerID


### PR DESCRIPTION
This is a good example of why non-reproducible tests are tricky. I spent at least half an hour debugging this before I realized it was because of something **outside** this repo. Specifically this commit: https://github.com/filecoin-project/index-provider/commit/e5a9c5499341c48bcb86466ee656cacbb692b8b6

I get that it's annoying if this was a specific hash of the other repo. But there's probably a better solution.