### PR TITLE
Handle deadlock on ingester close

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -123,9 +123,9 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 }
 
 func (ing *Ingester) Close() error {
+	ing.adWaiter.close()
 	// Close leg transport.
 	err := ing.sub.Close()
-	ing.adWaiter.close()
 	close(ing.sigUpdate)
 	return err
 }


### PR DESCRIPTION
Fixes a deadlock when we call `Ingester.Close`. This happens because we close
the subscriber before waiting for all the syncAdEntries goroutines to finish.
This means you can have a goroutine waiting hopelessly for a go-legs'
`subscriber.Sync` call to finish. By flipping the order you wait for the
goroutine to finish before shutting down go-legs.

Also adds  a test that checks if we handle the duplicate entries chunk case correctly.
(Adding this test uncovered the bug since it would hang after the test seemingly finished).
