### PR TITLE
Remove skip message from image update automation

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/storetheindex/flux-cd.yaml
@@ -84,8 +84,6 @@ spec:
         {{ range .Updated.Images -}}
         - {{.}}
         {{ end -}}
-        
-        [skip ci]
     push:
       branch: 'cd/dev'
   update:


### PR DESCRIPTION


## Context
Seems like the skip message stops running the Dev CD job too.

## Proposed Changes
see commit message

## Tests
N/A

## Revert Strategy
`git revert`
