### PR TITLE
Rename `nolatest` flag to `resync`

### DIFF
--- a/api/v0/admin/client/http/client.go
+++ b/api/v0/admin/client/http/client.go
@@ -96,7 +96,7 @@ func (c *Client) ImportFromCidList(ctx context.Context, fileName string, provID 
 }
 
 // Sync with a data peer up to the latest ID.
-func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Multiaddr, depth int64, nolatest bool) error {
+func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Multiaddr, depth int64, resync bool) error {
 	var data []byte
 	var err error
 	if peerAddr != nil {
@@ -115,8 +115,8 @@ func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Mu
 	}
 
 	// Only set if true, since by default the latest sync is not ignored.
-	if nolatest {
-		q = append(q, "nolatest", strconv.FormatBool(nolatest))
+	if resync {
+		q = append(q, "resync", strconv.FormatBool(resync))
 	}
 
 	return c.ingestRequest(ctx, peerID, "sync", http.MethodPost, data, q...)

--- a/command/admin.go
+++ b/command/admin.go
@@ -65,7 +65,7 @@ func syncCmd(cctx *cli.Context) error {
 			return err
 		}
 	}
-	err = cl.Sync(cctx.Context, peerID, addr, cctx.Int64("depth"), cctx.Bool("nolatest"))
+	err = cl.Sync(cctx.Context, peerID, addr, cctx.Int64("depth"), cctx.Bool("resync"))
 	if err != nil {
 		return err
 	}

--- a/command/flags.go
+++ b/command/flags.go
@@ -147,8 +147,8 @@ var adminSyncFlags = []cli.Flag{
 		Value: 0,
 	},
 	&cli.BoolFlag{
-		Name:  "nolatest",
-		Usage: "Whether to continue traversal beyond the latest synced advertisement.",
+		Name:  "resync",
+		Usage: "Ignore the latest synced advertisement and sync advertisements as far back as the depth limit allows.",
 		Value: false,
 	},
 }

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -89,17 +89,17 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 		log = log.With("depth", depth)
 	}
 
-	var nolatest bool
-	nolatestStr := query.Get("nolatest")
-	if nolatestStr != "" {
+	var resync bool
+	resyncStr := query.Get("resync")
+	if resyncStr != "" {
 		var err error
-		nolatest, err = strconv.ParseBool(nolatestStr)
+		resync, err = strconv.ParseBool(resyncStr)
 		if err != nil {
-			log.Errorw("Cannot unmarshal flag nolatest as bool", "nolatestStr", nolatestStr, "err", err)
+			log.Errorw("Cannot unmarshal flag resync as bool", "resync", resyncStr, "err", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		log = log.With("nolatest", nolatest)
+		log = log.With("resync", resync)
 	}
 
 	data, err := io.ReadAll(r.Body)
@@ -129,7 +129,7 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 	// Start the sync, but do not wait for it to complete.
 	//
 	// TODO: Provide some way for the client to see if the indexer has synced.
-	_, err = h.ingester.Sync(h.ctx, peerID, syncAddr, depth, nolatest)
+	_, err = h.ingester.Sync(h.ctx, peerID, syncAddr, depth, resync)
 	if err != nil {
 		msg := "Cannot sync with peer"
 		log.Errorw(msg, "err", err)


### PR DESCRIPTION
The flag "nolatest" says what the code is doing, but is not descriptive to users.  Changing to "resync" as it more clearly describes the behavior.