### PR TITLE
Record errors during ad ingest

### DIFF
--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -14,19 +14,21 @@ import (
 
 // Global Tags
 var (
+	ErrKind, _ = tag.NewKey("errKind")
+	Method, _  = tag.NewKey("method")
 	Version, _ = tag.NewKey("version")
-
-	Method, _ = tag.NewKey("method")
 )
 
 // Measures
 var (
-	FindLatency        = stats.Float64("find/latency", "Time to respond to a find request", stats.UnitMilliseconds)
-	IngestChange       = stats.Int64("ingest/change", "Number of syncAdEntries started", stats.UnitDimensionless)
-	AdSyncedCount      = stats.Int64("ingest/adsync", "Number of syncAdEntries completed successfully", stats.UnitDimensionless)
-	AdIngestLatency    = stats.Float64("ingest/adsynclatency", "latency of syncAdEntries completed successfully", stats.UnitDimensionless)
-	ProviderCount      = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
-	EntriesSyncLatency = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
+	FindLatency          = stats.Float64("find/latency", "Time to respond to a find request", stats.UnitMilliseconds)
+	IngestChange         = stats.Int64("ingest/change", "Number of syncAdEntries started", stats.UnitDimensionless)
+	AdIngestLatency      = stats.Float64("ingest/adsynclatency", "latency of syncAdEntries completed successfully", stats.UnitDimensionless)
+	AdIngestErrorCount   = stats.Int64("ingest/adingestError", "Number of errors encountered while processing an ad", stats.UnitDimensionless)
+	AdIngestSuccessCount = stats.Int64("ingest/adingestSuccess", "Number of successful ad ingest", stats.UnitDimensionless)
+	AdIngestSkippedCount = stats.Int64("ingest/adingestSkipped", "Number of ads skipped during ingest", stats.UnitDimensionless)
+	ProviderCount        = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
+	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 )
 
 // Views
@@ -44,10 +46,6 @@ var (
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{Method},
 	}
-	adSyncCountView = &view.View{
-		Measure:     AdSyncedCount,
-		Aggregation: view.Count(),
-	}
 	providerView = &view.View{
 		Measure:     ProviderCount,
 		Aggregation: view.LastValue(),
@@ -56,6 +54,18 @@ var (
 		Measure:     EntriesSyncLatency,
 		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
 	}
+	adIngestError = &view.View{
+		Measure:     AdIngestErrorCount,
+		Aggregation: view.Count(),
+	}
+	adIngestSuccess = &view.View{
+		Measure:     AdIngestSuccessCount,
+		Aggregation: view.Count(),
+	}
+	adIngestSkipped = &view.View{
+		Measure:     AdIngestSkippedCount,
+		Aggregation: view.Count(),
+	}
 )
 
 var log = logging.Logger("indexer/metrics")
@@ -63,7 +73,16 @@ var log = logging.Logger("indexer/metrics")
 // Start creates an HTTP router for serving metric info
 func Start(views []*view.View) http.Handler {
 	// Register default views
-	err := view.Register(findLatencyView, ingestChangeView, providerView, entriesSyncLatencyView, adSyncCountView, adIngestLatencyView)
+	err := view.Register(
+		findLatencyView,
+		ingestChangeView,
+		providerView,
+		entriesSyncLatencyView,
+		adIngestLatencyView,
+		adIngestError,
+		adIngestSkipped,
+		adIngestSuccess,
+	)
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)
 	}


### PR DESCRIPTION
## Context

We need more obs into our ingest process.

## Proposed Change
This uses the changes from #237 to give us better obs into errors around adIngest. Also cleans up the ambiguity with the adSyncedCount metric (which conflated success and skipped).
