### PR TITLE
Don't override image in prod until auto deploy is set up

### DIFF
--- a/deploy/manifests/prod/us-east-2/cluster/storetheindex/flux-cd.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/storetheindex/flux-cd.yaml
@@ -23,9 +23,6 @@ spec:
     kind: GitRepository
     name: storetheindex
   prune: true
-  images:
-    - name: storetheindex
-      newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
 
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta1


### PR DESCRIPTION
An inline image is specified in prod kustomization. But it gets
overridden by flux.
Remove the override so that prod deployment can proceed until we
automated deployment is set up for prod, like it has for dev.
