### PR TITLE
Need special case check if already synced

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -118,7 +118,6 @@ func (e *e2eTestRunner) stop(cmd *exec.Cmd, timeout time.Duration) {
 }
 
 func TestEndToEndWithReferenceProvider(t *testing.T) {
-	t.Skip("TODO this is our longest test by far.")
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test on windows")
 	}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -118,8 +118,9 @@ func (e *e2eTestRunner) stop(cmd *exec.Cmd, timeout time.Duration) {
 }
 
 func TestEndToEndWithReferenceProvider(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows")
+	switch runtime.GOOS {
+	case "windows", "darwin":
+		t.Skip("skipping test on", runtime.GOOS)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.8
-	github.com/filecoin-project/go-legs v0.3.4-0.20220223091155-656a11c0e6e5
+	github.com/filecoin-project/go-legs v0.3.4
 	github.com/frankban/quicktest v1.14.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.4

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.8
-	github.com/filecoin-project/go-legs v0.3.3
+	github.com/filecoin-project/go-legs v0.3.4-0.20220223091155-656a11c0e6e5
 	github.com/frankban/quicktest v1.14.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.8 h1:h1SRdZKTVcaXlzex3UevHh4OWDAhgpMzL4tHNAA7MQI=
 github.com/filecoin-project/go-indexer-core v0.2.8/go.mod h1:IagNfTdFuX4057kla43PjRCn3yBuUiZgIxuA0hTUamY=
-github.com/filecoin-project/go-legs v0.3.3 h1:x3/xXmW0e7rTKnFgXIqvYvN3IlZ8lCXJ7Vp/Na1c9f8=
-github.com/filecoin-project/go-legs v0.3.3/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
+github.com/filecoin-project/go-legs v0.3.4-0.20220223091155-656a11c0e6e5 h1:oKihDvQL81oyx+Nf+/z9WwTpOMGAWq/MJVcjF4UYtGY=
+github.com/filecoin-project/go-legs v0.3.4-0.20220223091155-656a11c0e6e5/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.8 h1:h1SRdZKTVcaXlzex3UevHh4OWDAhgpMzL4tHNAA7MQI=
 github.com/filecoin-project/go-indexer-core v0.2.8/go.mod h1:IagNfTdFuX4057kla43PjRCn3yBuUiZgIxuA0hTUamY=
-github.com/filecoin-project/go-legs v0.3.4-0.20220223091155-656a11c0e6e5 h1:oKihDvQL81oyx+Nf+/z9WwTpOMGAWq/MJVcjF4UYtGY=
-github.com/filecoin-project/go-legs v0.3.4-0.20220223091155-656a11c0e6e5/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
+github.com/filecoin-project/go-legs v0.3.4 h1:yid2IivTJ8JeF1ROA8jxNKNKJshU/HO1sRo5lEMNOUc=
+github.com/filecoin-project/go-legs v0.3.4/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -282,7 +282,7 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 				seenAdCids = append(seenAdCids, c)
 			}),
 		}
-		if !ignoreLatest {
+		if sel != nil && !ignoreLatest {
 			opts = append(opts, legs.CheckAlreadySynced())
 		}
 		c, err := ing.sub.Sync(ctx, peerID, cid.Undef, sel, peerAddr, opts...)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -236,13 +236,13 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 		return nil, err
 	}
 
-	log := log.With("provider", peerID, "peerAddr", peerAddr, "depth", depth, "ignoreLatest", ignoreLatest)
-	log.Info("Explicitly syncing the latest advertisement from peer")
-
 	ing.waitForPendingSyncs.Add(1)
 	go func() {
 		defer ing.waitForPendingSyncs.Done()
 		defer close(out)
+
+		log := log.With("provider", peerID, "peerAddr", peerAddr, "depth", depth, "ignoreLatest", ignoreLatest)
+		log.Info("Explicitly syncing the latest advertisement from peer")
 
 		var isResync bool
 		var sel ipld.Node
@@ -277,9 +277,13 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 		// Reference to the latest synced CID is only updated if the given
 		// selector is nil.
 		var seenAdCids []cid.Cid
-		c, err := ing.sub.SyncWithHook(ctx, peerID, cid.Undef, sel, peerAddr, func(i peer.ID, c cid.Cid) {
+		opts := []legs.SyncOption{legs.ScopedBlockHook(func(i peer.ID, c cid.Cid) {
 			seenAdCids = append(seenAdCids, c)
-		})
+		})}
+		if !ignoreLatest {
+			opts = append(opts, legs.CheckAlreadySynced())
+		}
+		c, err := ing.sub.Sync(ctx, peerID, cid.Undef, sel, peerAddr, opts...)
 
 		// If this is a resync, we need to mark the adChain as unprocessed so that
 		// we can reingest everything from the start of this sync. We cannot simply

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -268,18 +268,20 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 		}
 
 		// Start syncing. Notifications for the finished sync are sent
-		// asynchronously.  Sync with cid.Undef so that the latest head
-		// is queried by go-legs via head-publisher.
+		// asynchronously.  Sync with cid.Undef so that the latest head is
+		// queried by go-legs via head-publisher.
 		//
-		// Note that if the selector is nil the default selector is used
-		// where traversal stops at the latest known head.
+		// Note that if the selector is nil the default selector is used where
+		// traversal stops at the latest known head.
 		//
 		// Reference to the latest synced CID is only updated if the given
 		// selector is nil.
 		var seenAdCids []cid.Cid
-		opts := []legs.SyncOption{legs.ScopedBlockHook(func(i peer.ID, c cid.Cid) {
-			seenAdCids = append(seenAdCids, c)
-		})}
+		opts := []legs.SyncOption{
+			legs.ScopedBlockHook(func(i peer.ID, c cid.Cid) {
+				seenAdCids = append(seenAdCids, c)
+			}),
+		}
 		if !ignoreLatest {
 			opts = append(opts, legs.CheckAlreadySynced())
 		}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -317,12 +317,12 @@ func (ing *Ingester) ingestAd(publisher peer.ID, adCid cid.Cid) error {
 
 	// Traverse entries based on the entries selector that limits recursion depth.
 	var errsIngestingEntryChunks []error
-	_, err = ing.sub.SyncWithHook(ctx, publisher, entriesCid, ing.entriesSel, nil, func(p peer.ID, c cid.Cid) {
+	_, err = ing.sub.Sync(ctx, publisher, entriesCid, ing.entriesSel, nil, legs.ScopedBlockHook(func(p peer.ID, c cid.Cid) {
 		err := ing.ingestEntryChunk(p, adCid, c)
 		if err != nil {
 			errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
 		}
-	})
+	}))
 	if err != nil {
 		reprocessAd = true
 		return fmt.Errorf("failed to sync: %w", err)


### PR DESCRIPTION
A special case check to see if the current head is already synced is needed when using a selector with a stop node, because the selector only checks if the previous node is the stop node.