### PR TITLE
Set up public ECR and publish containers via CI

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -1,0 +1,42 @@
+name: ECR
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+jobs:
+  publisher:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      ECR_REGISTRY: public.ecr.aws/e2v8t0i4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Determine Container Tag
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/v}"
+          if test "${IMAGE_TAG}" = "${GITHUB_REF}"; then
+            IMAGE_TAG="$(date '+%Y%m%d%H%M%S')-${GITHUB_SHA}"
+          fi
+          echo "Using image tag: ${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+      - name: AWS Login
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: "arn:aws:iam::407967248065:role/common/github_actions"
+          role-duration-seconds: 1200
+      - name: Login to Amazon ECR
+        run: aws ecr-public get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+      - name: Publish Container Image
+        run: |
+          IMAGE_NAME="${ECR_REGISTRY}/storetheindex:${IMAGE_TAG}"
+          docker build -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"
+          echo "Published image ${IMAGE_NAME}"

--- a/deploy/infrastructure/common/.terraform.lock.hcl
+++ b/deploy/infrastructure/common/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.9.0"
+  hashes = [
+    "h1:OWIIlbMZl/iQ8qR1U7Co3sGjNHL1HJtgNRnnV1kXNuI=",
+    "zh:084b83aef3335ad4f5e4b8323c6fe43c1ff55e17a7647c6a5cad6af519f72b42",
+    "zh:132e47ce69f14de4523b84b213cedf7173398acda14245b1ffe7747aac50f050",
+    "zh:2068baef7dfce3613f3b4f27314175e971f8db68d9cde9ec30b5659f80c68c6c",
+    "zh:63c6f489683d5f1ac55e82a0df387143ed22701d5f22c109a4d5c9924dd4e437",
+    "zh:8115fd21965954fa4568c09331e05bb29da967fab8d077419aed09954378e216",
+    "zh:8efdc95fde108f777ed9c79ae25dc17aea9771903250f5c5c8a4c726b90a345f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d42a7bc34d84b70c1d1bcc215cabd63abbcbd0352b70bd84da6c3916634932f",
+    "zh:aacbcceb241aa475888c0869e87593182edeced3170c76a0c960dd9c905df449",
+    "zh:c7fe7904511052e4102870256819a1917177572cf684f0611ebf767f9c1fbaa8",
+    "zh:c8e07c3424663d1d0e7e32f4ade8099c19f6326d37c6da98104d90c986ff66fc",
+    "zh:e47cafbd38b56ef14fd8d727b4ffea847c166b1c684f585ee5fb78983b537248",
+  ]
+}

--- a/deploy/infrastructure/common/backend.tf
+++ b/deploy/infrastructure/common/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "sti-dev-terraform-state"
+    key    = "sti/common/terraform.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/deploy/infrastructure/common/ecr.tf
+++ b/deploy/infrastructure/common/ecr.tf
@@ -1,0 +1,10 @@
+resource "aws_ecrpublic_repository" "storetheindex" {
+  repository_name = "storetheindex"
+  # Public ECR is only supported on us-east-1 region.
+  provider        = aws.use1
+  catalog_data {
+    about_text        = "storetheindex"
+    operating_systems = ["linux"]
+    architectures     = ["amd64"]
+  }
+}

--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -1,0 +1,50 @@
+resource "aws_iam_openid_connect_provider" "github" {
+  client_id_list = [
+    "https://github.com/filecoin-project",
+    "sts.amazonaws.com"
+  ]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1"
+  ]
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "aws_iam_policy_document" "github_actions" {
+  statement {
+    effect  = "Allow"
+    actions = [
+      "ecr-public:BatchCheckLayerAvailability",
+      "ecr-public:CompleteLayerUpload",
+      "ecr-public:InitiateLayerUpload",
+      "ecr-public:PutImage",
+      "ecr-public:UploadLayerPart",
+      "ecr-public:GetAuthorizationToken",
+      "sts:GetServiceBearerToken"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "github_actions" {
+  name   = "github_actions"
+  policy = data.aws_iam_policy_document.github_actions.json
+  path   = local.iam_path
+}
+
+module "github_actions_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.18.0"
+
+  create_role = true
+
+  role_name    = "github_actions"
+  role_path    = local.iam_path
+  provider_url = aws_iam_openid_connect_provider.github.url
+
+  role_policy_arns = [
+    aws_iam_policy.github_actions.arn,
+  ]
+
+  oidc_subjects_with_wildcards = ["repo:filecoin-project/storetheindex:*"]
+}

--- a/deploy/infrastructure/common/locals.tf
+++ b/deploy/infrastructure/common/locals.tf
@@ -1,0 +1,17 @@
+locals {
+
+  environment_name = "common"
+  account_id       = "407967248065"
+
+  iam_path = "/${local.environment_name}/"
+
+  tags = {
+    "Environment" = local.environment_name
+    "ManagedBy"   = "terraform"
+    Owner         = "storetheindex"
+    Team          = "bedrock"
+    Organization  = "EngRes"
+  }
+}
+
+data "aws_region" "current" {}

--- a/deploy/infrastructure/common/main.tf
+++ b/deploy/infrastructure/common/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region              = "us-east-1"
+  alias               = "use1"
+  allowed_account_ids = [local.account_id]
+  default_tags {
+    tags = local.tags
+  }
+}

--- a/deploy/infrastructure/common/outputs.tf
+++ b/deploy/infrastructure/common/outputs.tf
@@ -1,0 +1,3 @@
+output "github_actions_role_arn" {
+  value = module.github_actions_role.iam_role_arn
+}


### PR DESCRIPTION
## Context
Use public ECR to make `storetheindex` containers available.

## Proposed Changes
Create an IAM role with minimal permissions for GitHub Actions that
allows it to publish images to public ECR repositories owned by
storetheindex. The role uses GitHub OIDC provider for authentication and
is only allowed to be assumed for builds in storetheindex repo.

Set up a GitHub Actions build that is triggered on either merge to main
branch or tag `v*` that builds and publishes container images to the
storetheindex public ECR repo. The container image tag is determined
based on the event that starts up the build:
- if the build is triggered by a tag starting with `v` then the
container image will be whatever came after the `v` in tag, i.e. semver.
- otherwise, it will be a timestamp at which build was run plues `-`
plus the build commit SHA. Note that to configure automatic CD
deployment we need some sortable numeric or alphabetical value and using
commit SHA alone will not suffice; hence the timestamp prefix.

## Tests
Tested locally

## Revert Strategy
`git revert` `terraform apply`