### PR TITLE
Deploy the latest release to `prod` environment

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -26,4 +26,4 @@ secretGenerator:
 images:
   - name: storetheindex
     newName: filecoin/storetheindex
-    newTag: 3b2c5f5df721dc2cdfb340490b73de856960bfab
+    newTag: f93b333c402b71820b04efdd2629884eaa636cf7

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -26,4 +26,4 @@ secretGenerator:
 images:
   - name: storetheindex
     newName: filecoin/storetheindex
-    newTag: f93b333c402b71820b04efdd2629884eaa636cf7
+    newTag: 1b16c2dd77b55cb83be99410b514068e059b952d


### PR DESCRIPTION
The CD pipeline for prod environment is not set up yet. In the meantime,
use the latest release commit in the prod manifests:
 - `f93b333c402b71820b04efdd2629884eaa636cf7`

Once CD is set up this will be updated automatically just like it is
now for `dev` environment.
