### PR TITLE
Use storethehash that has index GC

### DIFF
--- a/config/indexer.go
+++ b/config/indexer.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"time"
+)
+
 // Indexer holds configuration for the indexer core.
 type Indexer struct {
 	// Maximum number of CIDs that cache can hold. Setting to 0 disables cache.
@@ -7,8 +11,11 @@ type Indexer struct {
 	// Directory where value store is kept. If this is not an absolute path
 	// then the location is relative to the indexer repo directory.
 	ValueStoreDir string
-	// Type of valuestore to use, such as "sti" or "pogreb".
+	// Type of valuestore to use, such as "sth" or "pogreb".
 	ValueStoreType string
+	// GCInterval configures the garbage collection interval for valuestores
+	// that support it.
+	GCInterval Duration
 }
 
 // NewIndexer returns Indexer with values set to their defaults.
@@ -17,6 +24,7 @@ func NewIndexer() Indexer {
 		CacheSize:      300000,
 		ValueStoreDir:  "valuestore",
 		ValueStoreType: "sth",
+		GCInterval:     Duration(30 * time.Minute),
 	}
 }
 
@@ -32,5 +40,8 @@ func (c *Indexer) populateUnset() {
 	}
 	if c.ValueStoreType == "" {
 		c.ValueStoreType = def.ValueStoreType
+	}
+	if c.GCInterval == 0 {
+		c.GCInterval = def.GCInterval
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.2.9
+	github.com/filecoin-project/go-indexer-core v0.2.10
 	github.com/filecoin-project/go-legs v0.3.11
 	github.com/frankban/quicktest v1.14.2
 	github.com/gogo/protobuf v1.3.2
@@ -16,7 +16,7 @@ require (
 	github.com/ipfs/go-datastore v0.5.1
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-ipfs v0.11.0
-	github.com/ipfs/go-log/v2 v2.5.0
+	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipld/go-ipld-prime v0.16.0
 	github.com/libp2p/go-libp2p v0.18.0-rc5
 	github.com/libp2p/go-libp2p-core v0.14.0
@@ -103,7 +103,7 @@ require (
 	github.com/ipfs/go-unixfs v0.3.1 // indirect
 	github.com/ipfs/go-verifcid v0.0.1 // indirect
 	github.com/ipld/go-codec-dagpb v1.3.1 // indirect
-	github.com/ipld/go-storethehash v0.0.2 // indirect
+	github.com/ipld/go-storethehash v0.1.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/filecoin-project/go-data-transfer v1.15.1/go.mod h1:dXsUoDjR9tKN7aV6R
 github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.2.9 h1:sfnPCl0ualbxZAwcgzjsySIwh6AxqDJIzLkdObLS4gs=
-github.com/filecoin-project/go-indexer-core v0.2.9/go.mod h1:u03I3HB6ZnqCc3cm8Tq+QkTWBbfKOvNxM8K6Ny/IHRw=
+github.com/filecoin-project/go-indexer-core v0.2.10 h1:jvlgQEXqOXmoOpT7SXArij4vcrMU4rU8SXDVVd04XOA=
+github.com/filecoin-project/go-indexer-core v0.2.10/go.mod h1:CFnBiCAuzci1q8XtVEMeiKIvR27+KDQ7A3vJ7nsT1y4=
 github.com/filecoin-project/go-legs v0.3.11 h1:BhedZBaMeGAipc7n8nftslMh0m8+MbhaMDPsyuZRaDw=
 github.com/filecoin-project/go-legs v0.3.11/go.mod h1:YwnS0OrctbuUOxs5uiIhuYZrrhxLTH0p5kT6+6lpMWc=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -581,8 +581,9 @@ github.com/ipfs/go-log/v2 v2.0.5/go.mod h1:eZs4Xt4ZUJQFM3DlanGhy7TkwwawCZcSByscw
 github.com/ipfs/go-log/v2 v2.1.1/go.mod h1:2v2nsGfZsvvAJz13SyFzf9ObaqwHiHxsPLEHntrv9KM=
 github.com/ipfs/go-log/v2 v2.1.3/go.mod h1:/8d0SH3Su5Ooc31QlL1WysJhvyOTDCjcCZ9Axpmri6g=
 github.com/ipfs/go-log/v2 v2.3.0/go.mod h1:QqGoj30OTpnKaG/LKTGTxoP2mmQtjVMEnK72gynbe/g=
-github.com/ipfs/go-log/v2 v2.5.0 h1:+MhAooFd9XZNvR0i9FriKW6HB0ql7HNXUuflWtc0dd4=
 github.com/ipfs/go-log/v2 v2.5.0/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
+github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
+github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
 github.com/ipfs/go-merkledag v0.0.6/go.mod h1:QYPdnlvkOg7GnQRofu9XZimC5ZW5Wi3bKys/4GQQfto=
 github.com/ipfs/go-merkledag v0.2.3/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
 github.com/ipfs/go-merkledag v0.2.4/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
@@ -641,8 +642,8 @@ github.com/ipld/go-ipld-prime v0.16.0 h1:RS5hhjB/mcpeEPJvfyj0qbOj/QL+/j05heZ0qa9
 github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHPT2PjoiiU1qA=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.0.2 h1:PFAlcTG2RoS6Cwbes3J/X/NvuNTj+wgF1x0OED4x6bw=
-github.com/ipld/go-storethehash v0.0.2/go.mod h1:w8cQfWInks8lvvbQTiKbCPusU9v0sqiViBihTHbavpQ=
+github.com/ipld/go-storethehash v0.1.0 h1:HBa59pCuL33fLN8PekX+lq6vq1UlWCFxtfyLiN030ng=
+github.com/ipld/go-storethehash v0.1.0/go.mod h1:d3m79FZzARANjjBwZ1rNgyGUK+1M5m0SLHrarmJzcYo=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -501,7 +501,7 @@ func (ing *Ingester) metricsUpdater() {
 				// Update value store size metric after sync.
 				size, err := ing.indexer.Size()
 				if err != nil {
-					log.Errorf("Error getting indexer value store size: %w", err)
+					log.Errorw("Error getting indexer value store size", "err", err)
 					return
 				}
 				stats.Record(context.Background(), coremetrics.StoreSize.M(size))

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.4.3"
+  "version": "v0.4.4"
 }


### PR DESCRIPTION
## Context
Use a new version of go-indexer-core that includes the latest go-storethehash with index garbage collection.

## Proposed Changes
- Update dependency on go-storethehash
- Make storethehash GC interval configurable

## Tests
Included in go-storethehash

## Revert Strategy
This is not safe to revert since it automatically upgrades the storethehash index format.

To revert, it would be necessary to write a converter that converts multiple index files back into a single index file.  This would be relatively simple as it would mean writing the old header to a file and appending all the index files to that file.  However, this is not available immediately and would need to be written.
