### PR TITLE
Use io2 storage class for indexer pods in `dev`

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/dev/us-east-2/cloudfront.tf
@@ -100,5 +100,3 @@ module "records" {
     },
   ]
 }
-
-data "aws_region" "current" {}

--- a/deploy/infrastructure/dev/us-east-2/ebs_csi_driver.tf
+++ b/deploy/infrastructure/dev/us-east-2/ebs_csi_driver.tf
@@ -1,0 +1,18 @@
+module "ebs_csi_controller_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "${local.environment_name}_ebs_csi_controller"
+  role_path = local.iam_path
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy",
+  ]
+
+  oidc_fully_qualified_subjects = [
+    "system:serviceaccount:kube-system:ebs-csi-controller-sa",
+  ]
+}

--- a/deploy/infrastructure/dev/us-east-2/locals.tf
+++ b/deploy/infrastructure/dev/us-east-2/locals.tf
@@ -1,6 +1,9 @@
 locals {
 
   environment_name = "dev"
+  region           = data.aws_region.current.name
+
+  iam_path = "/${local.environment_name}/${local.region}/"
 
   tags = {
     "Environment" = local.environment_name
@@ -10,3 +13,5 @@ locals {
     Organization  = "EngRes"
   }
 }
+
+data "aws_region" "current" {}

--- a/deploy/infrastructure/dev/us-east-2/outputs.tf
+++ b/deploy/infrastructure/dev/us-east-2/outputs.tf
@@ -18,6 +18,10 @@ output "cluster_autoscaler_role_arn" {
   value = module.cluster_autoscaler_role.iam_role_arn
 }
 
+output "ebs_csi_controller_role_arn" {
+  value = module.ebs_csi_controller_role.iam_role_arn
+}
+
 output "monitoring_role_arn" {
   value = module.monitoring_role.iam_role_arn
 }

--- a/deploy/manifests/dev/us-east-2/cluster/aws-ebs-csi-driver/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/aws-ebs-csi-driver/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/aws-ebs-csi-driver
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/aws-ebs-csi-driver/patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/aws-ebs-csi-driver/patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-controller-sa
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/dev/us-east-2/dev_ebs_csi_controller"
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ebs-csi-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      tolerations:
+        # Override default tolerations to allow all tains. Otherwise, the daemonset pods will not
+        # run on nodes with specific taints.
+        - operator: Exists

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -21,3 +21,13 @@ spec:
         - name: identity
           secret:
             secretName: indexer-identity
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: io2
+        resources:
+          requests:
+            storage: 5Ti


### PR DESCRIPTION


## Context
PVC IOPS improvement for storetheindex in `dev`. Tying this out first in `dev` before `prod` changes. 

## Proposed Changes
Deploy EBS CSI controller to be able to provision io2 storage class and
patch the storetheindex manifests to use `io2` instead of the existing
`gp2` for better performance.

## Tests
N/A

## Revert Strategy
`git revert` `terraform apply`