### PR TITLE
Upgrade monitoring manifests now that K8S clusters are on 1.22

### DIFF
--- a/deploy/manifests/base/monitoring/kustomization.yaml
+++ b/deploy/manifests/base/monitoring/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/prometheus-operator/kube-prometheus?ref=v0.9.0
+  - github.com/prometheus-operator/kube-prometheus?ref=v0.10.0


### PR DESCRIPTION

## Context
Now that both clusters are upgraded to 1.22, upgrade the kube-prometheus
 manifests to run the latest compatible with the clusters which comes
 with upgraded prometheus operator allowing us to specify SigV4 auth to
 forward monitoring info to AWS managed prometheus.

## Proposed Changes
See commit message.

This change updates the base manifests which means both `prod` and `dev` environments will be upgraded.

## Tests
N/A

## Revert Strategy
`git revert`