### PR TITLE
Add cache control header to http Finder

### DIFF
--- a/server/finder/http/options.go
+++ b/server/finder/http/options.go
@@ -8,6 +8,7 @@ import (
 const (
 	apiWriteTimeout = 30 * time.Second
 	apiReadTimeout  = 30 * time.Second
+	cacheMaxAge     = 30 * time.Minute
 	maxConns        = 8_000
 )
 
@@ -15,6 +16,7 @@ const (
 type serverConfig struct {
 	apiWriteTimeout time.Duration
 	apiReadTimeout  time.Duration
+	cacheMaxAge     time.Duration
 	maxConns        int
 }
 
@@ -26,6 +28,7 @@ type ServerOption func(*serverConfig) error
 var serverDefaults = func(o *serverConfig) error {
 	o.apiWriteTimeout = apiWriteTimeout
 	o.apiReadTimeout = apiReadTimeout
+	o.cacheMaxAge = cacheMaxAge
 	o.maxConns = maxConns
 	return nil
 }


### PR DESCRIPTION
## Context
We aren't caching 404s with CloudFront yet. I think it's okay to cache 404s since if we don't have it now we also likely still won't have it if another caller asks us immediately afterwards.
<!-- What is a brief description of the problem you're solving? Imagine looking back at this PR in a year, what would you want to see? -->

## Proposed Changes
This adds the [cache control header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) to the finder HTTP endpoint. This should allow Cloudfront to cache our 404s to the same CID. See [How CloudFront processes and caches HTTP 4xx and 5xx status codes from your origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html)

Note that this sets the default cache age to be 30 minutes. I think this okay since we don't have an expectation of data being available immediately after ingest. We could of course tweak this later if we notice this becoming a pain point.
<!-- Succintly describe your changes. This should be high level, don't worry about the specifics. -->

## Tests
<!-- What tests did you add to assert the expected behavior? If no tests, why? -->
```
❯ curl 'http://127.0.0.1:3000/cid/bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy' -sI | grep Cache-Control
Cache-Control: max-age=1800
```

## Revert Strategy
<!-- Is this change safe to revert? -->

<!-- If yes, you can simply say:-->
Change is safe to revert.

<!-- If no, outline the steps required to revert this change. -->

