### PR TITLE
Spread indexer instances across AZs when possible

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/.terraform.lock.hcl
+++ b/deploy/infrastructure/prod/us-east-2/.terraform.lock.hcl
@@ -40,6 +40,26 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.10.0"
+  constraints = ">= 2.10.0"
+  hashes = [
+    "h1:v+xmcw54lMETOlhKPO61AlbxGB0OU8BphMfOO62e0Uo=",
+    "zh:0b011e77f02bc05194062c0a39f321a4f1bea0bae61787b0c1f5808f6efb2a26",
+    "zh:288ad46e240c5d1218909a9100ca8bd2197c8615558bbe7b393ba35877d5e4f0",
+    "zh:3e5554791ed103b6190efebe332fd3722796e6a59cf081f87ef1debb4e0b6ae3",
+    "zh:98e42cb48624be7eb2e16b5d8fc5044d7207943b6d13905bc3d3c006aa231cc7",
+    "zh:b1c800fd3971051d9deb4824f933e506ae288458e425be8ea449c9d40c7b0663",
+    "zh:bca1802585ecbc36bfcc700b6fa7c6ff96b2b8c4aca23c58df939a5002a05b4d",
+    "zh:c2f6bf46cd95d00f2bb1634afff92eeb269d27d83eea80b8cfceca1afdcd3033",
+    "zh:d2ccfbf3a9bf2ede8be6242c023173efd85a882cd3956a941f140c5718047412",
+    "zh:da19cd4a124f4ffc092e19f5b7a10ac4cce98db40cf855ea0d4a682f3df83a1f",
+    "zh:e3a2020453a86f80ad2b3f792e91a35fe272b907485a59c02d19269a1bdfe2fd",
+    "zh:f0659ca86e0dc0dd76b7f4497db8e58144ee9f0943b6d14dc57193d25ee22ced",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "3.2.1"
   constraints = ">= 3.0.0"

--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -1,6 +1,6 @@
 module "eks" {
   source  = "registry.terraform.io/terraform-aws-modules/eks/aws"
-  version = "18.19.0"
+  version = "18.20.2"
 
   cluster_name    = local.environment_name
   cluster_version = "1.22"
@@ -39,9 +39,9 @@ module "eks" {
     #  - https://aws.amazon.com/ec2/instance-types/#Memory_Optimized
     #  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#solid-state-drives
     prod-ue2-r5b-xl = {
-      min_size       = 1
+      min_size       = 3
       max_size       = 7
-      desired_size   = 1
+      desired_size   = 3
       instance_types = ["r5b.xlarge"]
       taints         = {
         dedicated = {

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   template:
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
       containers:
         - name: indexer
           env:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   template:
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
       containers:
         - name: indexer
           env:


### PR DESCRIPTION




## Context
To improve resilience against AZ failure, we want the indexer instances
to be spread across multiple AZs. So that, failure of one AZ does not
result in downtime.

## Proposed Changes
Increase worker count of type r5b in prod so that e have one in each AZ.

Configure topology spread constraints for indexer statefulsets in dev
and prod such that they are _preferably_ spread across the AZ in which
each worker node runs.

## Tests
N/A

## Revert Strategy
`git revert` `terraform apply`