### PR TITLE
Skip dev CD job if PR it should create exists already

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -1,7 +1,8 @@
 name: Dev CD
 on:
   push:
-    branches: [ 'cd/dev' ]
+    branches:
+      - 'cd/dev'
 
 jobs:
   pull-request:
@@ -15,17 +16,24 @@ jobs:
         with:
           script: |
             const { repo, owner } = context.repo;
-            const result = await github.rest.pulls.create({
-              title: 'Deploy latest to `dev` environment',
-              owner,
-              repo,
-              head: 'cd/dev',
-              base: 'main',
-              body: 'Approve changes to trigger the latest deployment to `dev` environment'
-            });
-            await github.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number: result.data.number,
-              labels: ['cd', 'env:dev']
-            });
+            try {
+              const result = await github.rest.pulls.create({
+                title: 'Deploy latest to `dev` environment',
+                owner,
+                repo,
+                head: 'cd/dev',
+                base: 'main',
+                body: 'Approve changes to trigger the latest deployment to `dev` environment'
+              });
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: result.data.number,
+                labels: ['cd', 'env:dev']
+              });
+            } catch (e) {
+              if (!e.message.includes('A pull request already exists')) {
+                throw e
+              }
+              core.info('Skipped PR creation since it already exists.')
+            }


### PR DESCRIPTION


## Context
The dev CD job that creates a PR to trigger deployment fails if the pr
is already open. 

## Proposed Changes
Check if the error we get is caused by that and if so
end job gracefully.

## Tests
Manually tested

## Revert Strategy
`git revert`