### PR TITLE
Define production infrastructure in `us-east-2`

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/.terraform.lock.hcl
+++ b/deploy/infrastructure/prod/us-east-2/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.8.0"
+  constraints = ">= 2.23.0, >= 2.49.0, >= 2.53.0, >= 3.63.0, >= 3.72.0"
+  hashes = [
+    "h1:W2cPGKmqkPbTc91lu42QeC3RFBqB5TnRnS3IxNME2FM=",
+    "zh:16cbdbc03ad13358d12433e645e2ab5a615e3a3662a74e3c317267c9377713d8",
+    "zh:1d813c5e6c21fe370652495e29f783db4e65037f913ff0d53d28515c36fbb70a",
+    "zh:31ad8282e31d0fac62e96fc2321a68ad4b92ab90f560be5f875d1b01a493e491",
+    "zh:5099a9e699784cabb5686d2cb52ca910f9c697e977c654ecedd196e838387623",
+    "zh:5758cbb813091db8573f27bba37c48f63ba95f2104f3bc49f13131e3c305b848",
+    "zh:67ea77fb00bf0a09e712f5259a7acb494ce503a34809b7919996744fd92e3312",
+    "zh:72c87be5d1f7917d4281c14a3335a9ec3cd57bf63d95a440faa7035248083dcd",
+    "zh:79005154b9f5eccc1580e0eb803f0dfee68ba856703ef6489719cb014a3c2b18",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:d27f9a8b5b30883a3e45f77506391524df0c66a76c3bc71f7236c3fc81d0597d",
+    "zh:e2985563dc652cf9b10420bc62f0a710308ef5c31e46b94c8ea10b8f27fa1ef3",
+    "zh:f11bb34ee0dad4bc865db51e7e299a4f030c5e9f6b6080d611797cc99deeb40a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.2.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:siiI0wK6/jUDdA5P8ifTO0yc9YmXHml4hz5K9I9N+MA=",
+    "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
+    "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
+    "zh:9200f02cb917fb99e44b40a68936fd60d338e4d30a718b7e2e48024a795a61b9",
+    "zh:a33cf255dc670c20678063aa84218e2c1b7a67d557f480d8ec0f68bc428ed472",
+    "zh:ba3c1b2cd0879286c1f531862c027ec04783ece81de67c9a3b97076f1ce7f58f",
+    "zh:bd575456394428a1a02191d2e46af0c00e41fd4f28cfe117d57b6aeb5154a0fb",
+    "zh:c68dd1db83d8437c36c92dc3fc11d71ced9def3483dd28c45f8640cfcd59de9a",
+    "zh:cbfe34a90852ed03cc074601527bb580a648127255c08589bc3ef4bf4f2e7e0c",
+    "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
+    "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
+    "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.2.1"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:p0vyCZjZqr6qf+CfUVvPSYghrn0/oMDJS4kp3pV26YY=",
+    "zh:0209adc722f1f2e319018bd2d38a3ef389fa7eaabf40ab3f82e791428712dc64",
+    "zh:2dbf76857b022ec44eaddb386d976a08b4a053bcc8e815fd601505f33b29b92e",
+    "zh:301f98065a3b45b1c6d671955d5f92d246e577be0a98e7f7e0553b11b1cd8b92",
+    "zh:4ee8effc669f9856d137249244b67fdcdc35262ebeab3dad262f42d6ddd39c5c",
+    "zh:66cdbf20523972e1e5e682b8776b78ad3ab296ad04784da8fe945d183766ac22",
+    "zh:71798604d4ff22f3c79ec9a8ab61802e969f57456e26ba30bef7d276b88815f7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9289d10fc5241bfd7a2e5de6ca229840eaa06066a129f483133e0a4517a91600",
+    "zh:a075e6bd64a452242e712c59d890cc0d5972158c9d71edbe1ac32d10ad051670",
+    "zh:deb5665f08b271bebe7d18c76cdcdf514ab49f1a85d96e73435728493ae54579",
+    "zh:e0b0a3c3427ee315582b4d17a6b9d2c09f07f2b86fb09821a7d713b68d4e1200",
+    "zh:f7519d1c7b1f108c0728036832a58dc06531203e878104f158ebb625b3c9438c",
+  ]
+}

--- a/deploy/infrastructure/prod/us-east-2/autoscaler.tf
+++ b/deploy/infrastructure/prod/us-east-2/autoscaler.tf
@@ -1,0 +1,40 @@
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "ec2:DescribeLaunchTemplateVersions"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  name   = "cluster_autoscaler"
+  policy = data.aws_iam_policy_document.cluster_autoscaler.json
+  path   = local.iam_path
+}
+
+module "cluster_autoscaler_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "cluster_autoscaler"
+  role_path    = local.iam_path
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    aws_iam_policy.cluster_autoscaler.arn,
+  ]
+
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler"]
+}

--- a/deploy/infrastructure/prod/us-east-2/backend.tf
+++ b/deploy/infrastructure/prod/us-east-2/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "sti-dev-terraform-state"
+    key    = "sti/prod/us-east-2/terraform.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/deploy/infrastructure/prod/us-east-2/cert_manager.tf
+++ b/deploy/infrastructure/prod/us-east-2/cert_manager.tf
@@ -1,0 +1,46 @@
+data "aws_iam_policy_document" "cert_manager" {
+  statement {
+    effect    = "Allow"
+    actions   = ["route53:GetChange"]
+    resources = ["arn:aws:route53:::change/*"]
+  }
+  statement {
+    effect  = "Allow"
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:ListResourceRecordSets"
+    ]
+    resources = ["arn:aws:route53:::hostedzone/*"]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["route53:ListHostedZonesByName"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "cert_manager" {
+  name   = "${local.environment_name}_cert_manager"
+  policy = data.aws_iam_policy_document.cert_manager.json
+  path   = local.iam_path
+}
+
+module "cert_manager_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "cert_manager"
+  role_path    = local.iam_path
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    aws_iam_policy.cert_manager.arn,
+  ]
+
+  oidc_fully_qualified_subjects = [
+    "system:serviceaccount:cert-manager:cert-manager",
+    "system:serviceaccount:cert-manager:cert-manager-webhook",
+  ]
+}

--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -1,0 +1,97 @@
+locals {
+  cdn_origin_id = "${local.environment_name}_${local.region}_sti_cdn"
+  cdn_subdomain = "cdn"
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  enabled = true
+
+  aliases     = ["${local.cdn_subdomain}.${aws_route53_zone.prod_external.name}"]
+  price_class = "PriceClass_All"
+
+  origin {
+    domain_name = aws_route53_zone.prod_external.name
+    origin_id   = local.cdn_origin_id
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
+    }
+    origin_shield {
+      enabled              = true
+      origin_shield_region = local.region
+    }
+  }
+
+  custom_error_response {
+    error_code            = 404
+    error_caching_min_ttl = 300
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.cdn_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+  viewer_certificate {
+    acm_certificate_arn = module.cdn_cert.acm_certificate_arn
+    ssl_support_method  = "sni-only"
+  }
+}
+
+provider "aws" {
+  alias  = "use1"
+  region = "us-east-1"
+}
+
+module "cdn_cert" {
+  source  = "registry.terraform.io/terraform-aws-modules/acm/aws"
+  version = "3.4.0"
+
+  #  Certificate must be in us-east-1 as dictated by CloudFront
+  providers = {
+    aws = aws.use1
+  }
+
+  domain_name               = aws_route53_zone.prod_external.name
+  zone_id                   = aws_route53_zone.prod_external.zone_id
+  subject_alternative_names = ["*.${aws_route53_zone.prod_external.name}"]
+}
+
+module "records" {
+  source  = "registry.terraform.io/terraform-aws-modules/route53/aws//modules/records"
+  version = "2.6.0"
+
+  zone_id = aws_route53_zone.prod_external.zone_id
+
+  records = [
+    {
+      name  = local.cdn_subdomain
+      type  = "A"
+      alias = {
+        name    = aws_cloudfront_distribution.cdn.domain_name
+        zone_id = aws_cloudfront_distribution.cdn.hosted_zone_id
+      }
+    },
+  ]
+}

--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -1,0 +1,59 @@
+module "eks" {
+  source  = "registry.terraform.io/terraform-aws-modules/eks/aws"
+  version = "18.19.0"
+
+  cluster_name    = local.environment_name
+  cluster_version = "1.22"
+
+  cluster_endpoint_private_access = true
+  cluster_endpoint_public_access  = true
+
+  cluster_addons = {
+    aws-ebs-csi-driver = {}
+  }
+  
+  iam_role_path = local.iam_path
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_group_defaults = {
+    # Enforce explicit naming of nodegrups and roles to avoid generated names
+    use_name_prefix                 = false
+    iam_role_use_name_prefix        = false
+    security_group_use_name_prefix  = false
+    launch_template_use_name_prefix = false
+
+    # Use EKS's own default launch template
+    create_launch_template = false
+    launch_template_name   = ""
+  }
+
+  eks_managed_node_groups = {
+    # General purpose node-group.
+    prod-ue2-m4-xl = {
+      min_size       = 1
+      max_size       = 7
+      desired_size   = 1
+      instance_types = ["m4.xlarge"]
+    }
+
+    # Supports high IOPS via io2 Block Express EBS volume types with specific taint.
+    # See:
+    #  - https://aws.amazon.com/ec2/instance-types/#Memory_Optimized
+    #  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#solid-state-drives
+    prod-ue2-r5b-xl = {
+      min_size       = 1
+      max_size       = 7
+      desired_size   = 1
+      instance_types = ["r5b.xlarge"]
+      taints         = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5b"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+  }
+}

--- a/deploy/infrastructure/prod/us-east-2/external_dns.tf
+++ b/deploy/infrastructure/prod/us-east-2/external_dns.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "external_dns" {
+  statement {
+    sid    = "ChangeAndListRecordsOnDevZone"
+    effect = "Allow"
+    actions = [
+      "route53:ChangeResourceRecordSets",
+    ]
+    resources = ["arn:aws:route53:::hostedzone/*"]
+  }
+  statement {
+    sid    = "ListZonesAndRecords"
+    effect = "Allow"
+    actions = [
+      "route53:ListHostedZones",
+      "route53:ListResourceRecordSets",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "external_dns" {
+  name   = "${local.environment_name}_external_dns"
+  policy = data.aws_iam_policy_document.external_dns.json
+  path   = local.iam_path
+}
+
+module "external_dns_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "external_dns"
+  role_path    = local.iam_path
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    aws_iam_policy.external_dns.arn,
+  ]
+
+  oidc_fully_qualified_subjects = ["system:serviceaccount:external-dns:external-dns"]
+}

--- a/deploy/infrastructure/prod/us-east-2/kms.tf
+++ b/deploy/infrastructure/prod/us-east-2/kms.tf
@@ -1,0 +1,104 @@
+resource "aws_kms_alias" "kms_sti" {
+  target_key_id = aws_kms_key.kms_sti.key_id
+  name          = "alias${local.iam_path}sti"
+}
+
+resource "aws_kms_key" "kms_sti" {
+  description = "Key used to encrypt storetheindex tenant secrets"
+  policy      = data.aws_iam_policy_document.kms_sti.json
+  is_enabled  = true
+}
+
+data "aws_iam_policy_document" "kms_sti" {
+  statement {
+    sid = "Enable IAM User Permissions"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::407967248065:root"]
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow access for Devs via sops"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::407967248065:user/masih",
+        "arn:aws:iam::407967248065:user/marco",
+        "arn:aws:iam::407967248065:user/gammazero",
+        "arn:aws:iam::407967248065:user/will.scott",
+        "arn:aws:iam::407967248065:user/kylehuntsman",
+        "arn:aws:iam::407967248065:user/steveFraser",
+        "arn:aws:iam::407967248065:user/cmharden",
+      ]
+    }
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow Flux to decrypt"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        module.kustomize_controller_role.iam_role_arn
+      ]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "kustomize_controller" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+
+    resources = [aws_kms_key.kms_sti.arn]
+  }
+}
+
+resource "aws_iam_policy" "kustomize_controller" {
+  name   = "kustomize_controller"
+  policy = data.aws_iam_policy_document.kustomize_controller.json
+  path   = local.iam_path
+}
+
+module "kustomize_controller_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "kustomize_controller"
+  role_path    = local.iam_path
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    aws_iam_policy.kustomize_controller.arn,
+  ]
+
+  oidc_fully_qualified_subjects = ["system:serviceaccount:flux-system:kustomize-controller"]
+}

--- a/deploy/infrastructure/prod/us-east-2/locals.tf
+++ b/deploy/infrastructure/prod/us-east-2/locals.tf
@@ -1,0 +1,17 @@
+locals {
+
+  environment_name = "prod"
+  region           = data.aws_region.current.name
+
+  iam_path = "/${local.environment_name}/${local.region}/"
+
+  tags = {
+    "Environment" = local.environment_name
+    "ManagedBy"   = "terraform"
+    Owner         = "storetheindex"
+    Team          = "bedrock"
+    Organization  = "EngRes"
+  }
+}
+
+data "aws_region" "current" {}

--- a/deploy/infrastructure/prod/us-east-2/main.tf
+++ b/deploy/infrastructure/prod/us-east-2/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region              = "us-east-2"
+  allowed_account_ids = ["407967248065"]
+  default_tags {
+    tags = local.tags
+  }
+}

--- a/deploy/infrastructure/prod/us-east-2/outputs.tf
+++ b/deploy/infrastructure/prod/us-east-2/outputs.tf
@@ -1,0 +1,27 @@
+output "kms_sti_flux_arn" {
+  value = aws_kms_alias.kms_sti.arn
+}
+
+output "kustomize_controller_role_arn" {
+  value = module.kustomize_controller_role.iam_role_arn
+}
+
+output "external_dns_role_arn" {
+  value = module.external_dns_role.iam_role_arn
+}
+
+output "cert_manager_role_arn" {
+  value = module.cert_manager_role.iam_role_arn
+}
+
+output "cluster_autoscaler_role_arn" {
+  value = module.cluster_autoscaler_role.iam_role_arn
+}
+
+output "prod_cid_contact_nameservers" {
+  value = aws_route53_zone.prod_external.name_servers
+}
+
+output "prod_cid_contact_zone_id" {
+  value = aws_route53_zone.prod_external.zone_id
+}

--- a/deploy/infrastructure/prod/us-east-2/route53.tf
+++ b/deploy/infrastructure/prod/us-east-2/route53.tf
@@ -1,0 +1,3 @@
+resource "aws_route53_zone" "prod_external" {
+  name = "${local.environment_name}.cid.contact"
+}

--- a/deploy/infrastructure/prod/us-east-2/versions.tf
+++ b/deploy/infrastructure/prod/us-east-2/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.1.7"
+}

--- a/deploy/infrastructure/prod/us-east-2/vpc.tf
+++ b/deploy/infrastructure/prod/us-east-2/vpc.tf
@@ -1,0 +1,27 @@
+module "vpc" {
+  source  = "registry.terraform.io/terraform-aws-modules/vpc/aws"
+  version = "3.13.0"
+
+  name = local.environment_name
+
+  azs = data.aws_availability_zones.available.names
+
+  cidr            = "20.10.0.0/16"
+  private_subnets = ["20.10.1.0/24", "20.10.2.0/24", "20.10.3.0/24"]
+  public_subnets  = ["20.10.11.0/24", "20.10.12.0/24", "20.10.13.0/24"]
+
+  enable_nat_gateway   = true
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = "1"
+  }
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}


### PR DESCRIPTION


## Context
production environment infrastructure set up in storetheindex aws account region `us-east-2` while we wait for the PL managed clusters to be created.

## Proposed Changes
Define terraforms that instantiate production infrastructure pretty much
identical to dev environment with following changes:
- larger instance types in EKS nodegroup
- a dedicated r5b instance type node group to take advantage of high
  IOPS of io2 type EBS volumes supported by this type.

The terraform also removes duplicate tags by setting them all once in
the terraform `aws` provider. It also changes the naming convention for
IAM resources by using `path` that includes both region and environment
name to avoid naming conflicts across multiple environments created in
the same region of the same AWS account.

## Tests
Applied.

## Revert Strategy
`terraform destroy` `git revert`