### PR TITLE
Revert "Remove redundant private ECR repo"

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/ecr.tf
+++ b/deploy/infrastructure/dev/us-east-2/ecr.tf
@@ -1,0 +1,9 @@
+module "ecr" {
+  source = "../../modules/ecr"
+
+  repositories = [
+    "storetheindex/storetheindex",
+  ]
+
+  tags = local.tags
+}

--- a/deploy/infrastructure/modules/ecr/main.tf
+++ b/deploy/infrastructure/modules/ecr/main.tf
@@ -1,0 +1,34 @@
+resource "aws_ecr_repository" "this" {
+  for_each = var.repositories
+  name     = each.key
+  tags     = var.tags
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+  image_tag_mutability = var.ecr_tag_immutability
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each   = var.repositories
+  repository = each.key
+  depends_on = [aws_ecr_repository.this]
+  policy     = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire untagged images older than ${var.ecr_untagged_expiry_days} days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": ${var.ecr_untagged_expiry_days}
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}

--- a/deploy/infrastructure/modules/ecr/variables.tf
+++ b/deploy/infrastructure/modules/ecr/variables.tf
@@ -1,0 +1,27 @@
+variable "repositories" {
+  type        = set(string)
+  description = "The list of namespace and repository names in `<namespace>/<repo-name>` format."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "The tags applied to all created AWS resources."
+}
+
+variable "ecr_untagged_expiry_days" {
+  type        = number
+  description = "The number of days after which to expire untagged pushed images"
+  default     = 7
+}
+
+variable "ecr_tag_immutability" {
+  type        = string
+  description = "The immutability of container image tags published to ECR repository, either `MUTABLE` or `IMMUTABLE`."
+  default     = "IMMUTABLE"
+}
+
+variable "scan_on_push" {
+  type        = bool
+  description = "Indicates whether images are scanned after being pushed to the repository."
+  default     = true
+}


### PR DESCRIPTION
Reverting back to private ECR repo, because:
* despite AWS docs claim that public ECR supports Docker Registry HTTP API, it does not provide `tags/list` endpoint. 
* that endpoint is needed by flux cd to list the available tags to then automate image updates.

See issue: https://github.com/aws/containers-roadmap/issues/1262

Reverts filecoin-project/storetheindex#347