### PR TITLE
Set up K8S monitoring for `dev` cluster

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/monitoring.tf
+++ b/deploy/infrastructure/dev/us-east-2/monitoring.tf
@@ -1,0 +1,44 @@
+resource "aws_prometheus_workspace" "monitoring" {
+  alias = local.environment_name
+  tags  = local.tags
+}
+# Placeholder for setting up remote_write and hook up to PL graphana
+data "aws_iam_policy_document" "monitoring" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "aps:RemoteWrite",
+      "aps:QueryMetrics",
+      "aps:GetSeries",
+      "aps:GetLabels",
+      "aps:GetMetricMetadata"
+    ]
+
+    resources = [aws_prometheus_workspace.monitoring.arn]
+  }
+}
+
+resource "aws_iam_policy" "monitoring" {
+  name   = "${local.environment_name}_monitoring"
+  policy = data.aws_iam_policy_document.monitoring.json
+  tags   = local.tags
+}
+
+module "monitoring_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "${local.environment_name}_monitoring"
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    aws_iam_policy.monitoring.arn,
+  ]
+
+  oidc_fully_qualified_subjects = ["system:serviceaccount:grafana-agent:grafana-agent"]
+
+  tags = local.tags
+}

--- a/deploy/infrastructure/dev/us-east-2/outputs.tf
+++ b/deploy/infrastructure/dev/us-east-2/outputs.tf
@@ -18,6 +18,10 @@ output "cluster_autoscaler_role_arn" {
   value = module.cluster_autoscaler_role.iam_role_arn
 }
 
+output "monitoring_role_arn" {
+  value = module.monitoring_role.iam_role_arn
+}
+
 output "dev_cid_contact_nameservers" {
   value = aws_route53_zone.dev_external.name_servers
 }

--- a/deploy/manifests/base/monitoring/kustomization.yaml
+++ b/deploy/manifests/base/monitoring/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Note: using v0.9.0 compatible with Kubernetes 1.21.
+# See: https://github.com/prometheus-operator/kube-prometheus#kubernetes-compatibility-matrix
+resources:
+  - https://github.com/prometheus-operator/kube-prometheus.git?ref=v0.9.0

--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - cert-manager
   - storetheindex
   - cluster-autoscaler
+  - monitoring

--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/monitoring
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - pods
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: storetheindex
 resources:
   - ../../../../base/storetheindex
   - ingress.yaml
+  - pod-monitor.yaml
 
 patchesStrategicMerge:
   - patch-indexer.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: indexer
+  labels:
+    app: indexer
+spec:
+  selector:
+    matchLabels:
+      app: indexer
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: admin


### PR DESCRIPTION
## Context
Set up stack to monitor the K8S cluster, worker nodes and extra K8S metrics. Add pod monitor for indexer instance.

## Proposed Changes
Install [`kube-prometheus`](https://github.com/prometheus-operator/kube-prometheus) stack which gives us:
* prometheus operator 
* grafana
* node exporter
* adapter for k8s metrics
* kube-state-metrics

Set up monitoring for pods belonging to the `indexer` running in dev cluster.

This PR also creates an AWS managed prometheus along with necessary roles to interact with it. But the `remote_write` is not hooked up because, the version of operator installed does not support `SigV4` authentication. K8S cluster needs to be upgraded for us to install a newer version, and that will be done in future PRs. For now, this PR installs a grafana instance accessible locally via port forwarding that lets us make progress while we figure out how to hook up things to PL grafana.

Unrelated to context: while at it, give Kyle access to interact with encrypted secrets like the rest of the team.

## Tests
Deployed manually for testing.

## Revert Strategy
`git revert` then `terraform apply`