### PR TITLE
Update provider addrs using latest advertisement

### DIFF
--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -324,7 +324,7 @@ func TestRecursionDepthLimitsEntriesSync(t *testing.T) {
 		checkMhsIndexedEventually(t, ing.indexer, providerID, mhs)
 
 		lcid, err = ing.getLatestSync(pubHost.ID())
-		for lcid == cid.Undef {
+		for err == nil && lcid == cid.Undef {
 			// May not have marked ad as processed yet, retry.
 			time.Sleep(time.Second)
 			if ctx.Err() != nil {

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -197,9 +197,9 @@ func (ing *Ingester) storageHook(pubID peer.ID, c cid.Cid) {
 			return
 		}
 
-		// Store entries link into the reverse map so there is a way of
-		// identifying what advertisementID announced these entries
-		// when we come across the link.
+		// Store a mapping of entries link cid to advertisement cid so there is
+		// a way of identifying what advertisement announced these entries when
+		// we come across the link.
 		log.Debug("Saving map of entries to advertisement and advertisement data")
 		elnk, err := ad.FieldEntries().AsLink()
 		if err != nil {
@@ -326,9 +326,9 @@ func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid,
 
 	// Wait for the previous ad to finish processing.
 	if !ing.adWaiter.wait(prevCid) {
-		// If there was a previous ad, but it was not waitiable, then check if
+		// If there was a previous ad, but it was not waitable, then check if
 		// is it already in the datastore.  It ad is not stored, then wait for
-		// it to become waitable.  If ad is already in the datastoreto, then
+		// it to become waitable.  If ad is already in the datastore to, then
 		// was previously processed, so do not wait.
 		exists, err := ing.ds.Has(context.Background(), dsKey(prevCid.String()))
 		if err != nil {
@@ -340,10 +340,10 @@ func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid,
 		ing.adWaiter.wait(prevCid)
 	}
 
-	// When done with this ad's entries,
+	// Signal when done with this ad's entries.
 	defer ing.adWaiter.done(adCid)
 
-	// Mark the ad as processed after done preocessing. This is even in most
+	// Mark the ad as processed after done processing. This is even in most
 	// error cases so that the indexer is not stuck trying to reprocessing a
 	// malformed ad.
 	var reprocessAd bool
@@ -352,7 +352,7 @@ func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid,
 			// Do not mark ad as done so that it will be reprocessed.
 			return
 		}
-		// Processed all the entries, so mark ths ad as processed.
+		// Processed all the entries, so mark this ad as processed.
 		if err := ing.markAdProcessed(from, adCid); err != nil {
 			log.Errorw("Failed to mark ad as processed", "err", err)
 		}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -374,7 +374,7 @@ func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid,
 	// provider must be allowed by policy to be registered.
 	err = ing.reg.RegisterOrUpdate(context.Background(), providerID, addrs, adCid)
 	if err != nil {
-		log.Errorw("Could register/update provider info", "err", err)
+		log.Errorw("Could not register/update provider info", "err", err)
 		return
 	}
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -256,30 +256,30 @@ func (r *Registry) BlockPeer(peerID peer.ID) bool {
 func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, addrs []string, adID cid.Cid) error {
 	// Check that the provider has been discovered and validated
 	info := r.ProviderInfo(providerID)
-	if info == nil {
-		if len(addrs) == 0 {
-			return errors.New("cannot register provider with no address")
-		}
-
-		maddrs, err := stringsToMultiaddrs(addrs)
-		if err != nil {
-			return err
-		}
-
+	if info != nil {
 		info = &ProviderInfo{
 			AddrInfo: peer.AddrInfo{
 				ID:    providerID,
-				Addrs: maddrs,
+				Addrs: info.AddrInfo.Addrs,
 			},
+			DiscoveryAddr:         info.DiscoveryAddr,
+			LastAdvertisement:     info.LastAdvertisement,
+			LastAdvertisementTime: info.LastAdvertisementTime,
 		}
 	} else {
-		if len(addrs) != 0 {
-			maddrs, err := stringsToMultiaddrs(addrs)
-			if err != nil {
-				return err
-			}
-			info.AddrInfo.Addrs = maddrs
+		info = &ProviderInfo{
+			AddrInfo: peer.AddrInfo{
+				ID: providerID,
+			},
 		}
+	}
+
+	if len(addrs) != 0 {
+		maddrs, err := stringsToMultiaddrs(addrs)
+		if err != nil {
+			panic(err)
+		}
+		info.AddrInfo.Addrs = maddrs
 	}
 
 	now := time.Now()

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -474,6 +474,13 @@ func (r *Registry) loadPersistedProviders(ctx context.Context) (int, error) {
 			return 0, fmt.Errorf("cannot decode provider ID: %s", err)
 		}
 
+		// If provider is not allowed, then do not load into registry.
+		allowed, _ := r.policy.Check(peerID)
+		if !allowed {
+			log.Warnw("Refusing to load registry data for forbidden peer", "peer", peerID)
+			continue
+		}
+
 		pinfo := new(ProviderInfo)
 		err = json.Unmarshal(ent.Value, pinfo)
 		if err != nil {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -266,49 +266,20 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 			return err
 		}
 
-		now := time.Now()
 		info = &ProviderInfo{
 			AddrInfo: peer.AddrInfo{
 				ID:    providerID,
 				Addrs: maddrs,
 			},
-			lastContactTime: now,
 		}
-
-		if adID != cid.Undef {
-			info.LastAdvertisement = adID
-			info.LastAdvertisementTime = now
-		}
-
-		return r.Register(ctx, info)
-	}
-
-	var update bool
-
-	if len(addrs) != 0 {
-		maddrs, err := stringsToMultiaddrs(addrs)
-		if err != nil {
-			return err
-		}
-
-		// If the registered addresses are different than those provided, then
-		// re-register with new address.
-		if len(addrs) != len(info.AddrInfo.Addrs) {
-			info.AddrInfo.Addrs = maddrs
-			update = true
-		} else {
-			for i := range maddrs {
-				if !maddrs[i].Equal(info.AddrInfo.Addrs[i]) {
-					info.AddrInfo.Addrs = maddrs
-					update = true
-					break
-				}
+	} else {
+		if len(addrs) != 0 {
+			maddrs, err := stringsToMultiaddrs(addrs)
+			if err != nil {
+				return err
 			}
+			info.AddrInfo.Addrs = maddrs
 		}
-	}
-
-	if !update && adID == cid.Undef {
-		return nil
 	}
 
 	now := time.Now()


### PR DESCRIPTION
When reading a chain of advertisements, the indexer uses the addresses from the last ad received, which is the earliest on the chain.  This PR fixes this so that the indexer updates to provider address using the last ad on the chain.
Fixes #193 

Other features in this PR:
- Cleanup any temproary entry cit to ad cid mappings.  The could be leftover from an unexpected termination of indexer and need to be cleaned up on restart.
- When processing a chain of advertisements, a removal of content by contextID causes the indexer to skip syncing entries from previous ads in the chain that have that same contextID. Fixes #124