### PR TITLE
Configure readiness probe and pod disruption budget

### DIFF
--- a/deploy/manifests/base/storetheindex/indexer-statefulset.yaml
+++ b/deploy/manifests/base/storetheindex/indexer-statefulset.yaml
@@ -34,6 +34,15 @@ spec:
               mountPath: /data
             - name: config
               mountPath: /config
+          readinessProbe:
+            httpGet:
+              port: finder
+              path: /health
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+            periodSeconds: 10
       volumes:
         - name: config
           configMap:

--- a/deploy/manifests/base/storetheindex/kustomization.yaml
+++ b/deploy/manifests/base/storetheindex/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: storetheindex
 resources:
   - indexer-statefulset.yaml
   - indexer-service.yaml
+  - pdb.yaml
 
 transformers:
   - labels.yaml

--- a/deploy/manifests/base/storetheindex/pdb.yaml
+++ b/deploy/manifests/base/storetheindex/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: indexer
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: indexer


### PR DESCRIPTION
## Context
We want to maintain availability during deployment, and during other admin operations like worker node drainage.

## Proposed Changes
* Specify readiness probe so that pods are not used to serve incoming requests unless ready.
* Specify pod disruption budget so that we tell the cluster the maximum unavailable pods allowed.

## Tests
N/A

## Revert Strategy
`git revert`