### PR TITLE
Specify remote build for `monitoring` in HTTP but different format

### DIFF
--- a/deploy/manifests/base/monitoring/kustomization.yaml
+++ b/deploy/manifests/base/monitoring/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - git@github.com:prometheus-operator/kube-prometheus.git?ref=v0.9.0
+  - github.com/prometheus-operator/kube-prometheus?ref=v0.9.0


### PR DESCRIPTION
## Context
Using SSH for remote build in kustomize requires SSH key set-up which `kustomize-controller` is not shipped with, expectedly.

Try a different format to specify remote build in kustomization to work around a rendering issue in kustomization and avoid using SSH since it requires extra setup in flux.

## Proposed Changes
remote build URL reformat but using HTTPS

## Tests
Local build with the same version of `kustomize` used by `kustomize-controller` works.

## Revert Strategy
`git revert`