### PR TITLE
Reduce log volume and log progress

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -63,6 +63,15 @@ func daemonCommand(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	// Do not log some facilities at info or debug level, unless "log-all" flag
+	// is true.
+	if !cctx.Bool("log-all") && (cctx.String("log-level") == "info" || cctx.String("log-level") == "debug") {
+		logging.SetLogLevel("basichost", "warn")
+		logging.SetLogLevel("bootstrap", "warn")
+		logging.SetLogLevel("dt_graphsync", "warn")
+		logging.SetLogLevel("dt-impl", "warn")
+		logging.SetLogLevel("graphsync", "warn")
+	}
 
 	cfg, err := config.Load("")
 	if err != nil {

--- a/command/flags.go
+++ b/command/flags.go
@@ -62,6 +62,7 @@ var daemonFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:     "log-all",
 		Usage:    "Log for subsystems that are normally only logged at warn level",
+		EnvVars:  []string{"LOG_ALL"},
 		Value:    false,
 		Required: false,
 	},

--- a/command/flags.go
+++ b/command/flags.go
@@ -60,6 +60,12 @@ var daemonFlags = []cli.Flag{
 	cacheSizeFlag,
 	logLevelFlag,
 	&cli.BoolFlag{
+		Name:     "log-all",
+		Usage:    "Log for subsystems that are normally only logged at warn level",
+		Value:    false,
+		Required: false,
+	},
+	&cli.BoolFlag{
 		Name:     "noadmin",
 		Usage:    "Disable admin server",
 		Value:    false,

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -720,9 +720,17 @@ func (ing *Ingester) ingestWorkerLogic(msg toWorkerMsg) {
 	}
 
 	log.Infow("Running worker on ad stack", "headAdCid", msg.adInfos[0].cid, "publisher", msg.publisher, "numAdsToProcess", splitAtIndex)
+	var count int
 	for i := splitAtIndex - 1; i >= 0; i-- {
 		// Note that we are iterating backwards here. Earliest to newest.
 		ai := msg.adInfos[i]
+
+		count++
+		log.Infow("Processing advertisement",
+			"adCid", ai.cid,
+			"publisher", msg.publisher,
+			"progress", fmt.Sprintf("%d of %d", count, splitAtIndex))
+
 		err := ing.ingestAd(msg.publisher, ai.cid, ai.ad)
 
 		if err == nil {

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -193,7 +193,6 @@ func (ing *Ingester) ingestAd(publisher peer.ID, adCid cid.Cid, ad schema.Advert
 	}()
 
 	log := log.With("publisher", publisher, "adCid", adCid)
-	log.Info("Processing advertisement")
 
 	// Get provider ID from advertisement.
 	providerID, err := peer.Decode(ad.Provider.String())


### PR DESCRIPTION
- Reduce logging by logging some facilities at info or debug
- Log progress when processing chain of ads

Log volume is reduced when logging at info or debug level, by setting the log level to "warn" level.  This can be canceled by using the "log-all" flag.