### PR TITLE
Use `io2` storage class for `prod` instances

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -27,3 +27,13 @@ spec:
         - name: identity
           secret:
             secretName: indexer-identity
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: io2
+        resources:
+          requests:
+            storage: 5Ti


### PR DESCRIPTION


## Context
CSI controller has already been installed. Patch the statefulset to use
`io2` storage class for better performance

## Proposed Changes
See commit message.

## Tests
Running the same on dev.

## Revert Strategy
`git revert`. Note change to statefulset needs to be handled manually since it is editing an immutable field.