### PR TITLE
Don't optimistically delete an Ad

### DIFF
--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -411,7 +411,8 @@ func TestIngestDoesNotSkipAdIfFirstTryFailed(t *testing.T) {
 
 	// Disable the ingester getting sync finished events, we'll manually run the
 	// ingest loop for ease of testing
-	te.ingester.toStaging = make(chan legs.SyncFinished)
+	te.ingester.cancelOnSyncFinished()
+	te.ingester.cancelOnSyncFinished = func() {}
 
 	cAdBuilder := typehelpers.RandomAdBuilder{
 		EntryChunkBuilders: []typehelpers.RandomEntryChunkBuilder{

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -374,12 +374,6 @@ func (ing *Ingester) loadAd(adCid cid.Cid) (ad schema.Advertisement, err error) 
 	if err != nil {
 		return nil, fmt.Errorf("cannot read advertisement for entry from datastore: %w", err)
 	}
-	// TODO(mm) this could break ingest if a worker pulls an ad, fails to process,
-	// and another worker fails to get this ad
-	err = ing.ds.Delete(context.Background(), adKey)
-	if err != nil {
-		log.Errorw("Failed to clean up ad from datastore", "err", err)
-	}
 
 	// Decode the advertisement.
 	adn, err := decodeIPLDNode(adCid.Prefix().Codec, bytes.NewBuffer(adb))


### PR DESCRIPTION
## Context

This fixes a bug where an ingest loop loads an ad (and thereby deleting it) and for whatever reason fails to finish ingesting the ad. The next time the loop tries to ingest the ad it will fail to load the ad and skip it.

Note this happens if we are ingesting the same ad chain back to back.


## Proposed change

Don't delete the ad when we load it. Instead only delete the ad when we've finished processing it, since that's really the only time we'll know that we'll never need this ad again.

Most of this diff is the test. The actual fix is just deleting the delete call in `loadAd`.

## Tests

This also adds a test to make sure we correctly ingest all ads in the case that we are given the same adChain back to back. Which can happen in at least the following cases:
1. A publisher broadcast the same head twice in gossipsub
2. We call sync twice back to back.
3. Combination of 1 & 2.