### PR TITLE
Fix ECR build still running on sti bot pushes to `deploy` directory

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -1,6 +1,8 @@
 name: ECR
 on:
   push:
+    paths-ignore:
+      - 'deploy/**'
     branches:
       - main
     tags:

--- a/deploy/manifests/README.md
+++ b/deploy/manifests/README.md
@@ -43,7 +43,7 @@ To encrypt a file containing sensitive information, e.g. `my-secret.txt`:
 
 You can now include the encrypted value in your `kustomization.yaml` using `secretGenerator` to
 create K8S `Secret` object. An example of this technique can be found in `storetheindex`
-Kustomization in both `dev` and `prod` environments.
+Kustomization file in both `dev` and `prod` environments.
 
 It is also possible to define K8S `Secret` object directly, and encrypt its content (i.e. at
 key `data` or `stringData`) using SOPS.


### PR DESCRIPTION


## Context
ECR build seem to still run when merging CD created PRs.

## Proposed Changes
Ignore the entire `deploy` director in ECR build.

## Tests
<!-- What tests did you add to assert the expected behavior? If no tests, why? -->

## Revert Strategy
<!-- Is this change safe to revert? -->

<!-- If yes, you can simply say:-->
<!-- Change is safe to revert. -->

<!-- If no, outline the steps required to revert this change. -->
