### PR TITLE
A couple of metric tweaks

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -190,7 +190,7 @@ func (ing *Ingester) signalMetricsUpdate() {
 // metricsUpdate periodically updates metrics.  This goroutine exits when the
 // sigUpdate channel is closed, when Close is called.
 func (ing *Ingester) metricsUpdater() {
-	var hasUpdate bool
+	hasUpdate := true
 	t := time.NewTimer(time.Minute)
 
 	for {

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -280,6 +280,10 @@ func (ing *Ingester) storageHook(pubID peer.ID, c cid.Cid) {
 func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid, prevCid cid.Cid) {
 	stats.Record(context.Background(), metrics.IngestChange.M(1))
 	var skip bool
+	ingestStart := time.Now()
+	defer func() {
+		stats.Record(context.Background(), metrics.AdIngestLatency.M(coremetrics.MsecSince(ingestStart)))
+	}()
 
 	log := log.With("publisher", from, "adCid", adCid)
 

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-indexer-core"
+	coremetrics "github.com/filecoin-project/go-indexer-core/metrics"
 	v0 "github.com/filecoin-project/storetheindex/api/v0"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/filecoin-project/storetheindex/internal/metrics"
@@ -22,7 +23,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multihash"
 	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 
 	// Import so these codecs get registered.
 	_ "github.com/ipld/go-ipld-prime/codec/dagcbor"
@@ -278,6 +278,7 @@ func (ing *Ingester) storageHook(pubID peer.ID, c cid.Cid) {
 
 // syncAdEntries fetches all the entries for a single advertisement
 func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid, prevCid cid.Cid) {
+	stats.Record(context.Background(), metrics.IngestChange.M(1))
 	var skip bool
 
 	log := log.With("publisher", from, "adCid", adCid)
@@ -357,6 +358,8 @@ func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid,
 		// Processed all the entries, so mark this ad as processed.
 		if err := ing.markAdProcessed(from, adCid); err != nil {
 			log.Errorw("Failed to mark ad as processed", "err", err)
+		} else {
+			stats.Record(context.Background(), metrics.AdSyncedCount.M(1))
 		}
 	}()
 
@@ -466,12 +469,8 @@ func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid,
 	}
 	elapsed := time.Since(startTime)
 	// Record how long sync took.
-	stats.Record(context.Background(), metrics.SyncLatency.M(float64(elapsed.Nanoseconds())/1e6))
+	stats.Record(context.Background(), metrics.EntriesSyncLatency.M(coremetrics.MsecSince(startTime)))
 	log.Infow("Finished syncing entries", "elapsed", elapsed)
-
-	_ = stats.RecordWithOptions(context.Background(),
-		stats.WithTags(tag.Insert(metrics.Method, "libp2p")),
-		stats.WithMeasurements(metrics.IngestChange.M(1)))
 
 	ing.signalMetricsUpdate()
 }

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -470,7 +470,7 @@ func (ing *Ingester) syncAdEntries(from peer.ID, ad schema.Advertisement, adCid,
 	log.Infow("Finished syncing entries", "elapsed", elapsed)
 
 	_ = stats.RecordWithOptions(context.Background(),
-		stats.WithTags(tag.Insert(metrics.Method, "libp2p2")),
+		stats.WithTags(tag.Insert(metrics.Method, "libp2p")),
 		stats.WithMeasurements(metrics.IngestChange.M(1)))
 
 	ing.signalMetricsUpdate()

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -24,6 +24,7 @@ var (
 	FindLatency        = stats.Float64("find/latency", "Time to respond to a find request", stats.UnitMilliseconds)
 	IngestChange       = stats.Int64("ingest/change", "Number of syncAdEntries started", stats.UnitDimensionless)
 	AdSyncedCount      = stats.Int64("ingest/adsync", "Number of syncAdEntries completed successfully", stats.UnitDimensionless)
+	AdIngestLatency    = stats.Float64("ingest/adsynclatency", "latency of syncAdEntries completed successfully", stats.UnitDimensionless)
 	ProviderCount      = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
 	EntriesSyncLatency = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 )
@@ -32,6 +33,10 @@ var (
 var (
 	findLatencyView = &view.View{
 		Measure:     FindLatency,
+		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
+	}
+	adIngestLatencyView = &view.View{
+		Measure:     AdIngestLatency,
 		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
 	}
 	ingestChangeView = &view.View{
@@ -47,7 +52,7 @@ var (
 		Measure:     ProviderCount,
 		Aggregation: view.LastValue(),
 	}
-	syncLatencyView = &view.View{
+	entriesSyncLatencyView = &view.View{
 		Measure:     EntriesSyncLatency,
 		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
 	}
@@ -58,7 +63,7 @@ var log = logging.Logger("indexer/metrics")
 // Start creates an HTTP router for serving metric info
 func Start(views []*view.View) http.Handler {
 	// Register default views
-	err := view.Register(findLatencyView, ingestChangeView, providerView, syncLatencyView)
+	err := view.Register(findLatencyView, ingestChangeView, providerView, entriesSyncLatencyView, adSyncCountView, adIngestLatencyView)
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)
 	}

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -21,10 +21,11 @@ var (
 
 // Measures
 var (
-	FindLatency   = stats.Float64("find/latency", "Time to respond to a find request", stats.UnitMilliseconds)
-	IngestChange  = stats.Int64("ingest/change", "Number of ingest triggers received", stats.UnitDimensionless)
-	ProviderCount = stats.Int64("provider/count", "Number of know (registered) providers", stats.UnitDimensionless)
-	SyncLatency   = stats.Float64("ingest/synclatency", "Time for sync to complete", stats.UnitMilliseconds)
+	FindLatency        = stats.Float64("find/latency", "Time to respond to a find request", stats.UnitMilliseconds)
+	IngestChange       = stats.Int64("ingest/change", "Number of syncAdEntries started", stats.UnitDimensionless)
+	AdSyncedCount      = stats.Int64("ingest/adsync", "Number of syncAdEntries completed successfully", stats.UnitDimensionless)
+	ProviderCount      = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
+	EntriesSyncLatency = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 )
 
 // Views
@@ -38,12 +39,16 @@ var (
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{Method},
 	}
+	adSyncCountView = &view.View{
+		Measure:     AdSyncedCount,
+		Aggregation: view.Count(),
+	}
 	providerView = &view.View{
 		Measure:     ProviderCount,
 		Aggregation: view.LastValue(),
 	}
 	syncLatencyView = &view.View{
-		Measure:     SyncLatency,
+		Measure:     EntriesSyncLatency,
 		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
 	}
 )


### PR DESCRIPTION
Just a couple tweaks around the metrics to make them more useful or give them a better description.

- Set hasUpdate to be initially true so that we set the storeSize on restart
- Ad a new metric for count of successful ad syncs
- Add a new metric for total latency of ad ingest

I'm hesitant to add any more metrics until we have a need for them. Also there's probably a couple things we want to record inside go-legs (like httpsync vs. dtsync which should be transparent to the ingester).