### PR TITLE
Metrics around errors in syncAdEntries

### DIFF
--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -16,17 +16,20 @@ import (
 var (
 	Version, _ = tag.NewKey("version")
 
-	Method, _ = tag.NewKey("method")
+	Method, _          = tag.NewKey("method")
+	AdIngestErrType, _ = tag.NewKey("ErrorType")
 )
 
 // Measures
 var (
-	FindLatency        = stats.Float64("find/latency", "Time to respond to a find request", stats.UnitMilliseconds)
-	IngestChange       = stats.Int64("ingest/change", "Number of syncAdEntries started", stats.UnitDimensionless)
-	AdSyncedCount      = stats.Int64("ingest/adsync", "Number of syncAdEntries completed successfully", stats.UnitDimensionless)
-	AdIngestLatency    = stats.Float64("ingest/adsynclatency", "latency of syncAdEntries completed successfully", stats.UnitDimensionless)
-	ProviderCount      = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
-	EntriesSyncLatency = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
+	FindLatency              = stats.Float64("find/latency", "Time to respond to a find request", stats.UnitMilliseconds)
+	IngestChange             = stats.Int64("ingest/change", "Number of syncAdEntries started", stats.UnitDimensionless)
+	AdSyncedCount            = stats.Int64("ingest/adsync", "Number of syncAdEntries completed successfully", stats.UnitDimensionless)
+	AdIngestError            = stats.Int64("ingest/adingesterror", "Number of errors encountered during syncAdEntries", stats.UnitDimensionless)
+	EntryChunkAlreadyPresent = stats.Int64("ingest/entryChunkAlreadyPresent", "Number of times we early return an ad ingest because we already have the entryChunk. This is an anamoly and would happen when an indexer crashes while processing an entry chunk.", stats.UnitDimensionless)
+	AdIngestLatency          = stats.Float64("ingest/adsynclatency", "latency of syncAdEntries completed successfully", stats.UnitDimensionless)
+	ProviderCount            = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
+	EntriesSyncLatency       = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 )
 
 // Views
@@ -48,6 +51,15 @@ var (
 		Measure:     AdSyncedCount,
 		Aggregation: view.Count(),
 	}
+	adIngestErrorView = &view.View{
+		Measure:     AdIngestError,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{AdIngestErrType},
+	}
+	entryChunkAlreadyPresentView = &view.View{
+		Measure:     EntryChunkAlreadyPresent,
+		Aggregation: view.Count(),
+	}
 	providerView = &view.View{
 		Measure:     ProviderCount,
 		Aggregation: view.LastValue(),
@@ -63,7 +75,17 @@ var log = logging.Logger("indexer/metrics")
 // Start creates an HTTP router for serving metric info
 func Start(views []*view.View) http.Handler {
 	// Register default views
-	err := view.Register(findLatencyView, ingestChangeView, providerView, entriesSyncLatencyView, adSyncCountView, adIngestLatencyView)
+	err := view.Register(
+		adIngestErrorView,
+		adIngestLatencyView,
+		adSyncCountView,
+		entriesSyncLatencyView,
+		entryChunkAlreadyPresentView,
+		findLatencyView,
+		ingestChangeView,
+		providerView,
+	)
+
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)
 	}

--- a/test/typehelpers/typehelpers.go
+++ b/test/typehelpers/typehelpers.go
@@ -200,3 +200,30 @@ func AllAds(t *testing.T, ad schema.Advertisement, lsys ipld.LinkSystem) []schem
 
 	return out
 }
+
+func AllEntryChunkLinks(t *testing.T, ad schema.Advertisement, lsys ipld.LinkSystem) []datamodel.Link {
+	var out []datamodel.Link
+
+	ecLink, err := ad.Entries.AsLink()
+	require.NoError(t, err)
+	out = append(out, ecLink)
+
+	ecNode, err := lsys.Load(linking.LinkContext{}, ecLink, schema.Type.EntryChunk)
+	require.NoError(t, err)
+
+	ec := ecNode.(schema.EntryChunk)
+
+	for {
+		if ec.Next.IsAbsent() {
+			return out
+		}
+
+		l, err := ec.Next.AsNode().AsLink()
+		require.NoError(t, err)
+		out = append(out, l)
+
+		n, err := lsys.Load(linking.LinkContext{}, l, schema.Type.EntryChunk)
+		require.NoError(t, err)
+		ec = n.(schema.EntryChunk)
+	}
+}


### PR DESCRIPTION
First pass at adding some obs around these error cases. 

I think the `EntryChunkAlreadyPresent` case is especially worrisome and likely wrong. Our current flow has us delete an entry chunk after processing, so the only way we have an entry chunk stored and hit that codepath is if we started processing an entry chunk and then crashed before finishing. Or if there are concurrent syncs (because of multiple publishers). So that specific metric is to highlight if we're seeing this in the wild, since it's almost certainly a bug.

Also makes a test a bit stronger by testing a restart in the middle of processing an Ad, not just the beginning.