### PR TITLE
Set latestsynchandler on go legs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.9
-	github.com/filecoin-project/go-legs v0.3.8
+	github.com/filecoin-project/go-legs v0.3.9
 	github.com/frankban/quicktest v1.14.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/filecoin-project/go-indexer-core v0.2.9 h1:sfnPCl0ualbxZAwcgzjsySIwh6
 github.com/filecoin-project/go-indexer-core v0.2.9/go.mod h1:u03I3HB6ZnqCc3cm8Tq+QkTWBbfKOvNxM8K6Ny/IHRw=
 github.com/filecoin-project/go-legs v0.3.8 h1:HDhunjC+E5g3s47zUQY/YnDveatOXWJyfK519jdKhOA=
 github.com/filecoin-project/go-legs v0.3.8/go.mod h1:FroH5LQUTfYzs8huA4PjW8spDF691uvK8uk9YAfDa78=
+github.com/filecoin-project/go-legs v0.3.9 h1:YDW+nHn3fdl/5M7dE0EOxU8E3EgJGjuccLcz9xaT3kg=
+github.com/filecoin-project/go-legs v0.3.9/go.mod h1:FroH5LQUTfYzs8huA4PjW8spDF691uvK8uk9YAfDa78=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,6 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.9 h1:sfnPCl0ualbxZAwcgzjsySIwh6AxqDJIzLkdObLS4gs=
 github.com/filecoin-project/go-indexer-core v0.2.9/go.mod h1:u03I3HB6ZnqCc3cm8Tq+QkTWBbfKOvNxM8K6Ny/IHRw=
-github.com/filecoin-project/go-legs v0.3.8 h1:HDhunjC+E5g3s47zUQY/YnDveatOXWJyfK519jdKhOA=
-github.com/filecoin-project/go-legs v0.3.8/go.mod h1:FroH5LQUTfYzs8huA4PjW8spDF691uvK8uk9YAfDa78=
 github.com/filecoin-project/go-legs v0.3.9 h1:YDW+nHn3fdl/5M7dE0EOxU8E3EgJGjuccLcz9xaT3kg=
 github.com/filecoin-project/go-legs v0.3.9/go.mod h1:FroH5LQUTfYzs8huA4PjW8spDF691uvK8uk9YAfDa78=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -374,6 +374,8 @@ func (ing *Ingester) loadAd(adCid cid.Cid) (ad schema.Advertisement, err error) 
 	if err != nil {
 		return nil, fmt.Errorf("cannot read advertisement for entry from datastore: %w", err)
 	}
+	// TODO(mm) this could break ingest if a worker pulls an ad, fails to process,
+	// and another worker fails to get this ad
 	err = ing.ds.Delete(context.Background(), adKey)
 	if err != nil {
 		log.Errorw("Failed to clean up ad from datastore", "err", err)

--- a/internal/ingest/synchandler.go
+++ b/internal/ingest/synchandler.go
@@ -1,0 +1,26 @@
+package ingest
+
+import (
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type syncHandler struct {
+	ing *Ingester
+}
+
+func (h *syncHandler) SetLatestSync(p peer.ID, c cid.Cid) {
+	// NOOP
+	// We don't care what go-legs tells us about it's latest sync, we are using
+	// the latestSync mechanism to traverse to the last processed Ad.
+	// This means that the only thing that sets our notion of latest sync is
+	// marking an ad as processed.
+}
+
+func (h *syncHandler) GetLatestSync(p peer.ID) (cid.Cid, bool) {
+	c, err := h.ing.GetLatestSync(p)
+	if err != nil {
+		return cid.Undef, false
+	}
+	return c, true
+}

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -27,6 +27,7 @@ var (
 	AdIngestErrorCount   = stats.Int64("ingest/adingestError", "Number of errors encountered while processing an ad", stats.UnitDimensionless)
 	AdIngestSuccessCount = stats.Int64("ingest/adingestSuccess", "Number of successful ad ingest", stats.UnitDimensionless)
 	AdIngestSkippedCount = stats.Int64("ingest/adingestSkipped", "Number of ads skipped during ingest", stats.UnitDimensionless)
+	AdLoadError          = stats.Int64("ingest/adLoadError", "Number of times an ad failed to load", stats.UnitDimensionless)
 	ProviderCount        = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 )
@@ -57,6 +58,7 @@ var (
 	adIngestError = &view.View{
 		Measure:     AdIngestErrorCount,
 		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{ErrKind},
 	}
 	adIngestSuccess = &view.View{
 		Measure:     AdIngestSuccessCount,
@@ -64,6 +66,10 @@ var (
 	}
 	adIngestSkipped = &view.View{
 		Measure:     AdIngestSkippedCount,
+		Aggregation: view.Count(),
+	}
+	adLoadError = &view.View{
+		Measure:     AdLoadError,
 		Aggregation: view.Count(),
 	}
 )
@@ -82,6 +88,7 @@ func Start(views []*view.View) http.Handler {
 		adIngestError,
 		adIngestSkipped,
 		adIngestSuccess,
+		adLoadError,
 	)
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)

--- a/test/typehelpers/typehelpers.go
+++ b/test/typehelpers/typehelpers.go
@@ -110,7 +110,7 @@ func (b RandomEntryChunkBuilder) Build(t *testing.T, lsys ipld.LinkSystem) datam
 	return headLink
 }
 
-func AllMultihashesFromAd(t *testing.T, ad schema.Advertisement, lsys ipld.LinkSystem) []multihash.Multihash {
+func AllMultihashesFromAdChain(t *testing.T, ad schema.Advertisement, lsys ipld.LinkSystem) []multihash.Multihash {
 	var out []multihash.Multihash
 
 	progress := traversal.Progress{
@@ -213,7 +213,7 @@ func AllAds(t *testing.T, ad schema.Advertisement, lsys ipld.LinkSystem) []schem
 func AllMultihashesFromAdLink(t *testing.T, adLink datamodel.Link, lsys ipld.LinkSystem) []multihash.Multihash {
 	adNode, err := lsys.Load(linking.LinkContext{}, adLink, schema.Type.Advertisement)
 	require.NoError(t, err)
-	return AllMultihashesFromAd(t, adNode.(schema.Advertisement), lsys)
+	return AllMultihashesFromAdChain(t, adNode.(schema.Advertisement), lsys)
 }
 
 func AdFromLink(t *testing.T, adLink datamodel.Link, lsys ipld.LinkSystem) schema.Advertisement {


### PR DESCRIPTION
## Context

This hooks up the changes from https://github.com/filecoin-project/go-legs/pull/106. See that PR for more context.

## Proposed Change

The latestSync state of go-legs now asks the indexer what the last ad processed was. The indexer ignores updates on latestSync from legs, since the indexer is the source of truth here.

## Tests

Added a test that repros that bug.