### PR TITLE
Fix wrong publisher address when using HTTP

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -14,13 +14,6 @@ var indexerHostFlag = altsrc.NewStringFlag(&cli.StringFlag{
 	Value:    "localhost",
 })
 
-var indexerIDFlag = altsrc.NewStringFlag(&cli.StringFlag{
-	Name:     "peerid",
-	Usage:    "Peer ID of indexer to use, when using libp2p",
-	EnvVars:  []string{"INDEXER_ID"},
-	Required: false,
-})
-
 var cacheSizeFlag = &cli.Int64Flag{
 	Name:     "cachesize",
 	Usage:    "Maximum number of multihashes that result cache can hold, 0 to disable cache",
@@ -98,7 +91,13 @@ var findFlags = []cli.Flag{
 		Required: false,
 	},
 	indexerHostFlag,
-	indexerIDFlag,
+	&cli.StringFlag{
+		Name:     "indexerid",
+		Usage:    "Indexer peer ID to use when protocol=libp2p",
+		Aliases:  []string{"iid"},
+		EnvVars:  []string{"INDEXER_ID"},
+		Required: false,
+	},
 	&cli.StringFlag{
 		Name:     "protocol",
 		Usage:    "Protocol to query the indexer (http, libp2p currently supported)",
@@ -128,7 +127,7 @@ var importFlags = []cli.Flag{
 var adminPolicyFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:     "peer",
-		Usage:    "Peer ID of publisher or provider",
+		Usage:    "Peer ID of publisher or provider to allow or block",
 		Aliases:  []string{"p"},
 		Required: true,
 	},
@@ -142,7 +141,7 @@ var adminReloadPolicyFlags = []cli.Flag{
 var adminSyncFlags = []cli.Flag{
 	indexerHostFlag,
 	&cli.StringFlag{
-		Name:     "peer",
+		Name:     "pubid",
 		Usage:    "Publisher peer ID",
 		Aliases:  []string{"p"},
 		Required: true,
@@ -211,7 +210,7 @@ var initFlags = []cli.Flag{
 
 var providersGetFlags = []cli.Flag{
 	&cli.StringFlag{
-		Name:     "peer",
+		Name:     "provid",
 		Usage:    "Provider peer ID",
 		Aliases:  []string{"p"},
 		Required: true,

--- a/command/flags.go
+++ b/command/flags.go
@@ -50,13 +50,6 @@ var providerFlag = &cli.StringFlag{
 	Required: true,
 }
 
-var peerFlag = &cli.StringFlag{
-	Name:     "peer",
-	Usage:    "Peer ID of publisher or provider",
-	Aliases:  []string{"p"},
-	Required: true,
-}
-
 var daemonFlags = []cli.Flag{
 	cacheSizeFlag,
 	logLevelFlag,
@@ -133,7 +126,12 @@ var importFlags = []cli.Flag{
 }
 
 var adminPolicyFlags = []cli.Flag{
-	peerFlag,
+	&cli.StringFlag{
+		Name:     "peer",
+		Usage:    "Peer ID of publisher or provider",
+		Aliases:  []string{"p"},
+		Required: true,
+	},
 	indexerHostFlag,
 }
 
@@ -142,8 +140,13 @@ var adminReloadPolicyFlags = []cli.Flag{
 }
 
 var adminSyncFlags = []cli.Flag{
-	peerFlag,
 	indexerHostFlag,
+	&cli.StringFlag{
+		Name:     "peer",
+		Usage:    "Publisher peer ID",
+		Aliases:  []string{"p"},
+		Required: true,
+	},
 	&cli.StringFlag{
 		Name:  "addr",
 		Usage: "Multiaddr address of peer to sync with",
@@ -207,7 +210,12 @@ var initFlags = []cli.Flag{
 }
 
 var providersGetFlags = []cli.Flag{
-	peerFlag,
+	&cli.StringFlag{
+		Name:     "peer",
+		Usage:    "Provider peer ID",
+		Aliases:  []string{"p"},
+		Required: true,
+	},
 	indexerHostFlag,
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.12
-	github.com/filecoin-project/go-legs v0.3.11
+	github.com/filecoin-project/go-legs v0.3.12-0.20220414004103-9cf8ae4a1b23
 	github.com/frankban/quicktest v1.14.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.2.12
-	github.com/filecoin-project/go-legs v0.3.12-0.20220414004103-9cf8ae4a1b23
+	github.com/filecoin-project/go-indexer-core v0.2.13
+	github.com/filecoin-project/go-legs v0.3.12
 	github.com/frankban/quicktest v1.14.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1
@@ -103,7 +103,7 @@ require (
 	github.com/ipfs/go-unixfs v0.3.1 // indirect
 	github.com/ipfs/go-verifcid v0.0.1 // indirect
 	github.com/ipld/go-codec-dagpb v1.3.1 // indirect
-	github.com/ipld/go-storethehash v0.1.2 // indirect
+	github.com/ipld/go-storethehash v0.1.3 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.12 h1:c3x8nYxKy1lutz+FLJ0afjLh0LyG+8iJfmGqFqMWWcE=
 github.com/filecoin-project/go-indexer-core v0.2.12/go.mod h1:/rNc9n8KV5ldPRrh6GVQ4pc5OUaCXWDDHA5x8CiM6Yg=
-github.com/filecoin-project/go-legs v0.3.11 h1:BhedZBaMeGAipc7n8nftslMh0m8+MbhaMDPsyuZRaDw=
-github.com/filecoin-project/go-legs v0.3.11/go.mod h1:YwnS0OrctbuUOxs5uiIhuYZrrhxLTH0p5kT6+6lpMWc=
+github.com/filecoin-project/go-legs v0.3.12-0.20220414004103-9cf8ae4a1b23 h1:bk3PJK4YiVWEWo+g2PlwJ3hqhw+9M6J3xa3cF+clqHM=
+github.com/filecoin-project/go-legs v0.3.12-0.20220414004103-9cf8ae4a1b23/go.mod h1:Ve7iMWBvXm8yQ7k07RFjPkbFsi9wrsCqixV2oWIfkWM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd h1:Ykxbz+LvSCUIl2zFaaPGmF8KHXTJu9T/PymgHr7IHjs=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=

--- a/go.sum
+++ b/go.sum
@@ -217,10 +217,10 @@ github.com/filecoin-project/go-data-transfer v1.15.1/go.mod h1:dXsUoDjR9tKN7aV6R
 github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.2.12 h1:c3x8nYxKy1lutz+FLJ0afjLh0LyG+8iJfmGqFqMWWcE=
-github.com/filecoin-project/go-indexer-core v0.2.12/go.mod h1:/rNc9n8KV5ldPRrh6GVQ4pc5OUaCXWDDHA5x8CiM6Yg=
-github.com/filecoin-project/go-legs v0.3.12-0.20220414004103-9cf8ae4a1b23 h1:bk3PJK4YiVWEWo+g2PlwJ3hqhw+9M6J3xa3cF+clqHM=
-github.com/filecoin-project/go-legs v0.3.12-0.20220414004103-9cf8ae4a1b23/go.mod h1:Ve7iMWBvXm8yQ7k07RFjPkbFsi9wrsCqixV2oWIfkWM=
+github.com/filecoin-project/go-indexer-core v0.2.13 h1:XYlCxQ3Pq9sVjhEa22AK53vb1bxbj5PS2kmrM8u+8J4=
+github.com/filecoin-project/go-indexer-core v0.2.13/go.mod h1:a5QkHLqeRaeS+W1udtN4hfitmX9GfjOysGtajrVnR5Q=
+github.com/filecoin-project/go-legs v0.3.12 h1:bxmV0y2WM2ERVJWk4fgWkuELpcjI0QHERMPK3ULOaOY=
+github.com/filecoin-project/go-legs v0.3.12/go.mod h1:Ve7iMWBvXm8yQ7k07RFjPkbFsi9wrsCqixV2oWIfkWM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd h1:Ykxbz+LvSCUIl2zFaaPGmF8KHXTJu9T/PymgHr7IHjs=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=
@@ -643,8 +643,8 @@ github.com/ipld/go-ipld-prime v0.16.0 h1:RS5hhjB/mcpeEPJvfyj0qbOj/QL+/j05heZ0qa9
 github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHPT2PjoiiU1qA=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.1.2 h1:5Oj4/yHfgBPJyDkoEV04XYw/YBdsk3PNkYzsDhLoQyQ=
-github.com/ipld/go-storethehash v0.1.2/go.mod h1:d3m79FZzARANjjBwZ1rNgyGUK+1M5m0SLHrarmJzcYo=
+github.com/ipld/go-storethehash v0.1.3 h1:fvPZkcih9VjRdx+pTuc8aW0sXDzUFPXBI4rvXSR7/gs=
+github.com/ipld/go-storethehash v0.1.3/go.mod h1:d3m79FZzARANjjBwZ1rNgyGUK+1M5m0SLHrarmJzcYo=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -192,9 +192,15 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 	// Register provider or update existing registration.  The
 	// provider must be allowed by policy to be registered.
 	var pubInfo peer.AddrInfo
-	peerStore := ing.host.Peerstore()
+	peerStore := ing.sub.HttpPeerStore()
 	if peerStore != nil {
 		pubInfo = peerStore.PeerInfo(publisherID)
+	}
+	if len(pubInfo.Addrs) == 0 {
+		peerStore = ing.host.Peerstore()
+		if peerStore != nil {
+			pubInfo = peerStore.PeerInfo(publisherID)
+		}
 	}
 	err = ing.reg.RegisterOrUpdate(context.Background(), providerID, ad.Addresses, adCid, pubInfo)
 	if err != nil {


### PR DESCRIPTION


## Context
When retrieving an advertisement over HTTP, the indexer gets the wrong publisher address.  The indexer should get the address that the advertisement was retrieved from as the publisher address.

## Proposed Changes
When an advertisement is retrieved via HTTP, the publisher address is not in the peerstore.  The indexer then uses the provided address as the publisher address, since it cannot find an address for the publisher.  To get the HTTP address it is necessary to get the http peerstore from go-legs and look there first.

Also, revised command flags to correctly specify publisher or provider peer ID.

## Tests
Manual testing

## Revert Strategy
Safe to revert.