### PR TITLE
Do not publish to ECR if pusher is `sti-bot`

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   publisher:
+    if: ${{ github.event.pusher.name != 'sti-bot' }}
     name: Publish
     runs-on: ubuntu-latest
     permissions:

--- a/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-cd.yaml
@@ -83,7 +83,9 @@ spec:
         Images:
         {{ range .Updated.Images -}}
         - {{.}}
-        {{ end -}} 
+        {{ end -}}
+        
+        [skip ci]
     push:
       branch: 'cd/dev'
   update:


### PR DESCRIPTION


## Context
Deploy automation loop caused by image build on all merges to main

## Proposed Changes
For updates pushed by `sti-bot` do not build and publish images to ECR.
This is because it causes an infinite loop of PRs and deployments since
every merge to main builds and pushes docker images.

Skip CI for changes pushed by flux image update automation.

## Tests
N/A

## Revert Strategy
`git revert`