### PR TITLE
Add AWS EBS CSI to dev cluster manifests

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - storetheindex
   - cluster-autoscaler
   - monitoring
+  - aws-ebs-csi-driver


### PR DESCRIPTION
Include CSI manifests in dev cluster kustomization.

Missed out in previous PR.