### PR TITLE
Fix `MalformedYAMLError` when kustomization uses HTTPS to clone repo

### DIFF
--- a/deploy/manifests/base/monitoring/kustomization.yaml
+++ b/deploy/manifests/base/monitoring/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Note: using v0.9.0 compatible with Kubernetes 1.21.
-# See: https://github.com/prometheus-operator/kube-prometheus#kubernetes-compatibility-matrix
 resources:
-  - https://github.com/prometheus-operator/kube-prometheus.git?ref=v0.9.0
+  - git@github.com:prometheus-operator/kube-prometheus.git?ref=v0.9.0


### PR DESCRIPTION


## Context
See: https://github.com/prometheus-operator/kube-prometheus/issues/1708

## Proposed Changes
Changing to SSH seems to fix the problem; I am not sure why. Captured:
- https://github.com/prometheus-operator/kube-prometheus/issues/1708

Many thanks to @marcopolo for pointing this out.

## Tests
local build with the same version of `kusotmize` as flux cd works after the change to SSH.

## Revert Strategy
`git revert`
