### PR TITLE
Use new flag names in commands

### DIFF
--- a/command/admin.go
+++ b/command/admin.go
@@ -53,7 +53,7 @@ func syncCmd(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	peerID, err := peer.Decode(cctx.String("peer"))
+	peerID, err := peer.Decode(cctx.String("pubid"))
 	if err != nil {
 		return err
 	}

--- a/command/providers.go
+++ b/command/providers.go
@@ -37,7 +37,7 @@ func getProvidersCmd(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	peerID, err := peer.Decode(cctx.String("peer"))
+	peerID, err := peer.Decode(cctx.String("provid"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Context
Some flags were previously renamed but commands needed to use new names.

## Proposed Changes
Update commands to use new flag names

## Tests
manual

## Revert Strategy
safe to revert
