### PR TITLE
Fix out of bounds panic in registery

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -391,7 +391,12 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 	}
 
 	if info.Publisher.Validate() == nil && info.PublisherAddr == nil && info.Publisher == info.AddrInfo.ID {
-		info.PublisherAddr = info.AddrInfo.Addrs[0]
+		if len(info.AddrInfo.Addrs) == 0 {
+			log.Warnw("Register provider with no provider or publisher addresses",
+				"provider", info.AddrInfo.ID, "publisher", info.Publisher)
+		} else {
+			info.PublisherAddr = info.AddrInfo.Addrs[0]
+		}
 	}
 
 	if len(addrs) != 0 {


### PR DESCRIPTION
When registering or updating the registry with provider information that does not have provider addresses or publisher addresses, an out-of-bounds panic could happen because it was assumed that the provider info would at least have provider addresses.

This is not assumed now.  If the situation is detected it is logged.
