### PR TITLE
Export function that signs advertisements

### DIFF
--- a/api/v0/ingest/schema/envelope.go
+++ b/api/v0/ingest/schema/envelope.go
@@ -97,8 +97,8 @@ func signaturePayload(previousID Link_Advertisement, provider string, addrs []st
 	return multihash.Sum(sigBuf.Bytes(), mhCode, -1)
 }
 
-// Signs advertisements using libp2p envelope
-func signAdvertisement(privkey crypto.PrivKey, ad Advertisement) ([]byte, error) {
+// SignAdvertisement signs an advertisement using the given private key.
+func SignAdvertisement(privkey crypto.PrivKey, ad Advertisement) ([]byte, error) {
 	previousID := ad.FieldPreviousID().v
 	provider := ad.FieldProvider().x
 	addrs, err := IpldToGoStrings(ad.FieldAddresses())

--- a/api/v0/ingest/schema/utils.go
+++ b/api/v0/ingest/schema/utils.go
@@ -251,7 +251,7 @@ func newAdvertisement(
 	}
 
 	// Sign advertisement
-	sig, err := signAdvertisement(signKey, ad)
+	sig, err := SignAdvertisement(signKey, ad)
 	if err != nil {
 		return nil, err
 	}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.1"
+  "version": "v0.3.2"
 }


### PR DESCRIPTION
Export the function that is used to sign advertisements so that it can
be reused for testing purposes in `index-provider`.

Note that its counterpart verify function is already exported.

Bump version in preparation for release.