### PR TITLE
Revert "Skip e2e tests until provider side is upgraded."

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -118,9 +118,6 @@ func (e *e2eTestRunner) stop(cmd *exec.Cmd, timeout time.Duration) {
 }
 
 func TestEndToEndWithReferenceProvider(t *testing.T) {
-	t.Skip(`Skip test until the changes to the finder client are upgraded in provider side
-See: https://github.com/filecoin-project/index-provider/pull/198
-`)
 	switch runtime.GOOS {
 	case "windows", "darwin":
 		t.Skip("skipping test on", runtime.GOOS)


### PR DESCRIPTION
This reverts commit 537eb37a1285ba065dfbfc669df83244eabe1f03 now that
the index-provider is upgraded.

See:
 - https://github.com/filecoin-project/index-provider/pull/198