### PR TITLE
More efficient batch processing of multihashes

### DIFF
--- a/config/ingest.go
+++ b/config/ingest.go
@@ -28,7 +28,7 @@ type Ingest struct {
 func NewIngest() Ingest {
 	return Ingest{
 		PubSubTopic:       "/indexer/ingest/mainnet",
-		StoreBatchSize:    256,
+		StoreBatchSize:    4096,
 		SyncTimeout:       Duration(2 * time.Hour),
 		IngestWorkerCount: 10,
 	}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -118,7 +118,6 @@ func (e *e2eTestRunner) stop(cmd *exec.Cmd, timeout time.Duration) {
 }
 
 func TestEndToEndWithReferenceProvider(t *testing.T) {
-	t.Skip("Skipping this test since it's currently broken – will fix in another PR.")
 	switch runtime.GOOS {
 	case "windows", "darwin":
 		t.Skip("skipping test on", runtime.GOOS)


### PR DESCRIPTION
Deliver a slice of multihashes to the batch processing goroutine, instead of one multihash at a time.  Reuse alternating slices of multihashes so that one is filling while the other is written to the indexer.