### PR TITLE
Set the maximum acceptable length for advertisement metadata

### DIFF
--- a/api/v0/ingest/schema/utils.go
+++ b/api/v0/ingest/schema/utils.go
@@ -56,6 +56,8 @@ const (
 	IsAdKey = LinkContextKey("isAdLink")
 	// ContextID must not exceed this number of bytes.
 	MaxContextIDLen = 64
+	// MaxMetadataLen specifies the maximum number of bytes an advertisement metadata can contain.
+	MaxMetadataLen = 1024 // 1KiB
 )
 
 func mhsToBytes(mhs []multihash.Multihash) []_Bytes {
@@ -184,6 +186,10 @@ func NewAdvertisementWithFakeSig(
 		return nil, nil, errors.New("context id too long")
 	}
 
+	if len(metadata) > MaxMetadataLen {
+		return nil, nil, errors.New("metadata too long")
+	}
+
 	ad := &_Advertisement{
 		Provider:  _String{x: provider},
 		Addresses: GoToIpldStrings(addrs),
@@ -223,6 +229,10 @@ func newAdvertisement(
 
 	if len(contextID) > MaxContextIDLen {
 		return nil, errors.New("context id too long")
+	}
+
+	if len(metadata) > MaxMetadataLen {
+		return nil, errors.New("metadata too long")
 	}
 
 	ad := &_Advertisement{

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -83,6 +83,10 @@ func (h *IngestHandler) IndexContent(ctx context.Context, data []byte) error {
 		return errors.New("context id too long")
 	}
 
+	if len(ingReq.Metadata) > schema.MaxMetadataLen {
+		return errors.New("metadata too long")
+	}
+
 	if err = h.registry.CheckSequence(ingReq.ProviderID, ingReq.Seq); err != nil {
 		return err
 	}

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -194,7 +194,18 @@ func IndexContentFail(t *testing.T, cl client.Ingest, providerID peer.ID, privat
 	}
 
 	if !strings.HasSuffix(err.Error(), "context id too long") {
-		t.Fatalf("expected erroe message: \"context id too long\", got %q", err.Error())
+		t.Fatalf("expected error message: \"context id too long\", got %q", err.Error())
+	}
+
+	contextID = []byte("test-context-id")
+	metadata = make([]byte, schema.MaxMetadataLen+1)
+	err = cl.IndexContent(ctx, providerID, privateKey, mhs[0], contextID, metadata, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.HasSuffix(err.Error(), "metadata too long") {
+		t.Fatalf("expected error message: \"metadata too long\", got %q", err.Error())
 	}
 
 	apierr, ok := err.(*v0.Error)


### PR DESCRIPTION
Set the maximum number of bytes acceptable as advertisement metadata to
`1KiB`, i.e. `1024` bytes. This value is a fixed upper limit and not
configurable by design to ensure interoperability across indexer nodes.

Fixes: #261