### PR TITLE
Return more information on ad ingest errors

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/go-legs"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/filecoin-project/storetheindex/config"
+	"github.com/filecoin-project/storetheindex/internal/metrics"
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -670,31 +671,68 @@ func (ing *Ingester) ingestWorker() {
 		case <-ing.closeWorkers:
 			return
 		case msg := <-ing.toWorkers:
-			log.Infow("Running worker on ad stack", "headAdCid", msg.adInfos[0].cid, "publisher", msg.publisher)
-			for i := len(msg.adInfos) - 1; i >= 0; i-- {
-				ai := msg.adInfos[i]
-				if ing.ingestWorkerLogic(msg.provider, msg.publisher, ai.cid, ai.ad) {
-					break
-				}
-			}
+			ing.ingestWorkerLogic(msg)
 		}
 	}
 }
 
-func (ing *Ingester) ingestWorkerLogic(provider peer.ID, publisher peer.ID, adCid cid.Cid, ad schema.Advertisement) (earlyBreak bool) {
+func (ing *Ingester) ingestWorkerLogic(msg toWorkerMsg) {
 	// It's assumed that the runIngestStep puts a mutex in this map.
-	ing.providersBeingProcessed[provider].Lock()
-	defer ing.providersBeingProcessed[provider].Unlock()
+	ing.providersBeingProcessed[msg.provider].Lock()
+	defer ing.providersBeingProcessed[msg.provider].Unlock()
 
-	v, err := ing.ds.Get(context.Background(), datastore.NewKey(adProcessedPrefix+adCid.String()))
-	if err == nil && v[0] == byte(1) {
-		// We've process this ad already, so we know we've processed all earlier ads too.
-		return true
+	// Filter out ads that we've already processed and any earlier ads
+	splitAtIndex := len(msg.adInfos)
+	for i, ai := range msg.adInfos {
+		// iterate latest to earliest
+		v, err := ing.ds.Get(context.Background(), datastore.NewKey(adProcessedPrefix+ai.cid.String()))
+		if err == nil && v[0] == byte(1) {
+			// We've process this ad already, so we know we've processed all
+			// earlier ads too. Break here and split at this index later. The cids
+			// before this index are newer and we haven't processed them, the cids
+			// after are older and we already have processed them.
+			splitAtIndex = i
+			break
+		}
 	}
-	err = ing.ingestAd(publisher, adCid, ad)
-	if err != nil {
-		log.Errorw("Error while ingesting ad.", "adCid", adCid, "publisher", publisher, "err", err)
-	}
+	yetToBeProcessed := msg.adInfos[:splitAtIndex]
 
-	return false
+	log.Infow("Running worker on ad stack", "headAdCid", msg.adInfos[0], "publisher", msg.publisher, "numAdsToProcess", len(yetToBeProcessed))
+	for i := len(yetToBeProcessed) - 1; i >= 0; i-- {
+		// Note that we are iterating backwards here. Earliest to newest.
+		ai := yetToBeProcessed[i]
+		err := ing.ingestAd(msg.publisher, ai.cid, ai.ad)
+
+		// if err != nil {
+		// 	log.Errorw("Error while ingesting ad. Bailing early, not ingesting later ads.", "adCid", adCid, "publisher", msg.provider, "err", err, "adsLeftToProcess", i+1)
+		// 	return
+		// }
+
+		var adIngestErr adIngestError
+		if errors.As(err, &adIngestErr) {
+			switch adIngestErr.state {
+			case adIngestDecodingErr, adIngestMalformedErr, adIngestEntryChunkErr:
+				// These error cases are permament. e.g. if we try again later we will hit the same error. So we log and drop this error.
+				log.Errorw("Skipping ad because of a permanant error", "adCid", ai.cid, "err", err, "errKind", adIngestErr.state)
+				err = nil
+			}
+		}
+
+		if err != nil {
+			log.Errorw("Error while ingesting ad. Bailing early, not ingesting later ads.", "adCid", ai.cid, "publisher", msg.provider, "err", err, "adsLeftToProcess", i+1)
+
+			// Tell anyone who's waiting that the sync finished for this head because we errored.
+			// TODO(mm) would be better to propagate the error.
+			ing.inEvents <- legs.SyncFinished{Cid: yetToBeProcessed[0].cid, PeerID: msg.publisher}
+			return
+		}
+
+		if markErr := ing.markAdProcessed(msg.publisher, ai.cid); markErr != nil {
+			log.Errorw("Failed to mark ad as processed", "err", markErr)
+		} else {
+			stats.Record(context.Background(), metrics.AdSyncedCount.M(1))
+		}
+		// Distribute the legs.SyncFinished notices to waiting Sync calls.
+		ing.inEvents <- legs.SyncFinished{Cid: ai.cid, PeerID: msg.publisher}
+	}
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -703,11 +703,6 @@ func (ing *Ingester) ingestWorkerLogic(msg toWorkerMsg) {
 		ai := yetToBeProcessed[i]
 		err := ing.ingestAd(msg.publisher, ai.cid, ai.ad)
 
-		// if err != nil {
-		// 	log.Errorw("Error while ingesting ad. Bailing early, not ingesting later ads.", "adCid", adCid, "publisher", msg.provider, "err", err, "adsLeftToProcess", i+1)
-		// 	return
-		// }
-
 		var adIngestErr adIngestError
 		if errors.As(err, &adIngestErr) {
 			switch adIngestErr.state {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -695,12 +695,11 @@ func (ing *Ingester) ingestWorkerLogic(msg toWorkerMsg) {
 			break
 		}
 	}
-	yetToBeProcessed := msg.adInfos[:splitAtIndex]
 
-	log.Infow("Running worker on ad stack", "headAdCid", msg.adInfos[0], "publisher", msg.publisher, "numAdsToProcess", len(yetToBeProcessed))
-	for i := len(yetToBeProcessed) - 1; i >= 0; i-- {
+	log.Infow("Running worker on ad stack", "headAdCid", msg.adInfos[0].cid, "publisher", msg.publisher, "numAdsToProcess", splitAtIndex)
+	for i := splitAtIndex - 1; i >= 0; i-- {
 		// Note that we are iterating backwards here. Earliest to newest.
-		ai := yetToBeProcessed[i]
+		ai := msg.adInfos[i]
 		err := ing.ingestAd(msg.publisher, ai.cid, ai.ad)
 
 		var adIngestErr adIngestError
@@ -718,7 +717,7 @@ func (ing *Ingester) ingestWorkerLogic(msg toWorkerMsg) {
 
 			// Tell anyone who's waiting that the sync finished for this head because we errored.
 			// TODO(mm) would be better to propagate the error.
-			ing.inEvents <- legs.SyncFinished{Cid: yetToBeProcessed[0].cid, PeerID: msg.publisher}
+			ing.inEvents <- legs.SyncFinished{Cid: msg.adInfos[0].cid, PeerID: msg.publisher}
 			return
 		}
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -489,18 +489,18 @@ func TestReSyncWithDepth(t *testing.T) {
 	require.NoError(t, err)
 	<-wait
 	allMHs := typehelpers.AllMultihashesFromAdLink(t, adHead, te.publisherLinkSys)
-	require.NoError(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), allMHs[2:]))
+	require.NoError(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), allMHs[1:]))
 	require.Error(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), allMHs[0:1]))
 
 	// When not resync, check that nothing beyond the latest is synced.
-	wait, err = te.ingester.Sync(context.Background(), te.pubHost.ID(), te.pubHost.Addrs()[0], 2, false)
+	wait, err = te.ingester.Sync(context.Background(), te.pubHost.ID(), te.pubHost.Addrs()[0], -1, false)
 	require.NoError(t, err)
 	<-wait
-	require.NoError(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), allMHs[2:]))
+	require.NoError(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), allMHs[1:]))
 	require.Error(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), allMHs[0:1]))
 
 	// When resync with greater depth, check that everything in synced.
-	wait, err = te.ingester.Sync(context.Background(), te.pubHost.ID(), te.pubHost.Addrs()[0], 2, true)
+	wait, err = te.ingester.Sync(context.Background(), te.pubHost.ID(), te.pubHost.Addrs()[0], -1, true)
 	require.NoError(t, err)
 	<-wait
 	require.NoError(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), allMHs))

--- a/test/typehelpers/typehelpers.go
+++ b/test/typehelpers/typehelpers.go
@@ -221,3 +221,20 @@ func AdFromLink(t *testing.T, adLink datamodel.Link, lsys ipld.LinkSystem) schem
 	require.NoError(t, err)
 	return adNode.(schema.Advertisement)
 }
+
+// AllAdLinks returns a list of all ad cids for a given chain. Latest last
+func AllAdLinks(t *testing.T, head datamodel.Link, lsys ipld.LinkSystem) []datamodel.Link {
+	out := []datamodel.Link{head}
+	ad := AdFromLink(t, head, lsys)
+	for ad.PreviousID.Exists() {
+		out = append(out, ad.PreviousID.Must().Link())
+		ad = AdFromLink(t, ad.PreviousID.Must().Link(), lsys)
+	}
+
+	// Flip order so the latest is last
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+
+	return out
+}


### PR DESCRIPTION
## Context

There was no way to exit early if we encountered an error while processing ads. It would just skip the ad that errored, and keep ingesting the ad chain. This is a problem in the case where we temporarily can't get an ad (network is temporarily down). Previously we would skip the ad and try ingesting the next one. That would lead to many wrongfully skipped ads.

Instead, when encountering a network flake, we should stop processing the whole ad chain. Then we can try again later.

Of course there are some errors we encounter while processing an ad that aren't temporary. For example, the ad could be malformed. In that case we do want to skip the ad.

## Proposed Change

Create a new adIngestError type. This type includes the general kind of error this was (was it a permanent error or a temporary sync error). The ingest worker can then decide if it wants to skip this ad and continue or stop processing the ad chain altogether.

This also fixes a bug in the logic of skipping processing earlier ads if a later ad has already been processed.

This change also paves the way to better observability around errors. In a future PR I'll make that change that emits a metric on error, and we can bucket them by kind.

Aside: This is the kind of logic that would have been very very tricky to implement in our previous ingester system, so it's nice to see this refactor already paying dividends!

## Testing

I added a new test that tests that we are actually skipping earlier ads if a later ad was processed.

Until the caller gets the information on if an ad was skipped or not, it's kind of hard to test the flow that an adchain bailed early (or skipped some ads). Although I would like the caller to get that information so we can test that. I can do that in this PR or another (depending on how soon we want to get these fixes in).


