### PR TITLE
Add admin `sync` with custom recursion depth

### DIFF
--- a/command/admin.go
+++ b/command/admin.go
@@ -65,7 +65,7 @@ func syncCmd(cctx *cli.Context) error {
 			return err
 		}
 	}
-	err = cl.Sync(cctx.Context, peerID, addr)
+	err = cl.Sync(cctx.Context, peerID, addr, cctx.Int64("depth"))
 	if err != nil {
 		return err
 	}

--- a/command/flags.go
+++ b/command/flags.go
@@ -141,6 +141,13 @@ var adminSyncFlags = []cli.Flag{
 		Usage:    "Multiaddr address of peer to sync with",
 		Required: false,
 	},
+	&cli.Int64Flag{
+		Name: "depth",
+		Usage: "The recursion depth limit while syncing advertisements. The value -1 indicates no limit. " +
+			"If unspecified, the configured indexer advertisement recursion limit is used.",
+		Required: false,
+		Value:    0,
+	},
 }
 
 var initFlags = []cli.Flag{

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -177,7 +177,7 @@ func TestRestartDuringSync(t *testing.T) {
 	err = te.publisher.UpdateRoot(ctx, bCid.(cidlink.Link).Cid)
 	require.NoError(t, err)
 
-	_, err = te.ingester.Sync(ctx, te.pubHost.ID(), nil)
+	_, err = te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0)
 	require.NoError(t, err)
 
 	// The ingester tried to sync B, but it was blocked. Now let's stop the ingester.
@@ -208,7 +208,7 @@ func TestRestartDuringSync(t *testing.T) {
 	// And sync to C
 	te.publisher.UpdateRoot(ctx, cCid.(cidlink.Link).Cid)
 
-	end, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil)
+	end, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0)
 	require.NoError(t, err)
 	<-end
 
@@ -232,7 +232,7 @@ func TestWithDuplicatedEntryChunks(t *testing.T) {
 
 	te.publisher.UpdateRoot(ctx, chainHead.(cidlink.Link).Cid)
 
-	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil)
+	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0)
 	require.NoError(t, err)
 	<-wait
 	var lcid cid.Cid
@@ -267,7 +267,7 @@ func TestRmWithNoEntries(t *testing.T) {
 	ctx := context.Background()
 	te.publisher.UpdateRoot(context.Background(), chainHead.(cidlink.Link).Cid)
 
-	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil)
+	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0)
 	require.NoError(t, err)
 	<-wait
 	var lcid cid.Cid
@@ -299,7 +299,7 @@ func TestSync(t *testing.T) {
 	// The explicit sync will happen concurrently with the sycn triggered by
 	// the published advertisement.  These will be serialized in the go-legs
 	// handler for the provider.
-	end, err := i.Sync(ctx, pubHost.ID(), nil)
+	end, err := i.Sync(ctx, pubHost.ID(), nil, 0)
 	require.NoError(t, err)
 	select {
 	case m := <-end:
@@ -337,7 +337,7 @@ func TestRecursionDepthLimitsEntriesSync(t *testing.T) {
 	adCid, _, providerID := publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, totalChunkCount)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	end, err := ing.Sync(ctx, pubHost.ID(), nil)
+	end, err := ing.Sync(ctx, pubHost.ID(), nil, 0)
 	require.NoError(t, err)
 
 	select {
@@ -465,12 +465,12 @@ func TestMultiplePublishers(t *testing.T) {
 
 	// Test with two random advertisement publications for each of them.
 	c1, mhs, providerID := publishRandomAdv(t, i, pubHost1, pub1, lsys1, false)
-	wait, err := i.Sync(ctx, pubHost1.ID(), nil)
+	wait, err := i.Sync(ctx, pubHost1.ID(), nil, 0)
 	require.NoError(t, err)
 	<-wait
 	checkMhsIndexedEventually(t, i.indexer, providerID, mhs)
 	c2, mhs, providerID := publishRandomAdv(t, i, pubHost2, pub2, lsys2, false)
-	wait, err = i.Sync(ctx, pubHost2.ID(), nil)
+	wait, err = i.Sync(ctx, pubHost2.ID(), nil, 0)
 	require.NoError(t, err)
 	<-wait
 	checkMhsIndexedEventually(t, i.indexer, providerID, mhs)

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -173,7 +173,7 @@ func (h *IngestHandler) Announce(r io.Reader) error {
 
 	// We set context background because this will be an async process. We don't
 	// want to attach the context to the request context that started this.
-	h.ingester.Sync(context.Background(), pid.ID, pid.Addrs[0])
+	h.ingester.Sync(context.Background(), pid.ID, pid.Addrs[0], 0)
 
 	return nil
 }


### PR DESCRIPTION
Add the ability to specify the recursion depth when syncing from a
provider via `admin sync` command. The flag `depth` now takes a
recursion depth limit. If non-zero, the depth is used to construct a
custom selector that:
  1. Recurses to the specified depth
  2. Stops at the currently latest synced ad

Fixes: #222