### PR TITLE
Write `prod` metrics to a dedicated AWS managed prometheus

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/monitoring.tf
+++ b/deploy/infrastructure/prod/us-east-2/monitoring.tf
@@ -1,0 +1,72 @@
+resource "aws_prometheus_workspace" "monitoring" {
+  alias = local.environment_name
+}
+
+data "aws_iam_policy_document" "monitoring" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "aps:RemoteWrite",
+      "aps:QueryMetrics",
+      "aps:GetSeries",
+      "aps:GetLabels",
+      "aps:GetMetricMetadata"
+    ]
+
+    resources = [aws_prometheus_workspace.monitoring.arn]
+  }
+}
+
+resource "aws_iam_policy" "monitoring" {
+  name   = "${local.environment_name}_monitoring"
+  policy = data.aws_iam_policy_document.monitoring.json
+}
+
+module "monitoring_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "monitoring"
+  role_path = local.iam_path
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    aws_iam_policy.monitoring.arn,
+  ]
+
+  oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:prometheus-k8s"]
+}
+
+resource "aws_security_group" "vpc_tls" {
+  name        = "${local.environment_name}_vpc_tls"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [module.vpc.vpc_cidr_block]
+  }
+}
+
+module "endpoints" {
+  source  = "registry.terraform.io/terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "3.14.0"
+
+  vpc_id             = module.vpc.vpc_id
+  security_group_ids = [aws_security_group.vpc_tls.id]
+  subnet_ids         = module.vpc.private_subnets
+
+  endpoints = {
+    aps-workspaces = {
+      service             = "aps-workspaces"
+      vpc_endpoint_type   = "Interface"
+      private_dns_enabled = true
+    }
+  }
+}

--- a/deploy/infrastructure/prod/us-east-2/outputs.tf
+++ b/deploy/infrastructure/prod/us-east-2/outputs.tf
@@ -22,6 +22,10 @@ output "ebs_csi_controller_role_arn" {
   value = module.ebs_csi_controller_role.iam_role_arn
 }
 
+output "monitoring_role_arn" {
+  value = module.monitoring_role.iam_role_arn
+}
+
 output "prod_cid_contact_nameservers" {
   value = aws_route53_zone.prod_external.name_servers
 }

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 
 patchesStrategicMerge:
   - patch.yaml
+  - prometheus-patch.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/patch.yaml
@@ -23,3 +23,12 @@ rules:
       - get
       - list
       - watch
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-k8s
+  namespace: monitoring
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/prod/us-east-2/monitoring"

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/prometheus-patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/prometheus-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: k8s
+  namespace: monitoring
+spec:
+  remoteWrite:
+    - url: https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-02af630f-e4e0-444f-a59b-e5632f79b46f/api/v1/remote_write
+      sigv4:
+        region: us-east-2


### PR DESCRIPTION


## Context
`prod` cluster monitoring and integration with PL grafana

## Proposed Changes
Connect the separated prod monitoring stack to write to a dedicated AWS
managed prometheus instance.

## Tests
Same setup running on `dev`.

## Revert Strategy
`git revert` `terraform apply`