### PR TITLE
Fix calculation of addrLen in envelop creation

### DIFF
--- a/api/v0/ingest/schema/envelope.go
+++ b/api/v0/ingest/schema/envelope.go
@@ -68,7 +68,7 @@ func signaturePayload(previousID Link_Advertisement, provider string, addrs []st
 
 	var addrsLen int
 	for _, addr := range addrs {
-		addrsLen = len(addr)
+		addrsLen += len(addr)
 	}
 
 	// Signature data is previousID+entries+metadata+isRm


### PR DESCRIPTION
We were setting the len of all addreses to be just the length of the last
address. This shouldn't affect anything since `bytes.Buffer` will grow as
needed. But it should save us a grow during write, and match the original intention of the code.
