### PR TITLE
Install `nginx` ingress controller on dev K8S cluster

### DIFF
--- a/deploy/manifests/base/ingress-nginx/kustomization.yaml
+++ b/deploy/manifests/base/ingress-nginx/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ingress-nginx
+
+resources:
+  - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.2/deploy/static/provider/aws/deploy.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ../../../base/ingress-nginx
   - kube-system
   - flux-system
   - storetheindex


### PR DESCRIPTION

## Context
Install `nginx` ingress controller onto dev K8S cluster using an overlay
on top of base `ingress-nginx` kustomization.

Note that this should get automatically installed once merged to main now that we have a CD pipeline running for cluster level changes.

## Proposed Changes
See context.

## Tests
N/A

## Revert Strategy
`git revert`, commit and merge to `main`. CD would then remove it from dev cluster.