### PR TITLE
Cache 404s in cloudfront

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/dev/us-east-2/cloudfront.tf
@@ -24,6 +24,11 @@ resource "aws_cloudfront_distribution" "cdn" {
     }
   }
 
+  custom_error_response {
+    error_code            = 404
+    error_caching_min_ttl = 300
+  }
+
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD"]


### PR DESCRIPTION
## Proposed Changes
Cache 404s for 5 minutes in cloudfront
<!-- Succintly describe your changes. This should be high level, don't worry about the specifics. -->

## Tests
Tested this in my own cloudfront setup.
<!-- What tests did you add to assert the expected behavior? If no tests, why? -->

## Revert Strategy
`git revert` and `terraform apply`
