### PR TITLE
Allow explicit sync to proceed beyond the latest synced advertisement

### DIFF
--- a/api/v0/admin/client/http/client.go
+++ b/api/v0/admin/client/http/client.go
@@ -96,7 +96,7 @@ func (c *Client) ImportFromCidList(ctx context.Context, fileName string, provID 
 }
 
 // Sync with a data peer up to the latest ID.
-func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Multiaddr, depth int64) error {
+func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Multiaddr, depth int64, nolatest bool) error {
 	var data []byte
 	var err error
 	if peerAddr != nil {
@@ -111,7 +111,12 @@ func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Mu
 	// means "use the limit configured in config.Ingest".
 	// Note that the value -1 means no-limit.
 	if depth != 0 {
-		q = []string{"depth", strconv.FormatInt(depth, 10)}
+		q = append(q, "depth", strconv.FormatInt(depth, 10))
+	}
+
+	// Only set if true, since by default the latest sync is not ignored.
+	if nolatest {
+		q = append(q, "nolatest", strconv.FormatBool(nolatest))
 	}
 
 	return c.ingestRequest(ctx, peerID, "sync", http.MethodPost, data, q...)

--- a/command/admin.go
+++ b/command/admin.go
@@ -65,7 +65,7 @@ func syncCmd(cctx *cli.Context) error {
 			return err
 		}
 	}
-	err = cl.Sync(cctx.Context, peerID, addr, cctx.Int64("depth"))
+	err = cl.Sync(cctx.Context, peerID, addr, cctx.Int64("depth"), cctx.Bool("nolatest"))
 	if err != nil {
 		return err
 	}

--- a/command/flags.go
+++ b/command/flags.go
@@ -137,16 +137,19 @@ var adminSyncFlags = []cli.Flag{
 	peerFlag,
 	indexerHostFlag,
 	&cli.StringFlag{
-		Name:     "addr",
-		Usage:    "Multiaddr address of peer to sync with",
-		Required: false,
+		Name:  "addr",
+		Usage: "Multiaddr address of peer to sync with",
 	},
 	&cli.Int64Flag{
 		Name: "depth",
 		Usage: "The recursion depth limit while syncing advertisements. The value -1 indicates no limit. " +
 			"If unspecified, the configured indexer advertisement recursion limit is used.",
-		Required: false,
-		Value:    0,
+		Value: 0,
+	},
+	&cli.BoolFlag{
+		Name:  "nolatest",
+		Usage: "Whether to continue traversal beyond the latest synced advertisement.",
+		Value: false,
 	},
 }
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -177,7 +177,7 @@ func TestRestartDuringSync(t *testing.T) {
 	err = te.publisher.UpdateRoot(ctx, bCid.(cidlink.Link).Cid)
 	require.NoError(t, err)
 
-	_, err = te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0)
+	_, err = te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
 
 	// The ingester tried to sync B, but it was blocked. Now let's stop the ingester.
@@ -208,7 +208,7 @@ func TestRestartDuringSync(t *testing.T) {
 	// And sync to C
 	te.publisher.UpdateRoot(ctx, cCid.(cidlink.Link).Cid)
 
-	end, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0)
+	end, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
 	<-end
 
@@ -232,7 +232,7 @@ func TestWithDuplicatedEntryChunks(t *testing.T) {
 
 	te.publisher.UpdateRoot(ctx, chainHead.(cidlink.Link).Cid)
 
-	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0)
+	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
 	<-wait
 	var lcid cid.Cid
@@ -267,7 +267,7 @@ func TestRmWithNoEntries(t *testing.T) {
 	ctx := context.Background()
 	te.publisher.UpdateRoot(context.Background(), chainHead.(cidlink.Link).Cid)
 
-	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0)
+	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
 	<-wait
 	var lcid cid.Cid
@@ -299,7 +299,7 @@ func TestSync(t *testing.T) {
 	// The explicit sync will happen concurrently with the sycn triggered by
 	// the published advertisement.  These will be serialized in the go-legs
 	// handler for the provider.
-	end, err := i.Sync(ctx, pubHost.ID(), nil, 0)
+	end, err := i.Sync(ctx, pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
 	select {
 	case m := <-end:
@@ -337,7 +337,7 @@ func TestRecursionDepthLimitsEntriesSync(t *testing.T) {
 	adCid, _, providerID := publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, totalChunkCount)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	end, err := ing.Sync(ctx, pubHost.ID(), nil, 0)
+	end, err := ing.Sync(ctx, pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
 
 	select {
@@ -465,12 +465,12 @@ func TestMultiplePublishers(t *testing.T) {
 
 	// Test with two random advertisement publications for each of them.
 	c1, mhs, providerID := publishRandomAdv(t, i, pubHost1, pub1, lsys1, false)
-	wait, err := i.Sync(ctx, pubHost1.ID(), nil, 0)
+	wait, err := i.Sync(ctx, pubHost1.ID(), nil, 0, false)
 	require.NoError(t, err)
 	<-wait
 	checkMhsIndexedEventually(t, i.indexer, providerID, mhs)
 	c2, mhs, providerID := publishRandomAdv(t, i, pubHost2, pub2, lsys2, false)
-	wait, err = i.Sync(ctx, pubHost2.ID(), nil, 0)
+	wait, err = i.Sync(ctx, pubHost2.ID(), nil, 0, false)
 	require.NoError(t, err)
 	<-wait
 	checkMhsIndexedEventually(t, i.indexer, providerID, mhs)

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -75,8 +75,8 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 	}
 	log := log.With("peerID", peerID)
 
-	var depth int64
 	query := r.URL.Query()
+	var depth int64
 	depthStr := query.Get("depth")
 	if depthStr != "" {
 		var err error
@@ -87,6 +87,19 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		log = log.With("depth", depth)
+	}
+
+	var nolatest bool
+	nolatestStr := query.Get("nolatest")
+	if nolatestStr != "" {
+		var err error
+		nolatest, err = strconv.ParseBool(nolatestStr)
+		if err != nil {
+			log.Errorw("Cannot unmarshal flag nolatest as bool", "nolatestStr", nolatestStr, "err", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		log = log.With("nolatest", nolatest)
 	}
 
 	data, err := io.ReadAll(r.Body)
@@ -116,7 +129,7 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 	// Start the sync, but do not wait for it to complete.
 	//
 	// TODO: Provide some way for the client to see if the indexer has synced.
-	_, err = h.ingester.Sync(h.ctx, peerID, syncAddr, depth)
+	_, err = h.ingester.Sync(h.ctx, peerID, syncAddr, depth, nolatest)
 	if err != nil {
 		msg := "Cannot sync with peer"
 		log.Errorw(msg, "err", err)

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -173,7 +173,7 @@ func (h *IngestHandler) Announce(r io.Reader) error {
 
 	// We set context background because this will be an async process. We don't
 	// want to attach the context to the request context that started this.
-	h.ingester.Sync(context.Background(), pid.ID, pid.Addrs[0], 0)
+	h.ingester.Sync(context.Background(), pid.ID, pid.Addrs[0], 0, false)
 
 	return nil
 }


### PR DESCRIPTION
Add an option that allows an explicit sync to continue beyond the CID of
an advertisement that is already synced.

This is useful for cases where the ad recursion limit is expanded and
already synced advertisements need to be re-synced beyond the previous
recursion limit.

Relates to: #222