### PR TITLE
Cleanup entry to ad reverse mapping when skipping ads

### DIFF
--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -368,7 +368,7 @@ func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid,
 			dk := dsKey(admapPrefix + entCid.String())
 			err = ing.ds.Delete(context.Background(), dk)
 			if err != nil {
-				log.Errorw("cannot delete advertisement cid for entries cid from datastore: %w", err)
+				log.Errorw("cannot delete advertisement cid for entries cid from datastore", "err", err)
 			}
 		}
 		return


### PR DESCRIPTION
When skipping ads, the initial reverse mapping of entry cid to ad cid needs to be deleted.  Also, when deleting by context ID the ad will have no entries, so a reverse mapping should not be created.