### PR TITLE
Deploy storetheindex to dev cluster

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/kms.tf
+++ b/deploy/infrastructure/dev/us-east-2/kms.tf
@@ -1,0 +1,105 @@
+resource "aws_kms_alias" "kms_sti" {
+  target_key_id = aws_kms_key.kms_sti.key_id
+  name          = "alias/sti_flux"
+}
+
+resource "aws_kms_key" "kms_sti" {
+  description = "Key used to encrypt storetheindex tenant secrets"
+  policy      = data.aws_iam_policy_document.kms_sti.json
+  is_enabled  = true
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "kms_sti" {
+  statement {
+    sid = "Enable IAM User Permissions"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::407967248065:root"]
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow access for Devs via sops"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::407967248065:user/masih",
+        "arn:aws:iam::407967248065:user/marco",
+        "arn:aws:iam::407967248065:user/gammazero",
+        "arn:aws:iam::407967248065:user/will.scott",
+      ]
+    }
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+  }
+
+
+  statement {
+    sid = "Allow Flux to decrypt"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        module.kustomize_controller_role.iam_role_arn
+      ]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "kust_ctrlr" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+
+    resources = [aws_kms_key.kms_sti.arn]
+  }
+}
+
+resource "aws_iam_policy" "kust_ctrlr" {
+  name   = "${local.environment_name}_kust_ctrlr"
+  policy = data.aws_iam_policy_document.kust_ctrlr.json
+  tags   = local.tags
+}
+
+module "kustomize_controller_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "${local.environment_name}_kustomize_controller"
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    aws_iam_policy.kust_ctrlr.arn,
+  ]
+
+  oidc_fully_qualified_subjects = ["system:serviceaccount:flux-system:kustomize-controller"]
+
+  tags = local.tags
+}

--- a/deploy/infrastructure/dev/us-east-2/outputs.tf
+++ b/deploy/infrastructure/dev/us-east-2/outputs.tf
@@ -1,0 +1,7 @@
+output "kms_sti_flux_arn" {
+  value = aws_kms_alias.kms_sti.arn
+}
+
+output "kustomize_controller_role_arn" {
+  value = module.kustomize_controller_role.iam_role_arn
+}

--- a/deploy/infrastructure/dev/us-east-2/versions.tf
+++ b/deploy/infrastructure/dev/us-east-2/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 1.13.7"
+  required_version = ">= 1.1.7"
 }

--- a/deploy/manifests/base/flux-system/kustomization.yaml
+++ b/deploy/manifests/base/flux-system/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: flux-system
 
 resources:
-  - https://github.com/fluxcd/flux2/releases/download/v0.28.3/install.yaml
+  - https://github.com/fluxcd/flux2/releases/download/v0.28.4/install.yaml
 
 patches:
   # Disallow cross namespace access, since the deployment follows a multi-tenant setup.
@@ -31,7 +31,7 @@ patches:
     target:
       kind: Deployment
       name: "(kustomize-controller|helm-controller)"
-  # Allow cluster-wide kustomizations to administer cluster.
+  # Allow cluster-wide kustomizations to administer the cluster.
   - patch: |
       - op: add
         path: /spec/serviceAccountName

--- a/deploy/manifests/base/storetheindex/config
+++ b/deploy/manifests/base/storetheindex/config
@@ -1,0 +1,61 @@
+{
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 15
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": true,
+      "Except": null,
+      "Trust": true,
+      "TrustExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5h0m0s",
+    "PollStopAfter": "168h0m0s",
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s"
+  },
+  "Indexer": {
+    "CacheSize": 300000,
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "sth"
+  },
+  "Ingest": {
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "StoreBatchSize": 4096,
+    "SyncTimeout": "2h0m0s"
+  }
+}

--- a/deploy/manifests/base/storetheindex/finder-service.yaml
+++ b/deploy/manifests/base/storetheindex/finder-service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: finder
+  labels:
+    app: finder
+spec:
+  ports:
+    - name: finder
+      port: 3000
+      targetPort: finder
+  selector:
+    app: indexer
+  type: LoadBalancer

--- a/deploy/manifests/base/storetheindex/indexer-statefulset.yaml
+++ b/deploy/manifests/base/storetheindex/indexer-statefulset.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: indexer
+spec:
+  serviceName: "indexer"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: indexer
+  template:
+    metadata:
+      labels:
+        app: indexer
+    spec:
+      securityContext:
+        runAsUser: 10001
+        fsGroup: 532
+      containers:
+        - name: indexer
+          # TODO: replace with images published to ECR once docker build to it is set up
+          image: filecoin/storetheindex:3b2c5f5df721dc2cdfb340490b73de856960bfab
+          envFrom:
+            - configMapRef:
+                name: indexer-env-vars
+          ports:
+            - containerPort: 3000
+              name: finder
+            - containerPort: 3001
+              name: ingest
+            - containerPort: 3002
+              name: admin
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          configMap:
+            name: indexer-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Ti

--- a/deploy/manifests/base/storetheindex/ingest-service.yaml
+++ b/deploy/manifests/base/storetheindex/ingest-service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingest
+  labels:
+    app: ingest
+spec:
+  ports:
+    - name: ingest
+      port: 3001
+      targetPort: ingest
+  selector:
+    app: indexer
+  type: LoadBalancer

--- a/deploy/manifests/base/storetheindex/kustomization.yaml
+++ b/deploy/manifests/base/storetheindex/kustomization.yaml
@@ -3,11 +3,25 @@ kind: Kustomization
 
 namespace: storetheindex
 
+resources:
+  - indexer-statefulset.yaml
+  - finder-service.yaml
+  - ingest-service.yaml
+
 transformers:
   - labels.yaml
 
 configMapGenerator:
-  - name: storetheindex-config
+  - name: indexer-env-vars
     behavior: create
     literals:
       - GOLOG_LOG_LEVEL=INFO
+      - GOLOG_LOG_FMT=json
+      - STORETHEINDEX_LOTUS_GATEWAY=wss://api.chain.love
+      - STORETHEINDEX_PATH=/config
+      - STORETHEINDEX_LISTEN_ADMIN=/ip4/0.0.0.0/tcp/3002
+  - name: indexer-config
+    behavior: create
+    files:
+      # Note: the name of file must be `config`; currently there is no way to customize this in daemon.
+      - config

--- a/deploy/manifests/dev/us-east-2/cluster/flux-system/cluster-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/flux-system/cluster-cd.yaml
@@ -19,6 +19,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: storetheindex
-  wait: true
-  timeout: 2m
-  prune: false # TODO: Re-enable this once the team is used to GitOps.
+  prune: true

--- a/deploy/manifests/dev/us-east-2/cluster/flux-system/kust-ctrlr-sa-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/flux-system/kust-ctrlr-sa-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/dev_kustomize_controller"

--- a/deploy/manifests/dev/us-east-2/cluster/flux-system/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/flux-system/kustomization.yaml
@@ -6,3 +6,6 @@ namespace: flux-system
 resources:
   - ../../../../base/flux-system
   - cluster-cd.yaml
+
+patchesStrategicMerge:
+  - kust-ctrlr-sa-patch.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-cd.yaml
@@ -7,6 +7,7 @@ spec:
   url: https://github.com/filecoin-project/storetheindex.git
   ref:
     branch: main
+
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
@@ -14,19 +15,18 @@ metadata:
   name: storetheindex
 spec:
   serviceAccountName: flux
+  decryption:
+    provider: sops
   interval: 5m
   path: "./deploy/manifests/dev/us-east-2/tenant/storetheindex"
   sourceRef:
     kind: GitRepository
     name: storetheindex
-  wait: true
-  timeout: 2m
-  prune: false # TODO: Re-enable this once the team is used to GitOps.
+  prune: true
   images:
     - name: storetheindex
       newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-  decryption:
-    provider: sops
+
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImageRepository

--- a/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-cd.yaml
@@ -25,6 +25,8 @@ spec:
   images:
     - name: storetheindex
       newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+  decryption:
+    provider: sops
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImageRepository

--- a/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-rbac.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-rbac.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: flux
-  annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/dev_sti_flux"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-rbac.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-rbac.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: flux
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/dev_sti_flux"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/manifests/dev/us-east-2/cluster/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/storetheindex/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 
 namespace: storetheindex
 
+commonLabels:
+  toolkit.fluxcd.io/tenant: storetheindex
+
 resources:
   - namespace.yaml
   - flux-cd.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/.sops.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/.sops.yaml
@@ -1,0 +1,4 @@
+creation_rules:
+  - path_regex: .*
+    encrypted_regex: '^(data|stringData)$'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/sti_flux'

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/identity.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/identity.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:jb2V1wNzhS3AnYnLnePaSI7ppLmsCK3fD1sET/8qv3aibX5F7pG0Nyd/8Hy4CfHy30Y7UCUBXnhCAF0AvTwMFnCjVMY=,iv:w8Inv/LhSoL3/3QVmLhVzv2kb57AXP9ZJ//V30K2P0Y=,tag:kc0YFmpPnY2uyavnbzdneg==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2022-03-30T15:24:20Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAGo3ZZUKyGQs1qIMKXJEsTPAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMHytgB5OTIK0A7oPfAgEQgDv62bWAFPeEOQoiy/CL17ebjkW0WH53kV0hLxtzPe/W6H93WCSoZyYt5dHvEWvyaCk5IjoJs3ghXggziw==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-03-30T15:24:21Z",
+		"mac": "ENC[AES256_GCM,data:kQUVcjzcGdnizPGPSZzkcTHZuLzDX2ad4+0xponQE447u64i+BGel03PoqMGEBVQ3baEhVJJGshG1TumQO8xP/bMdSw49/K/0epFWXcIllq+xdTACj5b7lBZOLWtbTcWgE9VsvqP+F+VBPNrME3k0RfO4HrWVLRwB7KnJECXOus=,iv:N/2xwM6n1ogP7Y3AOzQUYl24+2F0KCPEbL8nzwCankw=,tag:GOD0RflvQJuWcbiDbi9ALQ==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -1,5 +1,21 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: storetheindex
+
 resources:
   - ../../../../base/storetheindex
+
+patchesStrategicMerge:
+  - patch-indexer.yaml
+
+configMapGenerator:
+  - name: indexer-env-vars
+    behavior: merge
+    literals:
+      - STORETHEINDEX_PRIV_KEY_PATH=/identity/identity.key
+
+secretGenerator:
+  - name: indexer-identity
+    files:
+      - identity.key=identity.encrypted

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      containers:
+        - name: indexer
+          volumeMounts:
+            - name: identity
+              mountPath: /identity
+      volumes:
+        - name: identity
+          secret:
+            secretName: indexer-identity


### PR DESCRIPTION
## Context
Define `kustomization` base for storetheindex as a statefulset along with overlay that deploys it to the dev cluster. This work also adds encrypted secret management via [sops](https://github.com/mozilla/sops) and KMS to securely check in encrypted secrets into code, and have the CD pipeline decrypt them on the fly by assuming roles that permit it to do so.

## Proposed Changes
* Define base storetheindex manifest overlay
* Define dev concrete overlay to deploy storetheindex
* Set up secret management and generate a random libp2p identity for the dev instance  

## Tests
N/A

## Revert Strategy
`git revert` then `terraform apply` for infrastructure part.

Relates to: #287 