### PR TITLE
Add compatibility with old signature format

### DIFF
--- a/api/v0/admin/client/http/client.go
+++ b/api/v0/admin/client/http/client.go
@@ -13,12 +13,9 @@ import (
 	"path"
 
 	"github.com/filecoin-project/storetheindex/api/v0/httpclient"
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 )
-
-var log = logging.Logger("adminhttpclient")
 
 const (
 	adminPort = 3002
@@ -68,7 +65,6 @@ func (c *Client) ImportFromManifest(ctx context.Context, fileName string, provID
 		}
 		return fmt.Errorf("importing from manifest failed: %v%s", http.StatusText(resp.StatusCode), errMsg)
 	}
-	log.Infow("Success")
 	return nil
 }
 
@@ -95,7 +91,6 @@ func (c *Client) ImportFromCidList(ctx context.Context, fileName string, provID 
 		}
 		return fmt.Errorf("importing from cidlist failed: %v%s", http.StatusText(resp.StatusCode), errMsg)
 	}
-	log.Infow("Success")
 	return nil
 }
 

--- a/api/v0/finder/client/http/client.go
+++ b/api/v0/finder/client/http/client.go
@@ -10,12 +10,9 @@ import (
 
 	"github.com/filecoin-project/storetheindex/api/v0/finder/model"
 	"github.com/filecoin-project/storetheindex/api/v0/httpclient"
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multihash"
 )
-
-var log = logging.Logger("finderhttpclient")
 
 const (
 	finderPort    = 3000
@@ -142,7 +139,6 @@ func (c *Client) sendRequest(req *http.Request) (*model.FindResponse, error) {
 	// Handle failed requests
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusNotFound {
-			log.Info("Entry not found in indexer")
 			return &model.FindResponse{}, nil
 		}
 		return nil, fmt.Errorf("batch find query failed: %v", http.StatusText(resp.StatusCode))

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -47,7 +47,7 @@ const (
 	testRetryTimeout  = 10 * time.Second
 
 	testEntriesChunkCount = 3
-	testEntriesChunkSize  = 10
+	testEntriesChunkSize  = 15
 )
 
 var (
@@ -249,7 +249,6 @@ func TestRmWithNoEntries(t *testing.T) {
 	allMhs := typehelpers.AllMultihashesFromAd(t, prevAdNode.(schema.Advertisement), te.publisherLinkSys)
 	// Remove the mhs from the first ad (since the last add removed this from the indexer)
 	allMhs = allMhs[1:]
-	fmt.Println("!!!!", allMhs)
 	checkMhsIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMhs)
 }
 func TestSync(t *testing.T) {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.5"
+  "version": "v0.2.6"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.6"
+  "version": "v0.3.0"
 }


### PR DESCRIPTION
There are still many advertisements that are using the deprecated signature format.  Since these ads are still valid, allow the indexer to process them.  Log when an ad with a deprecated signature format is seen.

This will allow the new indexer to be deployed without requiring an update to any data providers/publishers.

Other changes:
- Removed some unwanted/unneeded logging from finder and admin client
- Update version