### PR TITLE
Set up and configure dev instance of storetheindex running on EKS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-storetheindex
+/storetheindex
 *~
 *.car
 *.out

--- a/deploy/infrastructure/dev/us-east-2/.terraform.lock.hcl
+++ b/deploy/infrastructure/dev/us-east-2/.terraform.lock.hcl
@@ -1,0 +1,60 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.7.0"
+  constraints = ">= 3.63.0, >= 3.72.0"
+  hashes = [
+    "h1:kVtMXXaRv4SpTKgbKt7IRQYITwvadfWRfLsvvFvnyVQ=",
+    "zh:00f77e618cdceb507b7033758a94459ca1d2904ec0f99d9dfdbfdd98f3f219d8",
+    "zh:49989eb97859e5ef7f2123422fceaa3a1d5d63a4b7800591737e835dd218701e",
+    "zh:5107f889858f99efcfb37a53dd5f5e1b064ae6debcd13d493ae4bb3c02370d1b",
+    "zh:7d4c85de26cbb8662cba441c923f9928756800380f36a68cf49f60f5b3212165",
+    "zh:87f1b4a26ed3e0741670dfc8708b45bf17ad77d3e72b43bfc123ffae170b3578",
+    "zh:9470ef10e55fdacec8aaf5457eb299c6624e05cc9890e162244c446bb704b93a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:acbf6fbdbdf284829cdfd5652e8fc17c9ad9f458978a16ea63b2bed2b4d98e41",
+    "zh:b491c45ae264512d744992a0ab88660e878b4462a38835dab54e61a61ade9378",
+    "zh:ee2a5908c074cb5ebe53d5abed99096695e3346833a80d9833c26882ddabf913",
+    "zh:f2b311a760b5a5a2a9c889632c15dd5617350ae95ac7e2253aab3931fbc41c37",
+    "zh:fdf1b5a37be1a3aa6953f4b56d7294c1e86da12bb661c24f4e0840321c10973f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.2.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:siiI0wK6/jUDdA5P8ifTO0yc9YmXHml4hz5K9I9N+MA=",
+    "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
+    "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
+    "zh:9200f02cb917fb99e44b40a68936fd60d338e4d30a718b7e2e48024a795a61b9",
+    "zh:a33cf255dc670c20678063aa84218e2c1b7a67d557f480d8ec0f68bc428ed472",
+    "zh:ba3c1b2cd0879286c1f531862c027ec04783ece81de67c9a3b97076f1ce7f58f",
+    "zh:bd575456394428a1a02191d2e46af0c00e41fd4f28cfe117d57b6aeb5154a0fb",
+    "zh:c68dd1db83d8437c36c92dc3fc11d71ced9def3483dd28c45f8640cfcd59de9a",
+    "zh:cbfe34a90852ed03cc074601527bb580a648127255c08589bc3ef4bf4f2e7e0c",
+    "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
+    "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
+    "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.1.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:XTU9f6sGMZHOT8r/+LWCz2BZOPH127FBTPjMMEAAu1U=",
+    "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
+    "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",
+    "zh:668217e78b210a6572e7b0ecb4134a6781cc4d738f4f5d09eb756085b082592e",
+    "zh:95354df03710691773c8f50a32e31fca25f124b7f3d6078265fdf3c4e1384dca",
+    "zh:9f97ab190380430d57392303e3f36f4f7835c74ea83276baa98d6b9a997c3698",
+    "zh:a16f0bab665f8d933e95ca055b9c8d5707f1a0dd8c8ecca6c13091f40dc1e99d",
+    "zh:be274d5008c24dc0d6540c19e22dbb31ee6bfdd0b2cddd4d97f3cd8a8d657841",
+    "zh:d5faa9dce0a5fc9d26b2463cea5be35f8586ab75030e7fa4d4920cd73ee26989",
+    "zh:e9b672210b7fb410780e7b429975adcc76dd557738ecc7c890ea18942eb321a5",
+    "zh:eb1f8368573d2370605d6dbf60f9aaa5b64e55741d96b5fb026dbfe91de67c0d",
+    "zh:fc1e12b713837b85daf6c3bb703d7795eaf1c5177aebae1afcf811dd7009f4b0",
+  ]
+}

--- a/deploy/infrastructure/dev/us-east-2/backend.tf
+++ b/deploy/infrastructure/dev/us-east-2/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "sti-dev-terraform-state"
+    key    = "sti/dev/us-east-2/terraform.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/deploy/infrastructure/dev/us-east-2/ecr.tf
+++ b/deploy/infrastructure/dev/us-east-2/ecr.tf
@@ -1,0 +1,9 @@
+module "ecr" {
+  source = "../../modules/ecr"
+
+  repositories = [
+    "storetheindex/storetheindex",
+  ]
+
+  tags = local.tags
+}

--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -1,0 +1,31 @@
+module "eks" {
+  source  = "registry.terraform.io/terraform-aws-modules/eks/aws"
+  version = "18.15.0"
+
+  cluster_name    = local.environment_name
+  cluster_version = "1.21"
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_group_defaults = {
+    instance_types = ["m4.large"]
+  }
+
+  eks_managed_node_groups = {
+    default_node_group = {
+      min_size     = 1
+      max_size     = 7
+      desired_size = 1
+
+      create_launch_template = false
+      launch_template_name   = ""
+    }
+  }
+
+  tags = local.tags
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_id
+}

--- a/deploy/infrastructure/dev/us-east-2/locals.tf
+++ b/deploy/infrastructure/dev/us-east-2/locals.tf
@@ -1,0 +1,12 @@
+locals {
+
+  environment_name = "dev"
+
+  tags = {
+    "Environment" = local.environment_name
+    "ManagedBy"   = "terraform"
+    Owner         = "storetheindex"
+    Team          = "bedrock"
+    Organization  = "EngRes"
+  }
+}

--- a/deploy/infrastructure/dev/us-east-2/main.tf
+++ b/deploy/infrastructure/dev/us-east-2/main.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region              = "us-east-2"
+  allowed_account_ids = ["407967248065"]
+}

--- a/deploy/infrastructure/dev/us-east-2/versions.tf
+++ b/deploy/infrastructure/dev/us-east-2/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.13.7"
+}

--- a/deploy/infrastructure/dev/us-east-2/vpc.tf
+++ b/deploy/infrastructure/dev/us-east-2/vpc.tf
@@ -1,0 +1,30 @@
+module "vpc" {
+  source  = "registry.terraform.io/terraform-aws-modules/vpc/aws"
+  version = "3.13.0"
+
+  name = local.environment_name
+
+  azs = data.aws_availability_zones.available.names
+
+  cidr            = "20.10.0.0/16"
+  private_subnets = ["20.10.1.0/24", "20.10.2.0/24", "20.10.3.0/24"]
+  public_subnets  = ["20.10.11.0/24", "20.10.12.0/24", "20.10.13.0/24"]
+
+  enable_nat_gateway   = true
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+
+  tags = local.tags
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/deploy/infrastructure/modules/ecr/main.tf
+++ b/deploy/infrastructure/modules/ecr/main.tf
@@ -1,0 +1,35 @@
+resource "aws_ecr_repository" "this" {
+  for_each = var.repositories
+  name     = each.key
+  tags     = var.tags
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+  image_tag_mutability = var.ecr_tag_immutability
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each   = var.repositories
+  repository = each.key
+  depends_on = [
+  aws_ecr_repository.this]
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire untagged images older than ${var.ecr_untagged_expiry_days} days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": ${var.ecr_untagged_expiry_days}
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}

--- a/deploy/infrastructure/modules/ecr/variables.tf
+++ b/deploy/infrastructure/modules/ecr/variables.tf
@@ -1,0 +1,27 @@
+variable "repositories" {
+  type        = set(string)
+  description = "The list of namespace and repository names in `<namespace>/<repo-name>` format."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "The tags applied to all created AWS resources."
+}
+
+variable "ecr_untagged_expiry_days" {
+  type        = number
+  description = "The number of days after which to expire untagged pushed images"
+  default     = 7
+}
+
+variable "ecr_tag_immutability" {
+  type        = string
+  description = "The immutability of container image tags published to ECR repository, either `MUTABLE` or `IMMUTABLE`."
+  default     = "IMMUTABLE"
+}
+
+variable "scan_on_push" {
+  type        = bool
+  description = "Indicates whether images are scanned after being pushed to the repository."
+  default     = true
+}


### PR DESCRIPTION
## Context
The current dev instance of `storetheindex` runs on plane EC2, with a runtime environment that is unlike staging or production. This reduces the confidence in rolling out changes tested in dev, onto the other two environments.

Ideally:
* All environments should be set up and deployed as close to one-another as possible
* No manual changes should be made to the runtime environment to avoid accidental human error.

With an organizational shift to GitOps, the changes proposed here sets up a dev environment for storetheindex using GitOps principles from ground up: a dedicated VPC that runs an EKS cluster dedicated to the dev environment, along with K8S manifests generated using Kustomizations. Topped with a CD mechanism that keeps the commits made to `main` consistent with what runs on the dev environment.

## Proposed Changes
* Set up a new dev environment running on a dedicated EKS cluster
* Configure a placeholder FluxCD pipeline for the dev environment that deployes the head of main.

## Tests
Observed the controllers action the changes.

## Revert Strategy
The changes in this PR are applied via `terraform apply` and `kubectl apply -k` to bootstrap the CD. To revert the changes, `terraform destroy` should be run to remove all resources created by this PR. The K8S resources will be removed automatically as a result of EKS destruction.


## TODO
- [x] Set up dev VPC and EKS cluster
- [x] Configure EKS cluster with default users
- [x] Install fluxCD
- [ ] Set up `storetheindex` as a tenant of dev cluster with place holders for K8S manifests.

Relates to: #287
