### PR TITLE
support a list of peers from which we accept advertisements for other providers

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -82,6 +82,9 @@ func daemonCommand(cctx *cli.Context) error {
 		}
 		return fmt.Errorf("cannot load config file: %w", err)
 	}
+	if cfg.CanUpgrade() {
+		log.Warn("Configuration file out-of-date. Upgrade by running: ./storetheindex init --upgrade")
+	}
 
 	if cfg.Datastore.Type != "levelds" {
 		return fmt.Errorf("only levelds datastore type supported, %q not supported", cfg.Datastore.Type)

--- a/command/flags.go
+++ b/command/flags.go
@@ -204,6 +204,12 @@ var initFlags = []cli.Flag{
 		EnvVars:  []string{"STORETHEINDE_PUBSUB_TOPIC"},
 		Required: false,
 	},
+	&cli.BoolFlag{
+		Name:     "upgrade",
+		Usage:    "Upgrade the config file to the current version, saving the old config as config.prev, and ignoring other flags ",
+		Aliases:  []string{"u"},
+		Required: false,
+	},
 }
 
 var providersGetFlags = []cli.Flag{

--- a/command/init.go
+++ b/command/init.go
@@ -23,8 +23,6 @@ func initCommand(cctx *cli.Context) error {
 		return err
 	}
 
-	fmt.Println("Initializing indexer node at", configRoot)
-
 	if err = checkWritable(configRoot); err != nil {
 		return err
 	}
@@ -33,6 +31,26 @@ func initCommand(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	if cctx.Bool("upgrade") {
+		cfg, err := config.Load(configFile)
+		if err != nil {
+			return err
+		}
+		prevVer := cfg.Version
+		upgraded, err := cfg.UpgradeConfig(configFile)
+		if err != nil {
+			return fmt.Errorf("cannot upgrade: %s", err)
+		}
+		if upgraded {
+			fmt.Println("Upgraded", configFile, "from version", prevVer, "to", cfg.Version)
+		} else {
+			fmt.Println("Config at current version, nothing to upgrade")
+		}
+		return nil
+	}
+
+	fmt.Println("Initializing indexer node at", configRoot)
 
 	if fileExists(configFile) {
 		return config.ErrInitialized

--- a/config/config.go
+++ b/config/config.go
@@ -115,6 +115,12 @@ func Load(filePath string) (*Config, error) {
 	return &cfg, nil
 }
 
+// CanUpgrade determines if the config can be converted to the current version.
+func (c *Config) CanUpgrade() bool {
+	return c.Version != version
+}
+
+// UpgradeConfig upgrades (or downgrades) the config file to the current version.
 func (c *Config) UpgradeConfig(filePath string) (bool, error) {
 	if c.Version == version {
 		return false, nil

--- a/config/discovery.go
+++ b/config/discovery.go
@@ -26,6 +26,8 @@ type Discovery struct {
 	// continuing polling for the latest advertisment without getting a
 	// responce.
 	PollStopAfter Duration
+	// PollOverrides configures polling for a specific providers.
+	PollOverrides []Polling
 	// RediscoverWait is the amount of time that must pass before a provider
 	// can be discovered following a previous discovery attempt.  A value of 0
 	// means there is no wait time.
@@ -33,6 +35,16 @@ type Discovery struct {
 	// Timeout is the maximum amount of time that the indexer will spend trying
 	// to discover and verify a new provider.
 	Timeout Duration
+}
+
+// Polling is a set of polling parameters that is applied to a specific
+// provider.  The values override the matching Poll values in the Discovery
+// config.
+type Polling struct {
+	ProviderID string
+	Interval   Duration
+	RetryAfter Duration
+	StopAfter  Duration
 }
 
 // NewDiscovery returns Discovery with values set to their defaults.

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -18,7 +18,6 @@ type Ingest struct {
 	// or a chain of advertisement entries.  The value is an integer string
 	// ending in "s", "m", "h" for seconds. minutes, hours.
 	SyncTimeout Duration
-
 	// How many ingest worker goroutines to spawn. This controls how many
 	// concurrent ingest from different providers we can handle.
 	IngestWorkerCount int

--- a/config/policy.go
+++ b/config/policy.go
@@ -1,45 +1,49 @@
 package config
 
-// Policy configures which peers are allowed and blocked, and which allowed
-// peers require verification or are already trusted.  Currently, this same
-// policy is applied to both publishers and providers.
+// Policy configures which peers are allowed, are rate-limited and which may
+// publish on behalf of others.  Currently, the allow policy is applied to both
+// providers and publishers.  The RateLimit and Publish policies applies to
+// publishers.
 //
 // Publishers and providers are not the same.  Publishers are peers that supply
 // data to the indexer.  Providers are the peers that appear in advertisements
 // and are where clients will retrieve content from.
-//
-// Policy evaluation works like two gates that must be passed in order to be
-// allowed to index content.  The first gate is the "allow" gate that
-// determines whether a publisher is allowed or not.  The second gate is the
-// "trust" gate that determines whether a publisher is trusted or must be
-// verified on-chain to be authorized to index content.
 type Policy struct {
 	// Allow is either false or true, and determines whether a peer is allowed
 	// (true) or is blocked (false), by default.
 	Allow bool
-	// Except is a list of peer IDs that are exceptions to the allow action.
-	// Peers that are allowed by policy or exception must still be verified or
-	// trusted in order to register.
+	// Except is a list of peer IDs that are exceptions to the Allow policy.
+	// If Allow is true, then all peers are allowed except those listed in
+	// Except.  If Allow is false, then no peers are allowed except those
+	// listed in Except.  in other words, Allow=true means that Except is a
+	// deny-list and Allow=false means that Except is an allow-list.
 	Except []string
 
-	// ExemptRateLimits is either false or true, and determines whether an allowed peer
-	// can skip (true) on-chain verification or not (false), by default.
-	ExemptRateLimits bool
-	// ExemptRateLimitsExcept is a list of peer IDs that are exceptions to the trust
-	// action.  If Trust is false then all allowed peers must be verified,
-	// except those listed here.  If Trust is true, then only the peers
-	// listed here require verification.
-	ExemptRateLimitsExcept []string
+	// Publish determines whether or not peers are allowed to publish
+	// advertisements for a provider with adifferen peer ID.
+	Publish bool
+	// PublisherExcept is a list of peer IDs that are exceptions to the Publish
+	// policy.  If Publish is false, then all allowed peers cannot publish
+	// advertisements for providers with a different peer ID, unless listed in
+	// PublishExcept.  If Publish is true, then all allowed peers can publish
+	// advertisements for any provider, unless listed in PublishExcept.
+	PublishExcept []string
 
-	// ExemptSelfPublisher is a list of peer IDs that are allowed to publish on
-	// behalf of other providers.
-	ExemptSelfPublisher []string
+	// RateLimit is either false or true, and determines whether an allowed peer
+	// if subject to rate limiting (true) or not (false), by default.
+	RateLimit bool
+	// RateLimitExcept is a list of peer IDs that are exceptions to the
+	// RateLimit policy.  If RateLimit is false then all allowed peers are not
+	// rate-limited unless they appear in the RateLimitExcept list.  If
+	// RateLimit is true, then only the peers listed in RateLimitExcept are not
+	// rate-limited.
+	RateLimitExcept []string
 }
 
 // NewPolicy returns Policy with values set to their defaults.
 func NewPolicy() Policy {
 	return Policy{
-		Allow:            true,
-		ExemptRateLimits: true,
+		Allow:   true,
+		Publish: true,
 	}
 }

--- a/config/policy.go
+++ b/config/policy.go
@@ -22,20 +22,24 @@ type Policy struct {
 	// trusted in order to register.
 	Except []string
 
-	// Trust is either false or true, and determines whether an allowed peer
+	// ExemptRateLimits is either false or true, and determines whether an allowed peer
 	// can skip (true) on-chain verification or not (false), by default.
-	Trust bool
-	// TrustExcept is a list of peer IDs that are exceptions to the trust
+	ExemptRateLimits bool
+	// ExemptRateLimitsExcept is a list of peer IDs that are exceptions to the trust
 	// action.  If Trust is false then all allowed peers must be verified,
 	// except those listed here.  If Trust is true, then only the peers
 	// listed here require verification.
-	TrustExcept []string
+	ExemptRateLimitsExcept []string
+
+	// ExemptSelfPublisher is a list of peer IDs that are allowed to publish on
+	// behalf of other providers.
+	ExemptSelfPublisher []string
 }
 
 // NewPolicy returns Policy with values set to their defaults.
 func NewPolicy() Policy {
 	return Policy{
-		Allow: true,
-		Trust: true,
+		Allow:            true,
+		ExemptRateLimits: true,
 	}
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -104,7 +104,7 @@ type Ingester struct {
 // NewIngester creates a new Ingester that uses a go-legs Subscriber to handle
 // communication with providers.
 func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *registry.Registry, ds datastore.Batching) (*Ingester, error) {
-	lsys := mkLinkSystem(ds)
+	lsys := mkLinkSystem(ds, reg)
 
 	// Construct a selector that recursively looks for nodes with field
 	// "PreviousID" as per Advertisement schema.  Note that the entries within

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -145,7 +145,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 
 	// Create and start pubsub subscriber.  This also registers the storage
 	// hook to index data as it is received.
-	sub, err := legs.NewSubscriber(h, ds, lsys, cfg.PubSubTopic, adSel, legs.AllowPeer(reg.Authorized), legs.UseLatestSyncHandler(&syncHandler{ing}))
+	sub, err := legs.NewSubscriber(h, ds, lsys, cfg.PubSubTopic, adSel, legs.AllowPeer(reg.Allowed), legs.UseLatestSyncHandler(&syncHandler{ing}))
 	if err != nil {
 		log.Errorw("Failed to start pubsub subscriber", "err", err)
 		return nil, errors.New("ingester subscriber failed")

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -950,8 +950,8 @@ func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
 func mkRegistry(t *testing.T) *registry.Registry {
 	discoveryCfg := config.Discovery{
 		Policy: config.Policy{
-			Allow: true,
-			Trust: true,
+			Allow:            true,
+			ExemptRateLimits: true,
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -950,8 +950,8 @@ func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
 func mkRegistry(t *testing.T) *registry.Registry {
 	discoveryCfg := config.Discovery{
 		Policy: config.Policy{
-			Allow:            true,
-			ExemptRateLimits: true,
+			Allow:   true,
+			Publish: true,
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -110,15 +110,10 @@ func verifyAdvertisement(n ipld.Node, reg *registry.Registry) (*schema.Advertise
 		return nil, "", errBadAdvert
 	}
 
-	// Verify that the advertised provider has signed, and
-	// therefore approved, the advertisement regardless of who
-	// published the advertisement.
-	if signerID != provID && !reg.CanPublishForOthers(signerID) {
-		// TODO: Have policy that allows a signer (publisher) to
-		// sign advertisements for certain providers.  This will
-		// allow that signer to add, update, and delete indexed
-		// content on behalf of those providers.
-		log.Errorw("Advertisement not signed by provider", "provider", ad.Provider, "signer", signerID)
+	// Verify that the advertised is signed by the provider or by an allowed
+	// publisher.
+	if signerID != provID && !reg.PublishAllowed(signerID, provID) {
+		log.Errorw("Advertisement not signed by provider or allowed publisher", "provider", ad.Provider, "signer", signerID)
 		return nil, "", errInvalidAdvertSignature
 	}
 

--- a/internal/registry/errors.go
+++ b/internal/registry/errors.go
@@ -3,10 +3,11 @@ package registry
 import "errors"
 
 var (
-	ErrInProgress  = errors.New("discovery already in progress")
-	ErrNotAllowed  = errors.New("provider not allowed by policy")
-	ErrNoDiscovery = errors.New("discovery not available")
-	ErrNotTrusted  = errors.New("provider not trusted to register without on-chain verification")
-	ErrNotVerified = errors.New("provider cannot be verified")
-	ErrTooSoon     = errors.New("not enough time since previous discovery")
+	ErrInProgress          = errors.New("discovery already in progress")
+	ErrCannotPublish       = errors.New("publisher not allowed to publish to other provider")
+	ErrNotAllowed          = errors.New("provider not allowed by policy")
+	ErrNoDiscovery         = errors.New("discovery not available")
+	ErrNotVerified         = errors.New("provider cannot be verified")
+	ErrPublisherNotAllowed = errors.New("publisher not allowed by policy")
+	ErrTooSoon             = errors.New("not enough time since previous discovery")
 )

--- a/internal/registry/policy/policy_test.go
+++ b/internal/registry/policy/policy_test.go
@@ -31,10 +31,10 @@ func init() {
 
 func TestNewPolicy(t *testing.T) {
 	policyCfg := config.Policy{
-		Allow:       false,
-		Except:      []string{exceptIDStr},
-		Trust:       false,
-		TrustExcept: []string{trustedIDStr},
+		Allow:                  false,
+		Except:                 []string{exceptIDStr},
+		ExemptRateLimits:       false,
+		ExemptRateLimitsExcept: []string{trustedIDStr},
 	}
 
 	_, err := New(policyCfg)
@@ -49,13 +49,13 @@ func TestNewPolicy(t *testing.T) {
 	}
 
 	policyCfg.Allow = false
-	policyCfg.TrustExcept = append(policyCfg.TrustExcept, "bad ID")
+	policyCfg.ExemptRateLimitsExcept = append(policyCfg.ExemptRateLimitsExcept, "bad ID")
 	_, err = New(policyCfg)
 	if err == nil {
 		t.Error("expected error with bad trust ID")
 	}
 
-	policyCfg.TrustExcept = nil
+	policyCfg.ExemptRateLimitsExcept = nil
 	policyCfg.Except = append(policyCfg.Except, "bad ID")
 	_, err = New(policyCfg)
 	if err == nil {
@@ -77,10 +77,10 @@ func TestNewPolicy(t *testing.T) {
 
 func TestPolicyAccess(t *testing.T) {
 	policyCfg := config.Policy{
-		Allow:       false,
-		Except:      []string{exceptIDStr},
-		Trust:       false,
-		TrustExcept: []string{trustedIDStr},
+		Allow:                  false,
+		Except:                 []string{exceptIDStr},
+		ExemptRateLimits:       false,
+		ExemptRateLimitsExcept: []string{trustedIDStr},
 	}
 
 	p, err := New(policyCfg)
@@ -113,7 +113,7 @@ func TestPolicyAccess(t *testing.T) {
 	}
 
 	policyCfg.Allow = true
-	policyCfg.Trust = true
+	policyCfg.ExemptRateLimits = true
 	err = p.Config(policyCfg)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -33,10 +33,10 @@ const (
 
 var discoveryCfg = config.Discovery{
 	Policy: config.Policy{
-		Allow:       false,
-		Except:      []string{exceptID, trustedID, trustedID2, publisherID},
-		Trust:       false,
-		TrustExcept: []string{trustedID, trustedID2, publisherID},
+		Allow:                  false,
+		Except:                 []string{exceptID, trustedID, trustedID2, publisherID},
+		ExemptRateLimits:       false,
+		ExemptRateLimitsExcept: []string{trustedID, trustedID2, publisherID},
 	},
 	PollInterval:   config.Duration(time.Minute),
 	RediscoverWait: config.Duration(time.Minute),
@@ -335,8 +335,8 @@ func TestDatastore(t *testing.T) {
 func TestPollProvider(t *testing.T) {
 	cfg := config.Discovery{
 		Policy: config.Policy{
-			Allow: true,
-			Trust: true,
+			Allow:            true,
+			ExemptRateLimits: true,
 		},
 		RediscoverWait: config.Duration(time.Minute),
 	}

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -47,10 +47,10 @@ func InitIndex(t *testing.T, withCache bool) indexer.Interface {
 func InitRegistry(t *testing.T) *registry.Registry {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Allow:       false,
-			Except:      []string{providerID},
-			Trust:       false,
-			TrustExcept: []string{providerID},
+			Allow:                  false,
+			Except:                 []string{providerID},
+			ExemptRateLimits:       false,
+			ExemptRateLimitsExcept: []string{providerID},
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -47,10 +47,11 @@ func InitIndex(t *testing.T, withCache bool) indexer.Interface {
 func InitRegistry(t *testing.T) *registry.Registry {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Allow:                  false,
-			Except:                 []string{providerID},
-			ExemptRateLimits:       false,
-			ExemptRateLimitsExcept: []string{providerID},
+			Allow:           false,
+			Except:          []string{providerID},
+			Publish:         false,
+			RateLimit:       false,
+			RateLimitExcept: []string{providerID},
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -136,13 +136,13 @@ func (h *IngestHandler) Announce(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	allow, err := h.registry.Authorized(pid.ID)
+	allow, err := h.registry.Allowed(pid.ID)
 	if err != nil {
 		err = fmt.Errorf("error checking if peer allowed: %w", err)
 		return v0.NewError(err, http.StatusInternalServerError)
 	}
 	if !allow {
-		return v0.NewError(errors.New("not authorized to announce"), http.StatusForbidden)
+		return v0.NewError(errors.New("not allowed to announce"), http.StatusForbidden)
 	}
 	cur, err := h.ingester.GetLatestSync(pid.ID)
 	if err == nil {

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -62,10 +62,11 @@ func (m *mockIndexer) Iter() (indexer.Iterator, error)                    { retu
 func init() {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Allow:                  false,
-			Except:                 []string{ident.PeerID},
-			ExemptRateLimits:       false,
-			ExemptRateLimitsExcept: []string{ident.PeerID},
+			Allow:           false,
+			Except:          []string{ident.PeerID},
+			Publish:         true,
+			RateLimit:       false,
+			RateLimitExcept: []string{ident.PeerID},
 		},
 	}
 

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -62,10 +62,10 @@ func (m *mockIndexer) Iter() (indexer.Iterator, error)                    { retu
 func init() {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Allow:       false,
-			Except:      []string{ident.PeerID},
-			Trust:       false,
-			TrustExcept: []string{ident.PeerID},
+			Allow:                  false,
+			Except:                 []string{ident.PeerID},
+			ExemptRateLimits:       false,
+			ExemptRateLimitsExcept: []string{ident.PeerID},
 		},
 	}
 

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -47,10 +47,11 @@ func InitIndex(t *testing.T, withCache bool) indexer.Interface {
 func InitRegistry(t *testing.T, trustedID string) *registry.Registry {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Allow:                  false,
-			Except:                 []string{trustedID},
-			ExemptRateLimits:       false,
-			ExemptRateLimitsExcept: []string{trustedID},
+			Allow:           false,
+			Except:          []string{trustedID},
+			Publish:         false,
+			RateLimit:       false,
+			RateLimitExcept: []string{trustedID},
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -47,10 +47,10 @@ func InitIndex(t *testing.T, withCache bool) indexer.Interface {
 func InitRegistry(t *testing.T, trustedID string) *registry.Registry {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Allow:       false,
-			Except:      []string{trustedID},
-			Trust:       false,
-			TrustExcept: []string{trustedID},
+			Allow:                  false,
+			Except:                 []string{trustedID},
+			ExemptRateLimits:       false,
+			ExemptRateLimitsExcept: []string{trustedID},
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),


### PR DESCRIPTION
## Context
Some advertisement publishers what to have a different provider specified in advertisements.

## Proposed Changes
Have a list of `exemptfromselfpublish` peers, who are exempt from needing to only list themselves in advertisements

## Revert Strategy
Change is safe to revert.