### PR TITLE
Add `io2` storage class to dev cluster

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/io2-storage-class.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/io2-storage-class.yaml
@@ -1,0 +1,25 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: io2
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: io2
+  # `iopsPerGB` is I/O operations per second per GiB, which is multiplied by the size of the 
+  # requested volume. The maximum supported also depends on the instance type i.e. K8S worker node 
+  # type.
+  # 
+  # To avoid hitting the upper IOPS limit, here we configure a low value, 10, and let the CSI increase it
+  # automatically to the minimum required. This means volumes of size 5TiB, currently provisioned 
+  # for storetheindex will demand 50,000 IOPS.
+  #
+  # For specific use-cases where IOPS is carefully calculated based on the PVC sizes, consider 
+  # defining explicit storage class.
+  # 
+  # See: 
+  #  - https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters
+  #  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#EBSVolumeTypes_piops
+  iopsPerGB: "10"
+  allowAutoIOPSPerGBIncrease: "true"

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: kube-system
 
 resources:
   - aws-auth.yaml
+  - io2-storage-class.yaml


### PR DESCRIPTION
Define `io2` storage class with reasonable defaults in `dev` cluster

## Context
`io2` storage class offers better performance in terms of storetheindex requirements.

## Proposed Changes
Define `io2` storage class with reasonable defaults in `dev` cluster

## Tests
N/A

## Revert Strategy
`git revert`