### PR TITLE
Push additional docker images with git tag as docker tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,9 @@ jobs:
             DOCKER_TAG=$CIRCLE_SHA1
             echo "export DOCKER_REPO=$DOCKER_REPO" >> $BASH_ENV
             echo "export DOCKER_TAG=$DOCKER_TAG" >> $BASH_ENV
-            docker build -t "${DOCKER_REPO}:${DOCKER_TAG}" .
+            docker build -t "${DOCKER_REPO}:${DOCKER_TAG}" -t "${DOCKER_REPO}:${CIRCLE_TAG}" .
             docker push "${DOCKER_REPO}:${DOCKER_TAG}"
+            docker push "${DOCKER_REPO}:${CIRCLE_TAG}"
 
   deploy-lotusinfra:
     docker:
@@ -72,6 +73,9 @@ workflows:
           context:
             - filecoin-dockerhub-publish
           filters:
+            # Do not run on branch builds
+            branches:
+              ignore: /.*/
             tags:
               only: /^v[0-9]+(\.[0-9]+)*$/
       - deploy-lotusinfra:


### PR DESCRIPTION


## Context
In order to have semantically versioned docker containers, tag images
with git tag as well as commit ID and push to docker hub as normal.

Relates to: #318

## Proposed Changes
Tag docker images with `git tag` and push in addition to existing commit-id tagged images.

## Tests
N/A

## Revert Strategy
`git revert`