### PR TITLE
Publish containers to ECR repo when a release is created

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -1,11 +1,15 @@
 name: ECR
+
 on:
+  # The tags in this repo are pushed via CI, the push events for which will not trigger workflows.
+  # However, releases are created by contributors, hence the use of release event to build images.
+  release:
+    types:
+      - published
   push:
     paths-ignore:
       - 'deploy/**'
-      - 'doc'
-    tags:
-      - 'v*'
+      - 'doc/**'
     branches:
       - main
 


### PR DESCRIPTION


## Context
Originally the ECR publisher CI job was configured to publish images to the ECR repo when a new tag `v*` was published. But it did not get triggered.

The issue is that tags in this repository are handled  by CI automation,
and it is a bot account that pushes the tag. In Github Actions events
generated by bot accounts do not trigger other jobs unless they use a
PAT that belongs to a non-bot user. Ideally, we want to avoid having PAT
in CI secrets that belong to individuals, and instead want to use the
built-in GitHub CI token.

## Proposed Changes
To work around this, the ECR publisher is changed to publish container
images tagged with semver when a GitHub Release is published. Because,
in this repo the releases are made by the contributors and creating a
release should trigger the job.

Update paths-ignore while at it to ignore all files under doc folder
recursively.


## Tests
N/A

## Revert Strategy
`git revert`