### PR TITLE
Allow the ability to configure private key via file

### DIFF
--- a/config/identity.go
+++ b/config/identity.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -12,36 +13,73 @@ const (
 	IdentityTag     = "Identity"
 	PrivKeyTag      = "PrivKey"
 	PrivKeySelector = IdentityTag + "." + PrivKeyTag
+
+	PrivateKeyPathEnvVar = "STORETHEINDEX_PRIV_KEY_PATH"
 )
 
 // Identity tracks the configuration of the local node's identity.
 type Identity struct {
-	PeerID  string
+	// PeerID is the peer ID of the indexer that must match the given PrivKey.
+	// If unspecified, it is automatically generated from the PrivKey.
+	PeerID string
+	// PrivKey represents the peer identity of the indexer.
+	//
+	// If unset, the key is loaded from the file at the path specified via
+	// STORETHEINDEX_PRIV_KEY_PATH environment variable.
 	PrivKey string `json:",omitempty"`
 }
 
 func (i Identity) Decode() (peer.ID, ic.PrivKey, error) {
-	peerID, err := peer.Decode(i.PeerID)
-	if err != nil {
-		return "", nil, fmt.Errorf("could not decode peer id: %s", err)
-	}
 
 	privKey, err := i.DecodePrivateKey("")
 	if err != nil {
-		return "", nil, fmt.Errorf("could not decode private key: %s", err)
+		return "", nil, fmt.Errorf("could not decode private key: %w", err)
 	}
 
-	return peerID, privKey, nil
+	peerIDFromPrivKey, err := peer.IDFromPrivateKey(privKey)
+	if err != nil {
+		return "", nil, fmt.Errorf("could not generate peer ID from private key: %w", err)
+	}
+
+	// If peer ID is specified in JSON config, then verify that it is:
+	//   1. a valid peer ID, and
+	//   2. consistent with the peer ID generated from private key.
+	if i.PeerID != "" {
+		peerID, err := peer.Decode(i.PeerID)
+		if err != nil {
+			return "", nil, fmt.Errorf("could not decode peer id: %w", err)
+		}
+
+		if peerID != "" && peerIDFromPrivKey != peerID {
+			return "", nil, fmt.Errorf("provided peer ID must either match the peer ID generated from private key or be omitted: expected %s but got %s", peerIDFromPrivKey, peerID)
+		}
+	}
+
+	return peerIDFromPrivKey, privKey, nil
 }
 
 // DecodePrivateKey is a helper to decode the user's PrivateKey.
 func (i Identity) DecodePrivateKey(passphrase string) (ic.PrivKey, error) {
-	pkb, err := base64.StdEncoding.DecodeString(i.PrivKey)
+	// TODO(security): currently storing key unencrypted. in the future we need to encrypt it.
+
+	// If a value is supplied in JSON config then attempt to decode it as the private key.
+	if i.PrivKey != "" {
+		pkb, err := base64.StdEncoding.DecodeString(i.PrivKey)
+		if err != nil {
+			return nil, err
+		}
+		return ic.UnmarshalPrivateKey(pkb)
+	}
+
+	// Otherwise, load the private key from path supplied via env var.
+	privKeyPath := os.Getenv(PrivateKeyPathEnvVar)
+	if privKeyPath == "" {
+		return nil, fmt.Errorf("private key not specified; it must be specified either in config or via %s env var", PrivateKeyPathEnvVar)
+	}
+
+	pkb, err := os.ReadFile(privKeyPath)
 	if err != nil {
 		return nil, err
 	}
-
-	// currently storing key unencrypted. in the future we need to encrypt it.
-	// TODO(security)
 	return ic.UnmarshalPrivateKey(pkb)
 }

--- a/config/identity_test.go
+++ b/config/identity_test.go
@@ -1,0 +1,112 @@
+package config_test
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/filecoin-project/storetheindex/config"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentity_Decode(t *testing.T) {
+	testB64PrivKey := "CAESQFcdYoJlGW2TPMxX3h1yH/29ML3873kW8sKeBJ/lSy2sscZbeFVI+TEz8T7F9vuw6KPYbokzZnPR4HgXkxw/xg0="
+	pkb, err := base64.StdEncoding.DecodeString(testB64PrivKey)
+	require.NoError(t, err)
+	testPrivKeyPath := filepath.Join(t.TempDir(), "identity.key")
+	err = os.WriteFile(testPrivKeyPath, pkb, 0666)
+	require.NoError(t, err)
+	testPrivKey, err := crypto.UnmarshalPrivateKey(pkb)
+	require.NoError(t, err)
+	testPeerID, err := peer.IDFromPrivateKey(testPrivKey)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		givenConfig config.Identity
+		givenEnvVar string
+		wantPeerID  peer.ID
+		wantPrivKey crypto.PrivKey
+		wantErr     string
+	}{
+		{
+			name:    "Empty config and env var is error",
+			wantErr: "could not decode private key: private key not specified; it must be specified either in config or via STORETHEINDEX_PRIV_KEY_PATH env var",
+		},
+		{
+			name: "Invalid private key in config is error",
+			givenConfig: config.Identity{
+				PrivKey: "invalid private key",
+			},
+			wantErr: "could not decode private key: illegal base64 data at input byte 7",
+		},
+		{
+			name: "Invalid peer ID in config is error",
+			givenConfig: config.Identity{
+				PeerID:  "invalid peer ID",
+				PrivKey: testB64PrivKey,
+			},
+			wantErr: "could not decode peer id: failed to parse peer ID: selected encoding not supported",
+		},
+		{
+			name:        "Invalid path via env var is error",
+			givenEnvVar: "non-existing-file",
+			wantErr:     "could not decode private key: open non-existing-file",
+		},
+		{
+			name: "Mismatching peer ID in config is error",
+			givenConfig: config.Identity{
+				PeerID:  "12D3KooWP5UZNGnCPsCoCgxbc9BRDVwwgFguZ7EaW6FEMHTzN2q7",
+				PrivKey: testB64PrivKey,
+			},
+			wantErr: "provided peer ID must either match the peer ID generated from private key or be omitted: expected 12D3KooWMnKm1H932NjBzETsTEFSeXpaPUiwCoCqQMrBc6sVnUeQ but got 12D3KooWP5UZNGnCPsCoCgxbc9BRDVwwgFguZ7EaW6FEMHTzN2q7",
+		},
+		{
+			name: "Matching peer ID and private key in config is valid",
+			givenConfig: config.Identity{
+				PeerID:  testPeerID.String(),
+				PrivKey: testB64PrivKey,
+			},
+			wantPeerID:  testPeerID,
+			wantPrivKey: testPrivKey,
+		},
+		{
+			name: "Matching peer ID and private key from env var is valid",
+			givenConfig: config.Identity{
+				PeerID: testPeerID.String(),
+			},
+			givenEnvVar: testPrivKeyPath,
+			wantPeerID:  testPeerID,
+			wantPrivKey: testPrivKey,
+		},
+		{
+			name: "Mismatching peer ID and private key from env var is error",
+			givenConfig: config.Identity{
+				PeerID: "12D3KooWP5UZNGnCPsCoCgxbc9BRDVwwgFguZ7EaW6FEMHTzN2q7",
+			},
+			givenEnvVar: testPrivKeyPath,
+			wantErr:     "provided peer ID must either match the peer ID generated from private key or be omitted: expected 12D3KooWMnKm1H932NjBzETsTEFSeXpaPUiwCoCqQMrBc6sVnUeQ but got 12D3KooWP5UZNGnCPsCoCgxbc9BRDVwwgFguZ7EaW6FEMHTzN2q7",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.givenEnvVar != "" {
+				t.Setenv(config.PrivateKeyPathEnvVar, tt.givenEnvVar)
+			}
+			gotPeerID, gotPrivKey, err := tt.givenConfig.Decode()
+			if tt.wantErr != "" {
+				// Only check prefix of error message to keep CI happy. Message returned in 1.18 is different.
+				require.True(t, strings.HasPrefix(err.Error(), tt.wantErr))
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPeerID.String(), gotPeerID.String())
+			require.Equal(t, tt.wantPrivKey, gotPrivKey)
+		})
+	}
+}


### PR DESCRIPTION
## Context
Right now the container deployment entails using `envsubst` just to populate secret values in a json file, the only way indexer reads peer identity.

In order to reduce complexity and improve security when deploying the indexer in containerized environment, provide a way to set the private key via a path spevified as `STORETHEINDEX_PRIV_KEY_PATH` environment variable.

This then allows private key to be generated separately by an admin and mounted as a file with limited permissions.

The config was also not checking whether the given peer ID matches the private key which this PR fixes.
It is unclear why indexer asks for peer ID at all since it can always be generated from private key. For now this PR keeps the scope of changes small by keeping the peer ID as is..

## Proposed Changes
* allow the identity to be specified as a path to a file, via env var.
* check that peer ID matches the identity given.

## Tests
See commit.

## Revert Strategy
`git revert`.