### PR TITLE
Configure resources for `dev` amd `prod`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -21,6 +21,13 @@ spec:
           volumeMounts:
             - name: identity
               mountPath: /identity
+          resources:
+            limits:
+              cpu: "1"
+              memory: 10Gi
+            requests:
+              cpu: 500m
+              memory: 10Gi
       volumes:
         - name: identity
           secret:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -21,6 +21,13 @@ spec:
           volumeMounts:
             - name: identity
               mountPath: /identity
+          resources:
+            limits:
+              cpu: "1"
+              memory: 10Gi
+            requests:
+              cpu: 500m
+              memory: 10Gi
       # Require r5b instance types to run index provider pods.
       tolerations:
         - key: dedicated


### PR DESCRIPTION
Use resources consistent with what is set in fil environments.
