### PR TITLE
Set up cluster-autoscaler in `dev`

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/autoscaler.tf
+++ b/deploy/infrastructure/dev/us-east-2/autoscaler.tf
@@ -1,0 +1,41 @@
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "ec2:DescribeLaunchTemplateVersions"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  name   = "${local.environment_name}_cluster_autoscaler"
+  policy = data.aws_iam_policy_document.cluster_autoscaler.json
+  tags   = local.tags
+}
+
+module "cluster_autoscaler_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "${local.environment_name}_cluster_autoscaler"
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    aws_iam_policy.cluster_autoscaler.arn,
+  ]
+
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler"]
+
+  tags = local.tags
+}

--- a/deploy/infrastructure/dev/us-east-2/outputs.tf
+++ b/deploy/infrastructure/dev/us-east-2/outputs.tf
@@ -14,6 +14,10 @@ output "cert_manager_role_arn" {
   value = module.cert_manager_role.iam_role_arn
 }
 
+output "cluster_autoscaler_role_arn" {
+  value = module.cluster_autoscaler_role.iam_role_arn
+}
+
 output "dev_cid_contact_nameservers" {
   value = aws_route53_zone.dev_external.name_servers
 }

--- a/deploy/manifests/base/cluster-autoscaler/kustomization.yaml
+++ b/deploy/manifests/base/cluster-autoscaler/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://raw.githubusercontent.com/kubernetes/autoscaler/cluster-autoscaler-chart-9.16.2/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/cluster-autoscaler/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/cluster-autoscaler/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/cluster-autoscaler
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/cluster-autoscaler/patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/cluster-autoscaler/patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/dev_cluster_autoscaler"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: cluster-autoscaler
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --expander=least-waste
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/dev


### PR DESCRIPTION
## Context
Use [autoscaler](https://github.com/kubernetes/autoscaler) to automatically manage EC2 instances in `dev` EKS cluster node group depending on the workload that's running.

**Note: to avoid destroying resources already applied in #301, that PR is merged into this PR.**

## Proposed Changes
* Add base layer for `cluster-autoscaler`
* Configure roles necessary for the autoscaler to do its job.
* Define overlay in dev cluster for autoscaler, assign the role to its service account and make configuration changes specific to dev for the auto-scaler deployment object

## Tests
N/A

## Revert Strategy
`git revert` then `terraform apply`
