### PR TITLE
Configure EBS CSI controller to run on all nodes

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/ebs_csi_driver.tf
+++ b/deploy/infrastructure/prod/us-east-2/ebs_csi_driver.tf
@@ -1,0 +1,18 @@
+module "ebs_csi_controller_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "ebs_csi_controller"
+  role_path    = local.iam_path
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy",
+  ]
+
+  oidc_fully_qualified_subjects = [
+    "system:serviceaccount:kube-system:ebs-csi-controller-sa",
+  ]
+}

--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -8,10 +8,6 @@ module "eks" {
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
 
-  cluster_addons = {
-    aws-ebs-csi-driver = {}
-  }
-  
   iam_role_path = local.iam_path
 
   vpc_id     = module.vpc.vpc_id

--- a/deploy/infrastructure/prod/us-east-2/outputs.tf
+++ b/deploy/infrastructure/prod/us-east-2/outputs.tf
@@ -18,6 +18,10 @@ output "cluster_autoscaler_role_arn" {
   value = module.cluster_autoscaler_role.iam_role_arn
 }
 
+output "ebs_csi_controller_role_arn" {
+  value = module.ebs_csi_controller_role.iam_role_arn
+}
+
 output "prod_cid_contact_nameservers" {
   value = aws_route53_zone.prod_external.name_servers
 }

--- a/deploy/manifests/base/aws-ebs-csi-driver/kustomization.yaml
+++ b/deploy/manifests/base/aws-ebs-csi-driver/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable?ref=v1.5.1

--- a/deploy/manifests/prod/us-east-2/cluster/aws-ebs-csi-driver/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/aws-ebs-csi-driver/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/aws-ebs-csi-driver
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/aws-ebs-csi-driver/patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/aws-ebs-csi-driver/patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-controller-sa
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/prod/us-east-2/ebs_csi_controller"
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ebs-csi-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      tolerations:
+        # Override default tolerations to allow all tains. Otherwise, the daemonset pods will not
+        # run on nodes with specific taints; more specifically, r5b nodegroup with "dedicated" taint.
+        - operator: Exists

--- a/deploy/manifests/prod/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - storetheindex
   - cluster-autoscaler
   - monitoring
+  - aws-ebs-csi-driver


### PR DESCRIPTION


## Context
The EBS CSI controller installed by EKS as addon doesn't seem to provide
taint control configuration. Install the controller directly so that:
1. we have better control over its configuration.
2. we avoid clash with CD-managed manifests applied via gitops

## Proposed Changes
With this change, the controller daemonset is configured to run on all
nodes regardless of their taint. Before this change, the daemonset was
not being scheduled on r5b nodes which meant we could not create io2
volumes on those nodes which defeated the whole point of having r5b node
types.

The changes here also create the IAM role needed by the controller to do
its job and patches the corresponding controller service account. This
 was missing in earlier PRs.


## Tests
Tried out manually on cluster.

## Revert Strategy
`git revert` and `terraform apply`