### PR TITLE
Limit number of open connection to the http server

### DIFF
--- a/server/finder/http/options.go
+++ b/server/finder/http/options.go
@@ -8,12 +8,14 @@ import (
 const (
 	apiWriteTimeout = 30 * time.Second
 	apiReadTimeout  = 30 * time.Second
+	maxConns        = 8_000
 )
 
 // serverConfig is a structure containing all the options that can be used when constructing an http server
 type serverConfig struct {
 	apiWriteTimeout time.Duration
 	apiReadTimeout  time.Duration
+	maxConns        int
 }
 
 // ServerOption for httpserver
@@ -24,6 +26,7 @@ type ServerOption func(*serverConfig) error
 var serverDefaults = func(o *serverConfig) error {
 	o.apiWriteTimeout = apiWriteTimeout
 	o.apiReadTimeout = apiReadTimeout
+	o.maxConns = maxConns
 	return nil
 }
 

--- a/server/finder/http/server.go
+++ b/server/finder/http/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	logging "github.com/ipfs/go-log/v2"
+	xnet "golang.org/x/net/netutil"
 )
 
 var log = logging.Logger("indexer/finder")
@@ -39,6 +40,9 @@ func New(listen string, indexer indexer.Interface, registry *registry.Registry, 
 	if err != nil {
 		return nil, err
 	}
+
+	// Limit the number of open connections to the listener.
+	l = xnet.LimitListener(l, cfg.maxConns)
 
 	// Resource handler
 	h := newHandler(indexer, registry)


### PR DESCRIPTION
We're seeing issues where we are overloading the indexer by trying to handle too many connection this is a quick attempt to limit the number of simultaneous connections to our endpoint.

In the future we should have a proper http cache (cloudfront?), but I'm hoping this will be an okay stop-gap for now.

