### PR TITLE
Remove public ECR and publish images to the private repo instead

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       contents: read
     env:
-      ECR_REGISTRY: public.ecr.aws/e2v8t0i4
+      ECR_REGISTRY: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -29,11 +29,11 @@ jobs:
       - name: AWS Login
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: us-east-1
+          aws-region: us-east-2
           role-to-assume: "arn:aws:iam::407967248065:role/common/github_actions"
           role-duration-seconds: 1200
       - name: Login to Amazon ECR
-        run: aws ecr-public get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+        run: aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
       - name: Publish Container Image
         run: |
           IMAGE_NAME="${ECR_REGISTRY}/storetheindex:${IMAGE_TAG}"

--- a/deploy/infrastructure/common/ecr.tf
+++ b/deploy/infrastructure/common/ecr.tf
@@ -1,10 +1,8 @@
-resource "aws_ecrpublic_repository" "storetheindex" {
-  repository_name = "storetheindex"
-  # Public ECR is only supported on us-east-1 region.
-  provider        = aws.use1
-  catalog_data {
-    about_text        = "storetheindex"
-    operating_systems = ["linux"]
-    architectures     = ["amd64"]
-  }
+module "ecr_ue2" {
+  source = "../modules/ecr"
+
+  repositories = [
+    "storetheindex/storetheindex",
+  ]
+  tags = local.tags
 }

--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -14,12 +14,12 @@ data "aws_iam_policy_document" "github_actions" {
   statement {
     effect  = "Allow"
     actions = [
-      "ecr-public:BatchCheckLayerAvailability",
-      "ecr-public:CompleteLayerUpload",
-      "ecr-public:InitiateLayerUpload",
-      "ecr-public:PutImage",
-      "ecr-public:UploadLayerPart",
-      "ecr-public:GetAuthorizationToken",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
       "sts:GetServiceBearerToken"
     ]
     resources = ["*"]

--- a/deploy/infrastructure/dev/us-east-2/ecr.tf
+++ b/deploy/infrastructure/dev/us-east-2/ecr.tf
@@ -1,9 +1,0 @@
-module "ecr" {
-  source = "../../modules/ecr"
-
-  repositories = [
-    "storetheindex/storetheindex",
-  ]
-
-  tags = local.tags
-}


### PR DESCRIPTION
## Context
Move the private ECR repo creation from `dev` to `common` infra folder,
because it is used by both production and dev environment.



## Proposed Changes
Remove the public ECR since it does not fully support docker registry
API despite docs claiming so.

Adjust github actions role and CI job to now publish images to the
private ECR repo.

## Tests
Manually tested

## Revert Strategy
`git revert`