### PR TITLE
Define prod kustomization overlay

### DIFF
--- a/deploy/manifests/README.md
+++ b/deploy/manifests/README.md
@@ -1,0 +1,60 @@
+# Storetheindex K8S manifests
+
+Storetheindex deployment K8S manifests is managed using GitOps. This means all changes to the
+runtime environment are reflected on automatically when the content of this directory changes.
+
+## Secret management
+
+The runtime secrets are managed by the CD pipeline, using [SOPS](https://github.com/mozilla/sops) as
+the encryption/decryption that under the hood uses designated KMS keys.
+
+The key designated to storetheindex is specified in a SOPS configuration file in the folder that
+contains its manifests for each of the runtime environments. For example, the SOPS config file for
+the `dev` environment can be found [here](dev/us-east-2/tenant/storetheindex/.sops.yaml). The
+presence of that file instructs all `sops` commands _executed in that directory_ to use the
+configured key.
+
+Upon deployment, the CD mechanism decrypts the encrypted secrets on the fly and applies the
+unencrypted value to the K8S cluster.
+
+### How to interact with SOPS encrypted secrets
+
+Prerequisites:
+
+* Terminal session authenticated to the AWS account containing the KMS key and the user has the
+  privilege to interact with the key.
+    * You can check the status of your current AWS session via aws CLI
+      command `aws sts get-caller-identity`
+* `sops` CLI installed.
+
+To encrypt a file containing sensitive information, e.g. `my-secret.txt`:
+
+* `cd` into the `storetheindex` directory corresponding to the environment you want to make that
+  secret available in.
+    * For example, `dev/us-east-2/tenant/storetheindex` for the `dev` environment
+* Execute `sops -e my-secret.txt > my-secret.encrypted`
+    * This command would encrypt the content of `my-secret.txt` and stores the encrypted value to a
+      file named `my-secret.encrypted`.
+    * Once encrypted, you can now safely delete the unencrypted version from disk and check the
+      encrypted file into version control system.
+    * Alternatively, you can execute the `sops` command using `-i` flag which performs an in-place
+      encryption and replaces the content of the given unencrypted file with its encrypted
+      equivalent.
+
+You can now include the encrypted value in your `kustomization.yaml` using `secretGenerator` to
+create K8S `Secret` object. An example of this technique can be found in `storetheindex`
+Kustomization in both `dev` and `prod` environments.
+
+It is also possible to define K8S `Secret` object directly, and encrypt its content (i.e. at
+key `data` or `stringData`) using SOPS.
+
+To examine/edit the value of an encrypted file checked into version control system:
+
+* `cd` into the directory that contains the encrypted file.
+* Execute `sops <encrypted-file>`
+    * This command would open the unencrypted content of the file in your default `EDITOR`.
+* Edit the content as you see fit and once finished, save and close you editor.
+* Upon closing the editor, `sops` will automatically re-encrypt the content to reflect your changes.
+
+Alternatively, use `-d` flag to output the content of a decrypted file. For more information,
+execute `sops -h`. 

--- a/deploy/manifests/prod/us-east-2/cluster/cert-manager/issuer.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/cert-manager/issuer.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: bedrock@protocol.ai
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+      - dns01:
+          route53:
+            region: us-east-2
+        selector:
+          dnsZones:
+            - prod.cid.contact

--- a/deploy/manifests/prod/us-east-2/cluster/cert-manager/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/cert-manager/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/cert-manager
+  - issuer.yaml
+
+patchesStrategicMerge:
+  - sa-patch.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/cert-manager/sa-patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/cert-manager/sa-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/prod/us-east-2/cert_manager"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-webhook
+  namespace: cert-manager
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/prod/us-east-2/cert_manager"

--- a/deploy/manifests/prod/us-east-2/cluster/cluster-autoscaler/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/cluster-autoscaler/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/cluster-autoscaler
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/cluster-autoscaler/patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/cluster-autoscaler/patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/prod/us-east-2/cluster_autoscaler"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: cluster-autoscaler
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --expander=least-waste
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/prod

--- a/deploy/manifests/prod/us-east-2/cluster/external-dns/deploy-patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/external-dns/deploy-patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: external-dns
+spec:
+  selector:
+    matchLabels:
+      app: external-dns
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+        - name: external-dns
+          args:
+            - --source=service
+            - --source=ingress
+            - --domain-filter=prod.cid.contact
+            - --provider=aws
+            - --policy=upsert-only
+            - --aws-zone-type=public
+            - --registry=txt
+            - --txt-owner-id=Z0812180J6HXR2V3GIFI # prod.cid.contact hosted zone ID; see terraform output `prod_cid_contact_zone_id`

--- a/deploy/manifests/prod/us-east-2/cluster/external-dns/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/external-dns/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: external-dns
+
+resources:
+  - ../../../../base/external-dns
+  - namespace.yaml
+
+patchesStrategicMerge:
+  - deploy-patch.yaml
+  - sa-patch.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/external-dns/namespace.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/external-dns/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: external-dns

--- a/deploy/manifests/prod/us-east-2/cluster/external-dns/sa-patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/external-dns/sa-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/prod/us-east-2/external_dns"

--- a/deploy/manifests/prod/us-east-2/cluster/flux-system/cluster-cd.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/flux-system/cluster-cd.yaml
@@ -1,0 +1,22 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: storetheindex
+spec:
+  interval: 5m
+  url: https://github.com/filecoin-project/storetheindex.git
+  ref:
+    branch: main
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: cluster
+spec:
+  serviceAccountName: kustomize-controller
+  interval: 5m
+  path: "./deploy/manifests/prod/us-east-2/cluster"
+  sourceRef:
+    kind: GitRepository
+    name: storetheindex
+  prune: true

--- a/deploy/manifests/prod/us-east-2/cluster/flux-system/kust-ctrlr-sa-patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/flux-system/kust-ctrlr-sa-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/prod/us-east-2/kustomize_controller"

--- a/deploy/manifests/prod/us-east-2/cluster/flux-system/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/flux-system/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: flux-system
+
+resources:
+  - ../../../../base/flux-system
+  - cluster-cd.yaml
+
+patchesStrategicMerge:
+  - kust-ctrlr-sa-patch.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+data:
+  mapRoles: |
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2-r5b-xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2-m4-xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+  mapUsers: |
+    - userarn: arn:aws:iam::407967248065:user/masih
+      username: masih
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::407967248065:user/marco
+      username: marco
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::407967248065:user/gammazero
+      username: gammazero
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::407967248065:user/will.scott
+      username: will.scott
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::407967248065:user/kylehuntsman
+      username: kylehuntsman
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::407967248065:user/steveFraser
+      username: steveFraser
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::407967248065:user/cmharden
+      username: cmharden
+      groups:
+        - system:masters

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/io2-storage-class.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/io2-storage-class.yaml
@@ -1,0 +1,25 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: io2
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: io2
+  # `iopsPerGB` is I/O operations per second per GiB, which is multiplied by the size of the 
+  # requested volume. The maximum supported also depends on the instance type i.e. K8S worker node 
+  # type.
+  # 
+  # To avoid hitting the upper IOPS limit, here we configure a low value, 10, and let the CSI increase it
+  # automatically to the minimum required. This means volumes of size 5TiB, currently provisioned 
+  # for storetheindex will demand 50,000 IOPS.
+  #
+  # For specific use-cases where IOPS is carefully calculated based on the PVC sizes, consider 
+  # defining explicit storage class.
+  # 
+  # See: 
+  #  - https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters
+  #  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#EBSVolumeTypes_piops
+  iopsPerGB: "10"
+  allowAutoIOPSPerGBIncrease: "true"

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - aws-auth.yaml
+  - io2-storage-class.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/ingress-nginx
+  - kube-system
+  - flux-system
+  - external-dns
+  - cert-manager
+  - storetheindex
+  - cluster-autoscaler
+  - monitoring

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/monitoring
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - pods
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch

--- a/deploy/manifests/prod/us-east-2/cluster/storetheindex/flux-cd.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/storetheindex/flux-cd.yaml
@@ -1,0 +1,37 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: storetheindex
+spec:
+  interval: 5m
+  url: https://github.com/filecoin-project/storetheindex.git
+  ref:
+    branch: main
+
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: storetheindex
+spec:
+  serviceAccountName: flux
+  decryption:
+    provider: sops
+  interval: 5m
+  path: "./deploy/manifests/prod/us-east-2/tenant/storetheindex"
+  sourceRef:
+    kind: GitRepository
+    name: storetheindex
+  prune: true
+  images:
+    - name: storetheindex
+      newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: storetheindex
+spec:
+  interval: 10m
+  image: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex

--- a/deploy/manifests/prod/us-east-2/cluster/storetheindex/flux-rbac.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/storetheindex/flux-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flux
+rules:
+  - apiGroups: [ '*' ]
+    resources: [ '*' ]
+    verbs: [ '*' ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flux
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: storetheindex

--- a/deploy/manifests/prod/us-east-2/cluster/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/storetheindex/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+commonLabels:
+  toolkit.fluxcd.io/tenant: storetheindex
+
+resources:
+  - namespace.yaml
+  - flux-cd.yaml
+  - flux-rbac.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/storetheindex/namespace.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/storetheindex/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: storetheindex

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/.sops.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/.sops.yaml
@@ -1,0 +1,4 @@
+creation_rules:
+  - path_regex: .*
+    encrypted_regex: '^(data|stringData)$'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/prod/us-east-2/sti'

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-0-identity.encrypted
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-0-identity.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:F+PbmodW5HPQufuPbnEi3f+CMHDtd2WBgegjKK19g3maH4gh/gjvA4kdmY+Q0o6mgLomUFXKsljLDFjf6btqik6B4VU=,iv:fwaWp7pDw5DtqUUVI4dLedJKk8qhlGs6dzAzNu9CiBE=,tag:ez8VyqaqU7asqDBJ5+NLnA==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/prod/us-east-2/sti",
+				"created_at": "2022-04-08T13:58:40Z",
+				"enc": "AQICAHjmLCaDZ4fRYyty7669VvFjJmy9C7/Y4dwd6seUJHRobwESImggCcGK7u50WYmdSbCnAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMjYpcZD7kdHNXuK9rAgEQgDtV7FuOvcsWmi+/uDQh+2xSp74Z4PRa6bI+XivH+3FAbwU8kHvZlspfbqzCUmZXjOoDSTuJcX59GBqy2Q==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-04-08T13:58:41Z",
+		"mac": "ENC[AES256_GCM,data:LvsK2JjW1l04AgIC9O01/f+hRPbnT9JkJZmUK6pcdUl5gvsXJZOhsBdNlHV1bQB05fcqLnR8kvgLsMUSYXUz46qh/81k5nGYFzFyADqGiwrWwJcQtv0GsjeUQUe0bJLK9iVF5kf+hlxp9fuiWeX+h4eI7TOKRaX7J9UNW5HQOgA=,iv:4je01vaQdJ8oIS1GjGNL6kHF4U0z/6JllxOEzry7lSM=,tag:RFyMsCVgodNoYaKmBHICsA==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-1-identity.encrypted
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-1-identity.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:gMTrwBeT8M1FpliLFp3NBd7paAS+8JoemI/G+TxOMW8x2ERZi8wUALYk6p3Qv4yRRt6iuB93+evRrvuMZhfg+wGNUdw=,iv:49tzBmjrf8Nta6pgdceVRgv07aKIPqhKrFKKiKn7PVM=,tag:uL/CSXdJ0HsWRPbj4mjmFQ==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/prod/us-east-2/sti",
+				"created_at": "2022-04-08T13:58:45Z",
+				"enc": "AQICAHjmLCaDZ4fRYyty7669VvFjJmy9C7/Y4dwd6seUJHRobwE3mZzS3HE9DgQ7MbFxbjDKAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMABODf14IQkJ9hsQLAgEQgDs/GWbkmPAesHbfPcUeQ8Eq95S69C4wl8IPFdzCXyqM5uHDcpw8cKBnxxJOBKsYCS3bh2V2/DTBIrIN/w==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-04-08T13:58:45Z",
+		"mac": "ENC[AES256_GCM,data:/IE+qlyu27cLpd+e00ZYDu1dDT35R98A+8xXYOzUd8tdPiP1rUq5/RykDVhYtl+MsPIQoYs3xv3x/LdJ+ggeTAB+8LaZAYCM2YYKJ7IfwiBwpesh50XAnJbT+QgdYDC1Bayj+krvHMZX4z/qFIeWY9mCZjz7hGTj8jAaZy1wV88=,iv:wxJLXOlClaVZep0zhvX3kxo9aLpDMeYVWKJGC1rFudI=,tag:5FbXCbZsW4GFVj7KCP870w==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+  namespace: storetheindex
+spec:
+  tls:
+    - hosts:
+        - prod.cid.contact
+      secretName: indexer-ingress-tls
+  rules:
+    - host: prod.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../base/storetheindex
+  - ingress.yaml
+  - pod-monitor.yaml
+
+patchesStrategicMerge:
+  - patch-indexer.yaml
+
+replicas:
+  - name: indexer
+    count: 2
+
+secretGenerator:
+  - name: indexer-identity
+    files:
+      - indexer-0.key=indexer-0-identity.encrypted
+      - indexer-1.key=indexer-1-identity.encrypted

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      containers:
+        - name: indexer
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: STORETHEINDEX_PRIV_KEY_PATH
+              value: /identity/$(POD_NAME).key
+          volumeMounts:
+            - name: identity
+              mountPath: /identity
+      # Require r5b instance types to run index provider pods.
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b
+          effect: NoSchedule
+      volumes:
+        - name: identity
+          secret:
+            secretName: indexer-identity

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: indexer
+  labels:
+    app: indexer
+spec:
+  selector:
+    matchLabels:
+      app: indexer
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: admin


### PR DESCRIPTION

## Context
K8S manifests to deploy cluster level and sit to self-Managed prod cluster.

## Proposed Changes
Define the prod kustomization overlay, which is pretty much the same as
dev overlay, with the following differences:
 - storetheindex demands specific taints to run on r5b instance type
 - indexer replica count is increased to 2

## Tests
https://prod.cid.contact 
Currently deployed with CD pipelines pointing to this PR for testing.

## Revert Strategy
`git revert`