### PR TITLE
Send metrics to AWS managed prometheus via private link

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/monitoring.tf
+++ b/deploy/infrastructure/dev/us-east-2/monitoring.tf
@@ -2,6 +2,7 @@ resource "aws_prometheus_workspace" "monitoring" {
   alias = local.environment_name
   tags  = local.tags
 }
+
 # Placeholder for setting up remote_write and hook up to PL graphana
 data "aws_iam_policy_document" "monitoring" {
   statement {
@@ -39,6 +40,41 @@ module "monitoring_role" {
   ]
 
   oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:prometheus-k8s"]
+
+  tags = local.tags
+}
+
+resource "aws_security_group" "vpc_tls" {
+  name        = "${local.environment_name}_vpc_tls"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [module.vpc.vpc_cidr_block]
+  }
+
+  tags = local.tags
+}
+
+module "endpoints" {
+  source  = "registry.terraform.io/terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "3.14.0"
+
+  vpc_id             = module.vpc.vpc_id
+  security_group_ids = [aws_security_group.vpc_tls.id]
+  subnet_ids         = module.vpc.private_subnets
+
+  endpoints = {
+    aps-workspaces = {
+      service             = "aps-workspaces"
+      vpc_endpoint_type   = "Interface"
+      private_dns_enabled = true
+    }
+  }
 
   tags = local.tags
 }

--- a/deploy/infrastructure/dev/us-east-2/vpc.tf
+++ b/deploy/infrastructure/dev/us-east-2/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "registry.terraform.io/terraform-aws-modules/vpc/aws"
-  version = "3.13.0"
+  version = "3.14.0"
 
   name = local.environment_name
 

--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 
 patchesStrategicMerge:
   - patch.yaml
+  - prometheus-patch.yaml


### PR DESCRIPTION

## Context
For better security, use AWS PrivateLink to talk to internal AWS services from VPC.

## Proposed Changes
Avoid sending metrics over internet gateway, and instead set up a vpc
endpoint interface for accessing AWS managed Prometheus workspaces in
dev.

Add the missing patch resource to monitoring kustomization missed out in
earlier PR.


## Tests
N/A

## Revert Strategy
`git revert` `terraform apply`