### PR TITLE
Explicit Sync always updates latest synced

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.8
-	github.com/filecoin-project/go-legs v0.3.4
+	github.com/filecoin-project/go-legs v0.3.5-0.20220223202522-095d2645014f
 	github.com/frankban/quicktest v1.14.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.4

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.8
-	github.com/filecoin-project/go-legs v0.3.5-0.20220223202522-095d2645014f
+	github.com/filecoin-project/go-legs v0.3.5
 	github.com/frankban/quicktest v1.14.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.8 h1:h1SRdZKTVcaXlzex3UevHh4OWDAhgpMzL4tHNAA7MQI=
 github.com/filecoin-project/go-indexer-core v0.2.8/go.mod h1:IagNfTdFuX4057kla43PjRCn3yBuUiZgIxuA0hTUamY=
-github.com/filecoin-project/go-legs v0.3.5-0.20220223202522-095d2645014f h1:hO5zp0lSnv+vmIjCX5INIcfjgujBwnTDveKmkO7v7fw=
-github.com/filecoin-project/go-legs v0.3.5-0.20220223202522-095d2645014f/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
+github.com/filecoin-project/go-legs v0.3.5 h1:tfL5C17o1QakRu9ER+tb+6eq2K139S/jGaahyv8w0gk=
+github.com/filecoin-project/go-legs v0.3.5/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.8 h1:h1SRdZKTVcaXlzex3UevHh4OWDAhgpMzL4tHNAA7MQI=
 github.com/filecoin-project/go-indexer-core v0.2.8/go.mod h1:IagNfTdFuX4057kla43PjRCn3yBuUiZgIxuA0hTUamY=
-github.com/filecoin-project/go-legs v0.3.4 h1:yid2IivTJ8JeF1ROA8jxNKNKJshU/HO1sRo5lEMNOUc=
-github.com/filecoin-project/go-legs v0.3.4/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
+github.com/filecoin-project/go-legs v0.3.5-0.20220223202522-095d2645014f h1:hO5zp0lSnv+vmIjCX5INIcfjgujBwnTDveKmkO7v7fw=
+github.com/filecoin-project/go-legs v0.3.5-0.20220223202522-095d2645014f/go.mod h1:P7ZPHqFG96OFaT11rnXyTdcxRdGkaH1dRyPxJSOiSuM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -281,9 +281,6 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 				seenAdCids = append(seenAdCids, c)
 			}),
 		}
-		if sel != nil && !resync && latest != cid.Undef {
-			opts = append(opts, legs.CheckAlreadySynced())
-		}
 		c, err := ing.sub.Sync(ctx, peerID, cid.Undef, sel, peerAddr, opts...)
 
 		// If this is a resync, we need to mark the adChain as unprocessed so that

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -276,11 +276,12 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 		// selector is nil.
 		var seenAdCids []cid.Cid
 		opts := []legs.SyncOption{
+			legs.AlwaysUpdateLatest(),
 			legs.ScopedBlockHook(func(i peer.ID, c cid.Cid) {
 				seenAdCids = append(seenAdCids, c)
 			}),
 		}
-		if sel != nil && !resync {
+		if sel != nil && !resync && latest != cid.Undef {
 			opts = append(opts, legs.CheckAlreadySynced())
 		}
 		c, err := ing.sub.Sync(ctx, peerID, cid.Undef, sel, peerAddr, opts...)
@@ -290,7 +291,7 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 		// index the ads we haven't seen before since later ads may have a different
 		// meaning in the context of earlier ads. So we have to start from the
 		// earliest ad we've just synced to the latest.
-		if sel != nil && len(seenAdCids) > 0 {
+		if resync && len(seenAdCids) > 0 {
 			ing.markAdChainUnprocessed(seenAdCids)
 			event := legs.SyncFinished{
 				Cid:        seenAdCids[0],
@@ -308,7 +309,7 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 
 		// If latest head had already finished syncing, then do not wait
 		// for syncDone since it will never happen.
-		if latest == c && sel == nil {
+		if latest == c && !resync {
 			log.Infow("Latest advertisement already processed", "adCid", c)
 			out <- c
 			return


### PR DESCRIPTION
When resyncing or syncing to a new head, the latest synced ad should be recorded.

When not doing a resync, and only setting a custom depth, make sure that go-legs still sends a sync done event since a non-nil selector is used for the custom depth.