### PR TITLE
Optionally disable individual servers in config or CLI

### DIFF
--- a/api/v0/protocol_ids.go
+++ b/api/v0/protocol_ids.go
@@ -5,6 +5,6 @@ import "github.com/libp2p/go-libp2p-core/protocol"
 const (
 	// FinderProtocolID is the libp2p protocol that finder API uses
 	FinderProtocolID protocol.ID = "/indexer/finder/0.0.1"
-	// FinderProtocolID is the libp2p protocol that ingest API uses
-	IngestProtocolID protocol.ID = "/indexer/indest/0.0.1"
+	// IngestProtocolID is the libp2p protocol that ingest API uses
+	IngestProtocolID protocol.ID = "/indexer/ingest/0.0.1"
 )

--- a/command/flags.go
+++ b/command/flags.go
@@ -60,8 +60,26 @@ var daemonFlags = []cli.Flag{
 	cacheSizeFlag,
 	logLevelFlag,
 	&cli.BoolFlag{
+		Name:     "noadmin",
+		Usage:    "Disable admin server",
+		Value:    false,
+		Required: false,
+	},
+	&cli.BoolFlag{
+		Name:     "noingest",
+		Usage:    "Disable ingest server (register, discover, single item ingest)",
+		Value:    false,
+		Required: false,
+	},
+	&cli.BoolFlag{
+		Name:     "nofinder",
+		Usage:    "Disable finder server",
+		Value:    false,
+		Required: false,
+	},
+	&cli.BoolFlag{
 		Name:     "nop2p",
-		Usage:    "Disable libp2p client api for indexer",
+		Usage:    "Disable libp2p hosting indexer",
 		Value:    false,
 		Required: false,
 	},

--- a/config/addresses.go
+++ b/config/addresses.go
@@ -2,15 +2,17 @@ package config
 
 // Addresses stores the (string) multiaddr addresses for the node.
 type Addresses struct {
-	// Admin is the admin http listen address
+	// Admin is the admin http listen address. Set to "none" to disable this
+	// server for both http and libp2p.
 	Admin string
-	// Finder is the finder http isten address
+	// Finder is the finder http isten address. Set to "none" to disable this
+	// server for both http and libp2p.
 	Finder string
-	// Ingest is the index data ingestion http listen address
+	// Ingest is the index data ingestion http listen address. Set to "none"
+	// to disable this server for both http and libp2p.
 	Ingest string
-	// DisbleP2P disables libp2p hosting
-	DisableP2P bool
-	// P2PMaddr is the libp2p host multiaddr for all servers
+	// P2PMaddr is the libp2p host multiaddr for all servers. Set to "none" to
+	// disable libp2p hosting.
 	P2PAddr string
 }
 


### PR DESCRIPTION
The admin, finder, and ingest servers can be individually disabled by using the keyword "none" as their http listen address. They can also be disabled by the `--noadmin`, `--nofinder`, and `--noingest` flags to the daemon.