### PR TITLE
Indexer auto-syncs after period of no contact with publisher

### DIFF
--- a/config/discovery.go
+++ b/config/discovery.go
@@ -14,9 +14,18 @@ type Discovery struct {
 	// Policy configures which providers are allowed and blocked
 	Policy Policy
 	// PollInterval is the amount of time to wait without getting any updates
-	// from a provider, before sending a request for the latest advertisement.
+	// for a provider, before sending a request for the latest advertisement.
 	// Values are a number ending in "s", "m", "h" for seconds. minutes, hours.
 	PollInterval Duration
+	// PollRetruAfter is the amount of time that must elapse from one poll
+	// attempt, without a response, to the next poll attempt.  This must be
+	// smaller than PollStopAfter for there to be more than one poll attempt.
+	// Time resolution is in hours.
+	PollRetryAfter Duration
+	// PollStopAfter is the amount of time, from the start of polling, to
+	// continuing polling for the latest advertisment without getting a
+	// responce.  Time resolution is in hours.
+	PollStopAfter Duration
 	// RediscoverWait is the amount of time that must pass before a provider
 	// can be discovered following a previous discovery attempt.  A value of 0
 	// means there is no wait time.
@@ -32,6 +41,8 @@ func NewDiscovery() Discovery {
 		LotusGateway:   "https://api.chain.love",
 		Policy:         NewPolicy(),
 		PollInterval:   Duration(24 * time.Hour),
+		PollRetryAfter: Duration(5 * time.Hour),
+		PollStopAfter:  Duration(48 * time.Hour),
 		RediscoverWait: Duration(5 * time.Minute),
 		Timeout:        Duration(2 * time.Minute),
 	}
@@ -43,6 +54,12 @@ func (c *Discovery) populateUnset() {
 
 	if c.PollInterval == 0 {
 		c.PollInterval = def.PollInterval
+	}
+	if c.PollRetryAfter == 0 {
+		c.PollRetryAfter = def.PollRetryAfter
+	}
+	if c.PollStopAfter == 0 {
+		c.PollStopAfter = def.PollStopAfter
 	}
 	if c.Timeout == 0 {
 		c.Timeout = def.Timeout

--- a/config/discovery.go
+++ b/config/discovery.go
@@ -17,14 +17,14 @@ type Discovery struct {
 	// for a provider, before sending a request for the latest advertisement.
 	// Values are a number ending in "s", "m", "h" for seconds. minutes, hours.
 	PollInterval Duration
-	// PollRetruAfter is the amount of time that must elapse from one poll
-	// attempt, without a response, to the next poll attempt.  This must be
-	// smaller than PollStopAfter for there to be more than one poll attempt.
-	// Time resolution is in hours.
+	// PollRetryAfter is the amount of time from one poll attempt, without a
+	// response, to the next poll attempt, and is also the time between checks
+	// for providers to poll.  This value must be smaller than PollStopAfter
+	// for there to be more than one poll attempt for a provider.
 	PollRetryAfter Duration
 	// PollStopAfter is the amount of time, from the start of polling, to
 	// continuing polling for the latest advertisment without getting a
-	// responce.  Time resolution is in hours.
+	// responce.
 	PollStopAfter Duration
 	// RediscoverWait is the amount of time that must pass before a provider
 	// can be discovered following a previous discovery attempt.  A value of 0
@@ -42,7 +42,7 @@ func NewDiscovery() Discovery {
 		Policy:         NewPolicy(),
 		PollInterval:   Duration(24 * time.Hour),
 		PollRetryAfter: Duration(5 * time.Hour),
-		PollStopAfter:  Duration(48 * time.Hour),
+		PollStopAfter:  Duration(7 * 24 * time.Hour),
 		RediscoverWait: Duration(5 * time.Minute),
 		Timeout:        Duration(2 * time.Minute),
 	}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -223,7 +223,7 @@ func (ing *Ingester) ingestAd(publisher peer.ID, adCid cid.Cid, ad schema.Advert
 
 	// Register provider or update existing registration.  The
 	// provider must be allowed by policy to be registered.
-	err = ing.reg.RegisterOrUpdate(context.Background(), providerID, addrs, adCid)
+	err = ing.reg.RegisterOrUpdate(context.Background(), providerID, addrs, adCid, publisher)
 	if err != nil {
 		return adIngestError{adIngestRegisterProviderErr, fmt.Errorf("could not register/update provider info: %w", err)}
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -25,8 +25,10 @@ import (
 )
 
 const (
-	// providerKeyPath is where provider info is stored in to indexer repo
+	// providerKeyPath is where provider info is stored in to indexer repo.
 	providerKeyPath = "/registry/pinfo"
+	// pollCheckInterval is how often to check for idle providers to poll.
+	pollCheckInterval = time.Hour
 )
 
 var log = logging.Logger("indexer/registry")
@@ -36,6 +38,7 @@ type Registry struct {
 	actions   chan func()
 	closed    chan struct{}
 	closeOnce sync.Once
+	closing   chan struct{}
 	dstore    datastore.Datastore
 	providers map[peer.ID]*ProviderInfo
 	sequences *sequences
@@ -46,10 +49,9 @@ type Registry struct {
 	policy     *policy.Policy
 
 	discoveryTimeout time.Duration
-	pollInterval     time.Duration
 	rediscoverWait   time.Duration
 
-	periodicTimer *time.Timer
+	syncChan chan *ProviderInfo
 }
 
 // ProviderInfo is an immutable data structure that holds information about a
@@ -60,13 +62,21 @@ type ProviderInfo struct {
 	// AddrInfo contains a peer.ID and set of Multiaddr addresses.
 	AddrInfo peer.AddrInfo
 	// DiscoveryAddr is the address that is used for discovery of the provider.
-	DiscoveryAddr string
+	DiscoveryAddr string `json:",omitempty"`
 	// LastAdvertisement identifies the latest advertisement the indexer has ingested.
-	LastAdvertisement cid.Cid
+	LastAdvertisement cid.Cid `json:",omitempty"`
 	// LastAdvertisementTime is the time the latest advertisement was received.
-	LastAdvertisementTime time.Time
+	LastAdvertisementTime time.Time `json:",omitempty"`
+	// Publisher is the ID of the peer that published the provider info.
+	Publisher peer.ID `json:",omitempty"`
 
+	// lastContactTime is the last time the publisher contexted the
+	// indexer. This is not persisted, so that the time since last contact is
+	// reset when the indexer is started. If not reset, then it would appear
+	// the publisher was unreachable for the indexer downtime.
 	lastContactTime time.Time
+	// lastSyncAttempt is the last time a sync was attempted during polling.
+	lastSyncAttempt time.Time
 }
 
 func (p *ProviderInfo) dsKey() datastore.Key {
@@ -88,33 +98,33 @@ func NewRegistry(ctx context.Context, cfg config.Discovery, dstore datastore.Dat
 	r := &Registry{
 		actions:   make(chan func()),
 		closed:    make(chan struct{}),
+		closing:   make(chan struct{}),
 		policy:    discoPolicy,
 		providers: map[peer.ID]*ProviderInfo{},
 		sequences: newSequences(0),
 
-		pollInterval:     time.Duration(cfg.PollInterval),
 		rediscoverWait:   time.Duration(cfg.RediscoverWait),
 		discoveryTimeout: time.Duration(cfg.Timeout),
 
 		discoverer: disco,
 		discoTimes: map[string]time.Time{},
 
-		dstore: dstore,
+		dstore:   dstore,
+		syncChan: make(chan *ProviderInfo, 1),
 	}
 
 	count, err := r.loadPersistedProviders(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot load provider data from datastore: %w", err)
 	}
 	log.Infow("loaded providers into registry", "count", count)
 
-	r.periodicTimer = time.AfterFunc(r.pollInterval/2, func() {
-		r.cleanup()
-		r.pollProviders()
-		r.periodicTimer.Reset(r.pollInterval / 2)
-	})
-
 	go r.run()
+	go r.runPollCheck(pollCheckInterval,
+		time.Duration(cfg.PollInterval),
+		time.Duration(cfg.PollRetryAfter),
+		time.Duration(cfg.PollStopAfter))
+
 	return r, nil
 }
 
@@ -122,11 +132,8 @@ func NewRegistry(ctx context.Context, cfg config.Discovery, dstore datastore.Dat
 func (r *Registry) Close() error {
 	var err error
 	r.closeOnce.Do(func() {
-		r.periodicTimer.Stop()
-		// Wait for any pending discoveries to complete, then stop the main run
-		// goroutine.
-		r.discoWait.Wait()
-		close(r.actions)
+		close(r.closing)
+		<-r.closed
 
 		if r.dstore != nil {
 			err = r.dstore.Close()
@@ -134,6 +141,10 @@ func (r *Registry) Close() error {
 	})
 	<-r.closed
 	return err
+}
+
+func (r *Registry) SyncChan() <-chan *ProviderInfo {
+	return r.syncChan
 }
 
 // run executes functions that need to be executed on the same goroutine
@@ -149,6 +160,34 @@ func (r *Registry) run() {
 	for action := range r.actions {
 		action()
 	}
+}
+
+func (r *Registry) runPollCheck(pollCheckInterval, pollInterval, pollRetryAfter, pollStopAfter time.Duration) {
+	timer := time.NewTimer(pollCheckInterval)
+running:
+	for {
+		select {
+		case <-timer.C:
+			r.cleanup()
+			r.pollProviders(pollInterval, pollRetryAfter, pollStopAfter)
+			timer.Reset(pollCheckInterval)
+		case <-r.closing:
+			break running
+		}
+	}
+
+	// Check that pollProviders is finished and close sync channel.
+	done := make(chan struct{})
+	r.actions <- func() {
+		close(done)
+	}
+	<-done
+	close(r.syncChan)
+
+	// Wait for any pending discoveries to complete, then stop the main run
+	// goroutine.
+	r.discoWait.Wait()
+	close(r.actions)
 }
 
 // Discover begins the process of discovering and verifying a provider.  The
@@ -184,6 +223,11 @@ func (r *Registry) Register(ctx context.Context, info *ProviderInfo) error {
 		return errors.New("missing provider address")
 	}
 
+	err := info.AddrInfo.ID.Validate()
+	if err != nil {
+		return err
+	}
+
 	allowed, trusted := r.policy.Check(info.AddrInfo.ID)
 
 	// If provider is not allowed, then ignore request.
@@ -198,13 +242,27 @@ func (r *Registry) Register(ctx context.Context, info *ProviderInfo) error {
 		return v0.NewError(ErrNotTrusted, http.StatusForbidden)
 	}
 
-	// If allowed provider is trusted, register immediately without verification.
+	// If publisher is valid and different than the provider, check if the
+	// publisher is allowed.
+	err = info.Publisher.Validate()
+	if err == nil && info.Publisher != info.AddrInfo.ID {
+		allowed, trusted := r.policy.Check(info.Publisher)
+		if !allowed {
+			return v0.NewError(ErrNotAllowed, http.StatusForbidden)
+		}
+		if !trusted {
+			return v0.NewError(ErrNotTrusted, http.StatusForbidden)
+		}
+	}
+
+	// If allowed provider and publisher are trusted, register immediately
+	// without verification.
 	errCh := make(chan error, 1)
 	r.actions <- func() {
 		errCh <- r.syncRegister(ctx, info)
 	}
 
-	err := <-errCh
+	err = <-errCh
 	if err != nil {
 		return err
 	}
@@ -253,10 +311,17 @@ func (r *Registry) BlockPeer(peerID peer.ID) bool {
 
 // RegisterOrUpdate attempts to register an unregistered provider, or updates
 // the addresses and latest advertisement of an already registered provider.
-func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, addrs []string, adID cid.Cid) error {
+func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, addrs []string, adID cid.Cid, publisherID peer.ID) error {
+	var fullRegister bool
 	// Check that the provider has been discovered and validated
 	info := r.ProviderInfo(providerID)
 	if info != nil {
+		if err := publisherID.Validate(); err != nil {
+			publisherID = info.Publisher
+		} else if publisherID != info.Publisher {
+			fullRegister = true
+		}
+
 		info = &ProviderInfo{
 			AddrInfo: peer.AddrInfo{
 				ID:    providerID,
@@ -265,12 +330,15 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 			DiscoveryAddr:         info.DiscoveryAddr,
 			LastAdvertisement:     info.LastAdvertisement,
 			LastAdvertisementTime: info.LastAdvertisementTime,
+			Publisher:             publisherID,
 		}
 	} else {
+		fullRegister = true
 		info = &ProviderInfo{
 			AddrInfo: peer.AddrInfo{
 				ID: providerID,
 			},
+			Publisher: publisherID,
 		}
 	}
 
@@ -284,13 +352,30 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 
 	now := time.Now()
 
-	if adID != cid.Undef {
+	if adID != info.LastAdvertisement && adID != cid.Undef {
 		info.LastAdvertisement = adID
 		info.LastAdvertisementTime = now
 	}
 	info.lastContactTime = now
 
-	return r.Register(ctx, info)
+	// If there is a new providerID or publisherID then do a full Register that
+	// check the allow policy.
+	if fullRegister {
+		return r.Register(ctx, info)
+	}
+
+	// If laready registered and no new IDs, register without verification.
+	errCh := make(chan error, 1)
+	r.actions <- func() {
+		errCh <- r.syncRegister(ctx, info)
+	}
+	err := <-errCh
+	if err != nil {
+		return err
+	}
+
+	log.Debugw("Updated registered provider info", "id", info.AddrInfo.ID, "addrs", info.AddrInfo.Addrs)
+	return nil
 }
 
 // IsRegistered checks if the provider is in the registry
@@ -527,8 +612,55 @@ func (r *Registry) cleanup() {
 	r.discoWait.Done()
 }
 
-func (r *Registry) pollProviders() {
-	// TODO: Poll providers that have not been contacted for more than pollInterval.
+func (r *Registry) pollProviders(pollInterval, pollRetryAfter, pollStopAfter time.Duration) {
+	pollStopAfter += pollInterval
+	r.actions <- func() {
+		now := time.Now()
+		for _, info := range r.providers {
+			err := info.Publisher.Validate()
+			if err != nil {
+				// No publisher.
+				continue
+			}
+			if info.lastContactTime.IsZero() {
+				// There has been no contact since startup.  Start counting now.
+				info.lastContactTime = now
+				continue
+			}
+			noContactTime := now.Sub(info.lastContactTime)
+			if noContactTime < pollInterval {
+				// Not enough time since last contact.
+				continue
+			}
+			if noContactTime > pollStopAfter {
+				// Too much time since last contact.
+				log.Warnw("Lost contact with provider's publisher", "publisher", info.Publisher, "provider", info.AddrInfo.ID, "since", info.lastContactTime)
+				// Remove the non-responsive publisher.
+				info = &ProviderInfo{
+					AddrInfo:              info.AddrInfo,
+					DiscoveryAddr:         info.DiscoveryAddr,
+					LastAdvertisement:     info.LastAdvertisement,
+					LastAdvertisementTime: info.LastAdvertisementTime,
+					lastContactTime:       info.lastContactTime,
+					Publisher:             peer.ID(""),
+				}
+				if err = r.syncRegister(context.Background(), info); err != nil {
+					log.Errorw("Failed to update provider info", "err", err)
+				}
+				continue
+			}
+			if now.Sub(info.lastSyncAttempt) < pollRetryAfter {
+				// Not enough time since last sync attempt
+				continue
+			}
+			select {
+			case r.syncChan <- info:
+				info.lastSyncAttempt = now
+			default:
+				log.Debugw("Sync channel blocked, skipping auto-sync", "publisher", info.Publisher)
+			}
+		}
+	}
 }
 
 // stringsToMultiaddrs converts a slice of string into a slice of Multiaddr

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -314,7 +314,6 @@ func TestPollProvider(t *testing.T) {
 			Allow: true,
 			Trust: true,
 		},
-		PollInterval:   0,
 		RediscoverWait: config.Duration(time.Minute),
 	}
 
@@ -340,7 +339,7 @@ func TestPollProvider(t *testing.T) {
 	}
 
 	retryAfter := time.Minute
-	stopAfter := time.Minute
+	stopAfter := time.Hour
 
 	// Check for auto-sync after pollInterval 0.
 	r.pollProviders(0, retryAfter, stopAfter)
@@ -351,27 +350,12 @@ func TestPollProvider(t *testing.T) {
 		t.Fatal("Expected sync channel to be written")
 	}
 
-	// Check that actions chan is not written, because retryAfter has not
-	// elapsed since previous retry.
-	r.pollProviders(0, retryAfter, stopAfter)
-	r.pollProviders(0, retryAfter, stopAfter)
-	r.pollProviders(0, retryAfter, stopAfter)
-	done := make(chan struct{})
-	r.actions <- func() {
-		close(done)
-	}
-	select {
-	case <-r.SyncChan():
-		t.Fatal("sync channel should not have beem written to")
-	default:
-	}
-
 	// Check that actions chan is not blocked by unread auto-sync channel.
 	retryAfter = 0
 	r.pollProviders(0, retryAfter, stopAfter)
 	r.pollProviders(0, retryAfter, stopAfter)
 	r.pollProviders(0, retryAfter, stopAfter)
-	done = make(chan struct{})
+	done := make(chan struct{})
 	r.actions <- func() {
 		close(done)
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/filecoin-project/storetheindex/config"
 	"github.com/filecoin-project/storetheindex/internal/registry/discovery"
+	"github.com/ipfs/go-cid"
 	leveldb "github.com/ipfs/go-ds-leveldb"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
@@ -250,12 +251,18 @@ func TestDatastore(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to register directly:", err)
 	}
-	err = r.Register(ctx, info2)
+
+	err = r.RegisterOrUpdate(ctx, info2.AddrInfo.ID, []string{minerAddr2}, cid.Undef, info2.AddrInfo.ID)
 	if err != nil {
 		t.Fatal("failed to register directly:", err)
 	}
 
 	pinfo := r.ProviderInfo(peerID)
+	if pinfo == nil {
+		t.Fatal("did not find registered provider")
+	}
+
+	pinfo = r.ProviderInfo(info2.AddrInfo.ID)
 	if pinfo == nil {
 		t.Fatal("did not find registered provider")
 	}
@@ -281,11 +288,128 @@ func TestDatastore(t *testing.T) {
 		t.Fatal("expected 2 provider infos")
 	}
 
-	for i := range infos {
-		pid := infos[i].AddrInfo.ID
-		if pid != info1.AddrInfo.ID && pid != info2.AddrInfo.ID {
-			t.Fatalf("loaded invalid provider ID: %s", pid)
+	for _, provInfo := range infos {
+		if provInfo.AddrInfo.ID == info1.AddrInfo.ID {
+			if err = provInfo.Publisher.Validate(); err == nil {
+				t.Fatal("info1 should not have valid publisher")
+			}
+		} else if provInfo.AddrInfo.ID == info2.AddrInfo.ID {
+			if provInfo.Publisher != info2.AddrInfo.ID {
+				t.Fatal("info2 has wrong publisher")
+			}
+		} else {
+			t.Fatalf("loaded invalid provider ID: %s", provInfo.AddrInfo.ID)
 		}
+	}
+
+	err = r.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPollProvider(t *testing.T) {
+	cfg := config.Discovery{
+		Policy: config.Policy{
+			Allow: true,
+			Trust: true,
+		},
+		PollInterval:   0,
+		RediscoverWait: config.Duration(time.Minute),
+	}
+
+	ctx := context.Background()
+	// Create datastore
+	dstore, err := leveldb.NewDatastore(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewRegistry(ctx, cfg, dstore, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peerID, err := peer.Decode(trustedID)
+	if err != nil {
+		t.Fatal("bad provider ID:", err)
+	}
+
+	err = r.RegisterOrUpdate(ctx, peerID, []string{minerAddr}, cid.Undef, peerID)
+	if err != nil {
+		t.Fatal("failed to register directly:", err)
+	}
+
+	retryAfter := time.Minute
+	stopAfter := time.Minute
+
+	// Check for auto-sync after pollInterval 0.
+	r.pollProviders(0, retryAfter, stopAfter)
+	timeout := time.After(2 * time.Second)
+	select {
+	case <-r.SyncChan():
+	case <-timeout:
+		t.Fatal("Expected sync channel to be written")
+	}
+
+	// Check that actions chan is not written, because retryAfter has not
+	// elapsed since previous retry.
+	r.pollProviders(0, retryAfter, stopAfter)
+	r.pollProviders(0, retryAfter, stopAfter)
+	r.pollProviders(0, retryAfter, stopAfter)
+	done := make(chan struct{})
+	r.actions <- func() {
+		close(done)
+	}
+	select {
+	case <-r.SyncChan():
+		t.Fatal("sync channel should not have beem written to")
+	default:
+	}
+
+	// Check that actions chan is not blocked by unread auto-sync channel.
+	retryAfter = 0
+	r.pollProviders(0, retryAfter, stopAfter)
+	r.pollProviders(0, retryAfter, stopAfter)
+	r.pollProviders(0, retryAfter, stopAfter)
+	done = make(chan struct{})
+	r.actions <- func() {
+		close(done)
+	}
+	select {
+	case <-done:
+	case <-timeout:
+		t.Fatal("actions channel blocked")
+	}
+	select {
+	case <-r.SyncChan():
+	case <-timeout:
+		t.Fatal("Expected sync channel to be written")
+	}
+
+	// Set stopAfter to 0 so that stopAfter will have elapsed since last
+	// contact. This will make publisher appear unresponsive and polling will
+	// stop.
+	stopAfter = 0
+	r.pollProviders(0, retryAfter, stopAfter)
+	r.pollProviders(0, retryAfter, stopAfter)
+	r.pollProviders(0, retryAfter, stopAfter)
+
+	// Check that publisher has been removed from provider info when publisher
+	// appeared non-responsive.
+	pinfo := r.ProviderInfo(peerID)
+	if pinfo == nil {
+		t.Fatal("did not find registered provider")
+	}
+	if err = pinfo.Publisher.Validate(); err == nil {
+		t.Fatal("should not have valid publisher after polling stopped")
+	}
+
+	// Check that sync channel was not written since polling should have
+	// stopped.
+	select {
+	case <-r.SyncChan():
+		t.Fatal("sync channel should not have beem written to")
+	default:
 	}
 
 	err = r.Close()

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -88,7 +88,7 @@ func (h *IngestHandler) IndexContent(ctx context.Context, data []byte) error {
 	}
 
 	// Register provider if not registered, or update addreses if already registered
-	err = h.registry.RegisterOrUpdate(ctx, ingReq.ProviderID, ingReq.Addrs, cid.Undef)
+	err = h.registry.RegisterOrUpdate(ctx, ingReq.ProviderID, ingReq.Addrs, cid.Undef, peer.ID(""))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If the indexer has had no contact with any publisher for a provider, the indexer attempts to sync with the provider's last known publisher.  As long as there is no contact with a publisher for the provider, the indexer continues retrying to sync periodically until contact is made or until the indexer gives up after a configurable abount of time.