### PR TITLE
Upgrade dev cluster to 1.22

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/.terraform.lock.hcl
+++ b/deploy/infrastructure/dev/us-east-2/.terraform.lock.hcl
@@ -40,6 +40,26 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.10.0"
+  constraints = ">= 2.10.0"
+  hashes = [
+    "h1:v+xmcw54lMETOlhKPO61AlbxGB0OU8BphMfOO62e0Uo=",
+    "zh:0b011e77f02bc05194062c0a39f321a4f1bea0bae61787b0c1f5808f6efb2a26",
+    "zh:288ad46e240c5d1218909a9100ca8bd2197c8615558bbe7b393ba35877d5e4f0",
+    "zh:3e5554791ed103b6190efebe332fd3722796e6a59cf081f87ef1debb4e0b6ae3",
+    "zh:98e42cb48624be7eb2e16b5d8fc5044d7207943b6d13905bc3d3c006aa231cc7",
+    "zh:b1c800fd3971051d9deb4824f933e506ae288458e425be8ea449c9d40c7b0663",
+    "zh:bca1802585ecbc36bfcc700b6fa7c6ff96b2b8c4aca23c58df939a5002a05b4d",
+    "zh:c2f6bf46cd95d00f2bb1634afff92eeb269d27d83eea80b8cfceca1afdcd3033",
+    "zh:d2ccfbf3a9bf2ede8be6242c023173efd85a882cd3956a941f140c5718047412",
+    "zh:da19cd4a124f4ffc092e19f5b7a10ac4cce98db40cf855ea0d4a682f3df83a1f",
+    "zh:e3a2020453a86f80ad2b3f792e91a35fe272b907485a59c02d19269a1bdfe2fd",
+    "zh:f0659ca86e0dc0dd76b7f4497db8e58144ee9f0943b6d14dc57193d25ee22ced",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "3.1.0"
   constraints = ">= 3.0.0"

--- a/deploy/infrastructure/dev/us-east-2/ebs_csi_driver.tf
+++ b/deploy/infrastructure/dev/us-east-2/ebs_csi_driver.tf
@@ -5,7 +5,7 @@ module "ebs_csi_controller_role" {
   create_role = true
 
   role_name    = "${local.environment_name}_ebs_csi_controller"
-  role_path = local.iam_path
+  role_path    = local.iam_path
   provider_url = module.eks.oidc_provider
 
   role_policy_arns = [

--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -1,25 +1,31 @@
 module "eks" {
   source  = "registry.terraform.io/terraform-aws-modules/eks/aws"
-  version = "18.15.0"
+  version = "18.20.2"
 
   cluster_name    = local.environment_name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
   eks_managed_node_group_defaults = {
-    instance_types = ["m4.large"]
+    # Enforce explicit naming of nodegrups and roles to avoid generated names
+    use_name_prefix                 = false
+    iam_role_use_name_prefix        = false
+    security_group_use_name_prefix  = false
+    launch_template_use_name_prefix = false
+
+    # Use EKS's own default launch template
+    create_launch_template = false
+    launch_template_name   = ""
   }
 
   eks_managed_node_groups = {
-    default_node_group = {
-      min_size     = 1
-      max_size     = 7
-      desired_size = 1
-
-      create_launch_template = false
-      launch_template_name   = ""
+    dev-ue2-m4-xl = {
+      min_size       = 3
+      max_size       = 7
+      desired_size   = 3
+      instance_types = ["m4.xlarge"]
     }
   }
 

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -7,7 +7,7 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/default_node_group-eks-node-group-20220326104849172600000002
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2-m4-xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih


### PR DESCRIPTION


## Context
See commit message.

## Proposed Changes
Upgrade the dev cluster to latest so that we can install the latest
monitoring overlay that supports sigv4 auth.

Rename node groups in dev clsuter to have human readable name.

Update minimum instance count to 3 so that we have one node per az.

## Tests
N/A

## Revert Strategy
`git revert` `terraform apply`