### PR TITLE
Bump version to `0.4.0` after bindnode merge

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.8"
+  "version": "v0.4.0"
 }


### PR DESCRIPTION
IPLD bindnode integration makes API changes in the Ingest schema. Bump
version in preparation for release.