### PR TITLE
Use context background so background task can continue

### DIFF
--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -116,7 +116,7 @@ func (h *IngestHandler) IndexContent(ctx context.Context, data []byte) error {
 
 const maxAnnounceSize = 512
 
-func (h *IngestHandler) Announce(ctx context.Context, r io.Reader) error {
+func (h *IngestHandler) Announce(r io.Reader) error {
 	data, err := io.ReadAll(io.LimitReader(r, maxAnnounceSize))
 	if err != nil {
 		return err
@@ -158,7 +158,10 @@ func (h *IngestHandler) Announce(ctx context.Context, r io.Reader) error {
 			return nil
 		}
 	}
-	h.ingester.Sync(ctx, pid.ID, pid.Addrs[0])
+
+	// We set context background because this will be an async process. We don't
+	// want to attach the context to the request context that started this.
+	h.ingester.Sync(context.Background(), pid.ID, pid.Addrs[0])
 
 	return nil
 }

--- a/server/ingest/http/handler.go
+++ b/server/ingest/http/handler.go
@@ -102,7 +102,7 @@ func (h *httpHandler) announce(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	defer r.Body.Close()
-	err := h.ingestHandler.Announce(r.Context(), r.Body)
+	err := h.ingestHandler.Announce(r.Body)
 	if err != nil {
 		httpserver.HandleError(w, err, "announce")
 		return


### PR DESCRIPTION
## Context
If you called the Announce endpoint you'd get some error like:
```
Failed to execute fetch request {"err": "Get \"http://127.0.0.1:8070/head\": context canceled"}
```

This is because the `h.ingester.Sync` function was called with the context of
the http request. And as soon as the http response was returned the request
context was cancelled.

## Proposed Solution

Pass a context.Background() instead since this is a background task.


this is built on top of @gammazero's https://github.com/filecoin-project/storetheindex/pull/207 update legs PR to avoid conflict thrashing.