### PR TITLE
Remove readBeforeErr hack now that cbor-gen bug is fixed

### DIFF
--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -113,30 +113,10 @@ func (h *IngestHandler) IndexContent(ctx context.Context, data []byte) error {
 	return nil
 }
 
-// readBeforErrReader implements io.Reader but guarantees the if bytes read is > 0 err is nil.
-type readBeforErrReader struct {
-	lastErr error
-	r       io.Reader
-}
-
-func (r *readBeforErrReader) Read(p []byte) (n int, err error) {
-	if r.lastErr != nil {
-		return n, r.lastErr
-	}
-
-	n, r.lastErr = r.r.Read(p)
-	if n != 0 {
-		return n, nil
-	}
-
-	return 0, r.lastErr
-}
-
 func (h *IngestHandler) Announce(r io.Reader) error {
 	// Decode CID and originator addresses from message.
 	an := dtsync.Message{}
-	// TODO remove readBeforErrReader when https://github.com/whyrusleeping/cbor-gen/pull/44 is merged
-	if err := an.UnmarshalCBOR(&readBeforErrReader{r: r}); err != nil {
+	if err := an.UnmarshalCBOR(r); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Now that cbor-gen correctly reads from an io.Reader we can drop this workaround.
