### PR TITLE
Store publisher address with publisher ID

### DIFF
--- a/api/v0/finder/model/provider_info.go
+++ b/api/v0/finder/model/provider_info.go
@@ -10,14 +10,16 @@ import (
 // ProviderData describes a provider.
 type ProviderInfo struct {
 	AddrInfo              peer.AddrInfo
-	LastAdvertisement     cid.Cid `json:",omitempty"`
-	LastAdvertisementTime string  `json:",omitempty"`
+	LastAdvertisement     cid.Cid        `json:",omitempty"`
+	LastAdvertisementTime string         `json:",omitempty"`
+	Publisher             *peer.AddrInfo `json:",omitempty"`
 }
 
-func MakeProviderInfo(addrInfo peer.AddrInfo, lastAd cid.Cid, lastAdTime time.Time) ProviderInfo {
+func MakeProviderInfo(addrInfo peer.AddrInfo, lastAd cid.Cid, lastAdTime time.Time, publisher *peer.AddrInfo) ProviderInfo {
 	pinfo := ProviderInfo{
 		AddrInfo:          addrInfo,
 		LastAdvertisement: lastAd,
+		Publisher:         publisher,
 	}
 
 	if lastAd != cid.Undef && !lastAdTime.IsZero() {

--- a/api/v0/finder/model/provider_info.go
+++ b/api/v0/finder/model/provider_info.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
 )
 
 // ProviderData describes a provider.
@@ -15,11 +16,20 @@ type ProviderInfo struct {
 	Publisher             *peer.AddrInfo `json:",omitempty"`
 }
 
-func MakeProviderInfo(addrInfo peer.AddrInfo, lastAd cid.Cid, lastAdTime time.Time, publisher *peer.AddrInfo) ProviderInfo {
+func MakeProviderInfo(addrInfo peer.AddrInfo, lastAd cid.Cid, lastAdTime time.Time, publisherID peer.ID, publisherAddr string) ProviderInfo {
 	pinfo := ProviderInfo{
 		AddrInfo:          addrInfo,
 		LastAdvertisement: lastAd,
-		Publisher:         publisher,
+	}
+
+	if publisherID.Validate() == nil && publisherAddr != "" {
+		maddr, err := multiaddr.NewMultiaddr(publisherAddr)
+		if err == nil {
+			pinfo.Publisher = &peer.AddrInfo{
+				ID:    publisherID,
+				Addrs: []multiaddr.Multiaddr{maddr},
+			}
+		}
 	}
 
 	if lastAd != cid.Undef && !lastAdTime.IsZero() {

--- a/api/v0/finder/model/provider_info.go
+++ b/api/v0/finder/model/provider_info.go
@@ -16,19 +16,16 @@ type ProviderInfo struct {
 	Publisher             *peer.AddrInfo `json:",omitempty"`
 }
 
-func MakeProviderInfo(addrInfo peer.AddrInfo, lastAd cid.Cid, lastAdTime time.Time, publisherID peer.ID, publisherAddr string) ProviderInfo {
+func MakeProviderInfo(addrInfo peer.AddrInfo, lastAd cid.Cid, lastAdTime time.Time, publisherID peer.ID, publisherAddr multiaddr.Multiaddr) ProviderInfo {
 	pinfo := ProviderInfo{
 		AddrInfo:          addrInfo,
 		LastAdvertisement: lastAd,
 	}
 
-	if publisherID.Validate() == nil && publisherAddr != "" {
-		maddr, err := multiaddr.NewMultiaddr(publisherAddr)
-		if err == nil {
-			pinfo.Publisher = &peer.AddrInfo{
-				ID:    publisherID,
-				Addrs: []multiaddr.Multiaddr{maddr},
-			}
+	if publisherID.Validate() == nil && publisherAddr != nil {
+		pinfo.Publisher = &peer.AddrInfo{
+			ID:    publisherID,
+			Addrs: []multiaddr.Multiaddr{publisherAddr},
 		}
 	}
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -119,7 +119,7 @@ func (e *e2eTestRunner) stop(cmd *exec.Cmd, timeout time.Duration) {
 
 func TestEndToEndWithReferenceProvider(t *testing.T) {
 	switch runtime.GOOS {
-	case "windows", "darwin":
+	case "windows":
 		t.Skip("skipping test on", runtime.GOOS)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -518,19 +518,13 @@ func (ing *Ingester) autoSync() {
 	for provInfo := range ing.reg.SyncChan() {
 		ing.waitForPendingSyncs.Add(1)
 
-		go func(pubID peer.ID, pubAddrStr string, provID peer.ID) {
+		go func(pubID peer.ID, pubAddr multiaddr.Multiaddr, provID peer.ID) {
 			defer ing.waitForPendingSyncs.Done()
-
-			pubAddr, err := multiaddr.NewMultiaddr(pubAddrStr)
-			if err != nil {
-				log.Errorw("failed to convert to multiaddr", "err", err)
-				return
-			}
 
 			log := log.With("provider", provID, "publisher", pubID, "addr", pubAddr)
 			log.Info("Auto-syncing the latest advertisement with publisher")
 
-			_, err = ing.sub.Sync(ctx, pubID, cid.Undef, nil, pubAddr)
+			_, err := ing.sub.Sync(ctx, pubID, cid.Undef, nil, pubAddr)
 			if err != nil {
 				log.Errorw("Failed to auto-sync with publisher", "err", err)
 				return

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -84,8 +84,6 @@ func (p *ProviderInfo) dsKey() datastore.Key {
 // NewRegistry creates a new provider registry, giving it provider policy
 // configuration, a datastore to persist provider data, and a Discoverer
 // interface.  The context is only used for cancellation of this function.
-//
-// TODO: It is probably necessary to have multiple discoverer interfaces
 func NewRegistry(ctx context.Context, cfg config.Discovery, dstore datastore.Datastore, disco discovery.Discoverer) (*Registry, error) {
 	// Create policy from config
 	discoPolicy, err := policy.New(cfg.Policy)
@@ -676,26 +674,6 @@ func (r *Registry) pollProviders(pollInterval, pollRetryAfter, pollStopAfter tim
 			}
 		}
 	}
-}
-
-func equalAddrs(addrs, others []multiaddr.Multiaddr) bool {
-	if len(addrs) != len(others) {
-		return false
-	}
-
-	for i := range addrs {
-		var j int
-		for j = range others {
-			if addrs[i].Equal(others[j]) {
-				break
-			}
-		}
-		if j == len(others) {
-			return false
-		}
-	}
-
-	return true
 }
 
 // stringsToMultiaddrs converts a slice of string into a slice of Multiaddr

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -309,6 +309,8 @@ func (r *Registry) BlockPeer(peerID peer.ID) bool {
 
 // RegisterOrUpdate attempts to register an unregistered provider, or updates
 // the addresses and latest advertisement of an already registered provider.
+// If publisher has a valid ID, then the data in publisher replaces the
+// provider's previous publisher information.
 func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, addrs []string, adID cid.Cid, publisher peer.AddrInfo) error {
 	var fullRegister bool
 	// Check that the provider has been discovered and validated

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -246,7 +246,7 @@ func TestDatastore(t *testing.T) {
 			Addrs: []multiaddr.Multiaddr{maddr},
 		},
 		Publisher:     pubID,
-		PublisherAddr: pubAddr.String(),
+		PublisherAddr: pubAddr,
 	}
 
 	// Create datastore
@@ -315,10 +315,10 @@ func TestDatastore(t *testing.T) {
 			if provInfo.Publisher != info2.Publisher {
 				t.Fatal("info2 has wrong publisher ID")
 			}
-			if provInfo.PublisherAddr == "" {
+			if provInfo.PublisherAddr == nil {
 				t.Fatal("info2 missing publisher address")
 			}
-			if provInfo.PublisherAddr != info2.PublisherAddr {
+			if !provInfo.PublisherAddr.Equal(info2.PublisherAddr) {
 				t.Fatalf("info2 has wrong publisher ID %q, expected %q", provInfo.PublisherAddr, info2.PublisherAddr)
 			}
 		default:

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -90,7 +90,8 @@ func (h *FinderHandler) ListProviders() ([]byte, error) {
 
 	responses := make([]model.ProviderInfo, len(infos))
 	for i := range infos {
-		responses[i] = model.MakeProviderInfo(infos[i].AddrInfo, infos[i].LastAdvertisement, infos[i].LastAdvertisementTime)
+		responses[i] = model.MakeProviderInfo(infos[i].AddrInfo, infos[i].LastAdvertisement,
+			infos[i].LastAdvertisementTime, infos[i].Publisher)
 	}
 
 	return json.Marshal(responses)
@@ -102,7 +103,7 @@ func (h *FinderHandler) GetProvider(providerID peer.ID) ([]byte, error) {
 		return nil, nil
 	}
 
-	rsp := model.MakeProviderInfo(info.AddrInfo, info.LastAdvertisement, info.LastAdvertisementTime)
+	rsp := model.MakeProviderInfo(info.AddrInfo, info.LastAdvertisement, info.LastAdvertisementTime, info.Publisher)
 
 	return json.Marshal(&rsp)
 }

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -91,7 +91,7 @@ func (h *FinderHandler) ListProviders() ([]byte, error) {
 	responses := make([]model.ProviderInfo, len(infos))
 	for i := range infos {
 		responses[i] = model.MakeProviderInfo(infos[i].AddrInfo, infos[i].LastAdvertisement,
-			infos[i].LastAdvertisementTime, infos[i].Publisher)
+			infos[i].LastAdvertisementTime, infos[i].Publisher, infos[i].PublisherAddr)
 	}
 
 	return json.Marshal(responses)
@@ -103,7 +103,7 @@ func (h *FinderHandler) GetProvider(providerID peer.ID) ([]byte, error) {
 		return nil, nil
 	}
 
-	rsp := model.MakeProviderInfo(info.AddrInfo, info.LastAdvertisement, info.LastAdvertisementTime, info.Publisher)
+	rsp := model.MakeProviderInfo(info.AddrInfo, info.LastAdvertisement, info.LastAdvertisementTime, info.Publisher, info.PublisherAddr)
 
 	return json.Marshal(&rsp)
 }

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -92,7 +92,7 @@ func (h *IngestHandler) IndexContent(ctx context.Context, data []byte) error {
 	}
 
 	// Register provider if not registered, or update addreses if already registered
-	err = h.registry.RegisterOrUpdate(ctx, ingReq.ProviderID, ingReq.Addrs, cid.Undef, peer.ID(""))
+	err = h.registry.RegisterOrUpdate(ctx, ingReq.ProviderID, ingReq.Addrs, cid.Undef, peer.AddrInfo{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Context
The publisher addresses may be different than the provider addresses, and will not remain in the peerstore across restarts.  This PR stores the last publisher ID and addresses as part of the provider information.  When triggering an auto-sync, the publisher address is now used.

## Proposed Changes
- ProviderInfo has additional string field that is persisted
- Publisher address is used by autoSycn
- Publisher info returned in response to `/providers` query

## Tests
Validate that publisher address is saved and correct publisher address is loaded.

## Revert Strategy
Change is safe to revert.
