### PR TITLE
Quote glob format to select tags

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -3,10 +3,11 @@ on:
   push:
     paths-ignore:
       - 'deploy/**'
+      - 'doc'
+    tags:
+      - 'v*'
     branches:
       - main
-    tags:
-      - v*
 
 jobs:
   publisher:


### PR DESCRIPTION
ECR build is not triggered on tag. Quote the glob format to see if that
fixes it.

While at it, ignore changes to `doc` in ECR build.

