### PR TITLE
Add comments and tests for ad signature

### DIFF
--- a/api/v0/ingest/schema/envelope_test.go
+++ b/api/v0/ingest/schema/envelope_test.go
@@ -53,6 +53,13 @@ func TestAdvertisement_SignAndVerify(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, peerID, signerID)
 
+	// Show that signature can be valid even though advertisement not signed by
+	// provider ID.  This is why it is necessary to check that the signer ID is
+	// the expected signed after verifying the signature is valid.
+	provID, err := peer.Decode(adv.Provider)
+	require.NoError(t, err)
+	require.NotEqual(t, signerID, provID)
+
 	// Verification fails if something in the advertisement changes
 	adv.Provider = ""
 	_, err = adv.VerifySignature()


### PR DESCRIPTION
Added comments to document that the advertisement does not have to be signed by the provider, and a test to show this.

This addresses #257

## Context
Demonstrates that it is still necessary to check that the signer of an advertisement is allowed to sign the advertisement.

## Proposed Changes
- Added comments
- Added test to show valid signature on advertisement, when not signed by provider.

## Tests
- Show valid signature on advertisement, when not signed by provider

## Revert Strategy
Change is safe to revert.
