### PR TITLE
Only increase error metric on error

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -720,7 +720,7 @@ func (ing *Ingester) ingestWorkerLogic(msg toWorkerMsg) {
 			stats.RecordWithOptions(context.Background(),
 				stats.WithMeasurements(metrics.AdIngestErrorCount.M(1)),
 				stats.WithTags(tag.Insert(metrics.ErrKind, string(adIngestErr.state))))
-		} else {
+		} else if err != nil {
 			stats.RecordWithOptions(context.Background(),
 				stats.WithMeasurements(metrics.AdIngestErrorCount.M(1)),
 				stats.WithTags(tag.Insert(metrics.ErrKind, "other error")))


### PR DESCRIPTION
Accidentally increased error metrics when the error wasn't a special error. So error metric would increase on `err == nil`.

This fixes it.
