### PR TITLE
Remove recursion depth limits for sync

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -149,10 +149,8 @@ var adminSyncFlags = []cli.Flag{
 		Usage: "Multiaddr address of peer to sync with",
 	},
 	&cli.Int64Flag{
-		Name: "depth",
-		Usage: "The recursion depth limit while syncing advertisements. The value -1 indicates no limit. " +
-			"If unspecified, the configured indexer advertisement recursion limit is used.",
-		Value: 0,
+		Name:  "depth",
+		Usage: "Depth limit of advertisements (distance from current) to sync. No limit if unspecified.",
 	},
 	&cli.BoolFlag{
 		Name:  "resync",

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"time"
-
-	"github.com/ipld/go-ipld-prime/traversal/selector"
 )
 
 // Ingest tracks the configuration related to the ingestion protocol.
@@ -21,14 +19,6 @@ type Ingest struct {
 	// ending in "s", "m", "h" for seconds. minutes, hours.
 	SyncTimeout Duration
 
-	// The recursion depth limit when syncing advertisement entries.
-	// The value -1 means no limit. Defaults to 400.
-	EntriesDepthLimit int64
-
-	// The recursion depth limit when syncing advertisements.
-	// The value -1 means no limit. Defaults to 400.
-	AdvertisementDepthLimit int64
-
 	// How many ingest worker goroutines to spawn. This controls how many
 	// concurrent ingest from different providers we can handle.
 	IngestWorkerCount int
@@ -37,12 +27,10 @@ type Ingest struct {
 // NewIngest returns Ingest with values set to their defaults.
 func NewIngest() Ingest {
 	return Ingest{
-		PubSubTopic:             "/indexer/ingest/mainnet",
-		StoreBatchSize:          256,
-		SyncTimeout:             Duration(2 * time.Hour),
-		EntriesDepthLimit:       400,
-		AdvertisementDepthLimit: 400,
-		IngestWorkerCount:       10,
+		PubSubTopic:       "/indexer/ingest/mainnet",
+		StoreBatchSize:    256,
+		SyncTimeout:       Duration(2 * time.Hour),
+		IngestWorkerCount: 10,
 	}
 }
 
@@ -59,31 +47,7 @@ func (c *Ingest) populateUnset() {
 	if c.SyncTimeout == 0 {
 		c.SyncTimeout = def.SyncTimeout
 	}
-	if c.EntriesDepthLimit == 0 {
-		c.EntriesDepthLimit = def.EntriesDepthLimit
-	}
-	if c.AdvertisementDepthLimit == 0 {
-		c.AdvertisementDepthLimit = def.AdvertisementDepthLimit
-	}
 	if c.IngestWorkerCount == 0 {
 		c.IngestWorkerCount = def.IngestWorkerCount
 	}
-}
-
-// EntriesRecursionLimit returns the recursion limit of advertisement entries.
-// See Ingest.EntriesDepthLimit
-func (c *Ingest) EntriesRecursionLimit() selector.RecursionLimit {
-	if c.EntriesDepthLimit == -1 {
-		return selector.RecursionLimitNone()
-	}
-	return selector.RecursionLimitDepth(c.EntriesDepthLimit)
-}
-
-// AdvertisementRecursionLimit returns the recursion limit of advertisements.
-// See Ingest.AdvertisementDepthLimit
-func (c *Ingest) AdvertisementRecursionLimit() selector.RecursionLimit {
-	if c.AdvertisementDepthLimit == -1 {
-		return selector.RecursionLimitNone()
-	}
-	return selector.RecursionLimitDepth(c.AdvertisementDepthLimit)
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
@@ -112,13 +113,6 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 			efsb.Insert("PreviousID", ssb.ExploreRecursiveEdge())
 		}).Node()
 
-	// Construct the selector used when syncing entries of an advertisement with the configured
-	// recursion limit.
-	entSel := ssb.ExploreRecursive(cfg.EntriesRecursionLimit(),
-		ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
-			efsb.Insert("Next", ssb.ExploreRecursiveEdge()) // Next field in EntryChunk
-		})).Node()
-
 	ing := &Ingester{
 		host:        h,
 		ds:          ds,
@@ -126,7 +120,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 		batchSize:   cfg.StoreBatchSize,
 		sigUpdate:   make(chan struct{}, 1),
 		syncTimeout: time.Duration(cfg.SyncTimeout),
-		entriesSel:  entSel,
+		entriesSel:  selectorparse.CommonSelector_ExploreAllRecursively,
 		reg:         reg,
 		cfg:         cfg,
 		inEvents:    make(chan adProcessedEvent, 1),
@@ -141,7 +135,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 
 	// Create and start pubsub subscriber.  This also registers the storage
 	// hook to index data as it is received.
-	sub, err := legs.NewSubscriber(h, ds, lsys, cfg.PubSubTopic, adSel, legs.AllowPeer(reg.Authorized), legs.SyncRecursionLimit(cfg.AdvertisementRecursionLimit()), legs.UseLatestSyncHandler(&syncHandler{ing}))
+	sub, err := legs.NewSubscriber(h, ds, lsys, cfg.PubSubTopic, adSel, legs.AllowPeer(reg.Authorized), legs.UseLatestSyncHandler(&syncHandler{ing}))
 	if err != nil {
 		log.Errorw("Failed to start pubsub subscriber", "err", err)
 		return nil, errors.New("ingester subscriber failed")
@@ -212,8 +206,8 @@ func (ing *Ingester) Close() error {
 // parameters: depth, and resync.
 //
 // The depth argument specifies the recursion depth limit to use during sync.
-// Its value may be one of: -1 for no-limit, 0 for same value as config.Ingest,
-// or larger than 0 for an explicit limit.
+// Its value may less than 1 for no limit, or greater than 1 for an explicit
+// limit.
 //
 // The resync argument specifies whether to stop the traversal at the latest
 // known advertisement that is already synced. If set to true, the traversal
@@ -228,15 +222,11 @@ func (ing *Ingester) Close() error {
 // The Context argument controls the lifetime of the sync.  Canceling it
 // cancels the sync and causes the multihash channel to close without any data.
 func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Multiaddr, depth int64, resync bool) (<-chan cid.Cid, error) {
-	out := make(chan cid.Cid, 1)
-
-	// Fail fast if peer ID or depth is invalid.
-	if depth < -1 {
-		return nil, fmt.Errorf("recursion depth limit must not be less than -1; got %d", depth)
-	}
 	if err := peerID.Validate(); err != nil {
 		return nil, err
 	}
+
+	out := make(chan cid.Cid, 1)
 
 	ing.waitForPendingSyncs.Add(1)
 	go func() {
@@ -333,14 +323,10 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 }
 
 func (ing *Ingester) makeLimitedDepthSelector(peerID peer.ID, depth int64, resync bool) (ipld.Node, error) {
-	// Consider the value of -1 as no-limit, similar to config.Ingest.
+	// Consider the value of < 1 as no-limit.
 	var rLimit selector.RecursionLimit
-	if depth == -1 {
+	if depth < 1 {
 		rLimit = selector.RecursionLimitNone()
-	} else if depth == 0 {
-		rLimit = ing.cfg.AdvertisementRecursionLimit()
-		// Override the value of depth with config.Ingest value for logging purposes.
-		depth = ing.cfg.AdvertisementDepthLimit
 	} else {
 		rLimit = selector.RecursionLimitDepth(depth)
 	}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -276,7 +276,7 @@ func (ing *Ingester) ingestAd(publisher peer.ID, adCid cid.Cid, ad schema.Advert
 
 	startTime := time.Now()
 
-	// Traverse entries based on the entries selector that limits recursion depth.
+	// Traverse entries based on the entries selector.
 	var errsIngestingEntryChunks []error
 	_, err = ing.sub.Sync(ctx, publisher, entriesCid, ing.entriesSel, nil, legs.ScopedBlockHook(func(p peer.ID, c cid.Cid) {
 		err := ing.ingestEntryChunk(p, adCid, ad, c)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -622,8 +622,9 @@ func (r *Registry) pollProviders(pollInterval, pollRetryAfter, pollStopAfter tim
 				continue
 			}
 			if info.lastContactTime.IsZero() {
-				// There has been no contact since startup.  Start counting now.
-				info.lastContactTime = now
+				// There has been no contact since startup.  Poll during next
+				// call to this function if no updated for provider.
+				info.lastContactTime = now.Add(-pollInterval)
 				continue
 			}
 			noContactTime := now.Sub(info.lastContactTime)


### PR DESCRIPTION
Limiting traversal depth for advertisement chains and entry chains is not a reliable mechanism for preventing DoS, and can cause the indexer to serve incorrect content if advertisements are missed, and incomplete content if entries are missed when the limits are configured too low.  Rate limiting will be used to prevent busy publishers from starving others, instead of depth limiting.

A large non-configurable depth limit is still in effect for the entries list but is large enough that it should only apply to misconfigured badly-behaving publishers.