### PR TITLE
Set up remote write for dev metrics to aws managed prometheus

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/monitoring.tf
+++ b/deploy/infrastructure/dev/us-east-2/monitoring.tf
@@ -38,7 +38,7 @@ module "monitoring_role" {
     aws_iam_policy.monitoring.arn,
   ]
 
-  oidc_fully_qualified_subjects = ["system:serviceaccount:grafana-agent:grafana-agent"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:prometheus-k8s"]
 
   tags = local.tags
 }

--- a/deploy/infrastructure/dev/us-east-2/outputs.tf
+++ b/deploy/infrastructure/dev/us-east-2/outputs.tf
@@ -33,3 +33,7 @@ output "dev_cid_contact_nameservers" {
 output "dev_cid_contact_zone_id" {
   value = aws_route53_zone.dev_external.zone_id
 }
+
+output "amp_endpoint" {
+  value = aws_prometheus_workspace.monitoring.prometheus_endpoint
+}

--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/patch.yaml
@@ -23,3 +23,12 @@ rules:
       - get
       - list
       - watch
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-k8s
+  namespace: monitoring
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/dev_monitoring"

--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/prometheus-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/prometheus-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: k8s
+  namespace: monitoring
+spec:
+  remoteWrite:
+    - url: https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-324f25cd-3624-4250-9b66-96d36addd73f/api/v1/remote_write
+      sigv4:
+        region: us-east-2


### PR DESCRIPTION


## Context
Use AWS managed services to store metrics collected in dev cluster

## Proposed Changes
Configure service account credentials and remote write settings for the
`dev` prometheus instance to write metrics to the aws managed
prometheus.

## Tests
N/A

## Revert Strategy
`git revert` `terraform apply`