### PR TITLE
Fix pprof handlers

### DIFF
--- a/internal/metrics/pprof/pprof.go
+++ b/internal/metrics/pprof/pprof.go
@@ -1,6 +1,7 @@
-// Package pprof is separated out from metrics to isolate the 'init' functionality of pprof, so that it is
-// included when used by binaries, but not if other packages get used or integrated into clients that
-// don't expect the pprof side effect to have taken effect.
+// Package pprof is separated out from metrics to isolate the 'init'
+// functionality of pprof, so thatit is included when used by binaries, but not
+// if other packages get used or integrated into clients that don't expect the
+// pprof side effect to have taken effect.
 package pprof
 
 import (
@@ -10,16 +11,17 @@ import (
 	pprof "net/http/pprof" // adds default pprof endpoint at /debug/pprof
 )
 
-// WithProfile provides an http mux setup to serve pprof endpoints. it should be mounted at /debug/pprof
+// WithProfile provides an http mux setup to serve pprof endpoints. it should
+// be mounted at /debug/pprof.
 func WithProfile() http.Handler {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/", pprof.Index)
-	mux.HandleFunc("/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/profile", pprof.Profile)
-	mux.HandleFunc("/symbol", pprof.Symbol)
-	mux.HandleFunc("/trace", pprof.Trace)
-	mux.HandleFunc("/gc", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.HandleFunc("/debug/pprof/gc", func(w http.ResponseWriter, req *http.Request) {
 		runtime.GC()
 	})
 

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -71,7 +71,7 @@ func New(listen string, indexer indexer.Interface, ingester *ingest.Ingester, re
 
 	// Metrics routes
 	r.Handle("/metrics", metrics.Start(coremetrics.DefaultViews))
-	r.Handle("/debug/pprof", pprof.WithProfile())
+	r.PathPrefix("/debug/pprof").Handler(pprof.WithProfile())
 
 	//Config routes
 	registerSetLogLevelHandler(r)


### PR DESCRIPTION
## Context
The /debug/pprof endpoint was serving an index html, but the links were incorrect.  The handlers were also not available at the correct links.  This fixed these problems, and all pprof functionality, including profiling and tracing, is available through the admin interface.

## Proposed Changes
Correct how `/debug/pprof` endpoint is registered with the admin server.

## Tests
Manual testing with all endpoints

## Revert Strategy
Change is safe to revert.
