### PR TITLE
If no value for "indexer" CLI flag, then read from config

### DIFF
--- a/command/admin.go
+++ b/command/admin.go
@@ -49,7 +49,7 @@ var AdminCmd = &cli.Command{
 }
 
 func syncCmd(cctx *cli.Context) error {
-	cl, err := httpclient.New(cctx.String("indexer"))
+	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func syncCmd(cctx *cli.Context) error {
 }
 
 func allowCmd(cctx *cli.Context) error {
-	cl, err := httpclient.New(cctx.String("indexer"))
+	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func allowCmd(cctx *cli.Context) error {
 }
 
 func blockCmd(cctx *cli.Context) error {
-	cl, err := httpclient.New(cctx.String("indexer"))
+	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func blockCmd(cctx *cli.Context) error {
 }
 
 func reloadPolicyCmd(cctx *cli.Context) error {
-	cl, err := httpclient.New(cctx.String("indexer"))
+	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err
 	}

--- a/command/find.go
+++ b/command/find.go
@@ -46,7 +46,7 @@ func findCmd(cctx *cli.Context) error {
 
 	switch protocol {
 	case "http":
-		cl, err = httpclient.New(cctx.String("indexer"))
+		cl, err = httpclient.New(cliIndexer(cctx, "finder"))
 		if err != nil {
 			return err
 		}
@@ -61,7 +61,7 @@ func findCmd(cctx *cli.Context) error {
 			return err
 		}
 
-		err = c.Connect(cctx.Context, cctx.String("indexer"))
+		err = c.Connect(cctx.Context, cliIndexer(cctx, "finder"))
 		if err != nil {
 			return err
 		}

--- a/command/flags.go
+++ b/command/flags.go
@@ -275,6 +275,15 @@ func cliIndexer(cctx *cli.Context, addrType string) string {
 		return idxr
 	}
 
+	idxr = indexerHost(addrType)
+	if idxr != "" {
+		return idxr
+	}
+
+	return "localhost"
+}
+
+func indexerHost(addrType string) string {
 	// No indexer given on command line, get from config.
 	cfg, err := config.Load("")
 	if err != nil {

--- a/command/flags.go
+++ b/command/flags.go
@@ -1,6 +1,10 @@
 package command
 
 import (
+	"fmt"
+
+	"github.com/filecoin-project/storetheindex/config"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )
@@ -11,7 +15,6 @@ var indexerHostFlag = altsrc.NewStringFlag(&cli.StringFlag{
 	EnvVars:  []string{"INDEXER"},
 	Aliases:  []string{"i"},
 	Required: false,
-	Value:    "localhost",
 })
 
 var cacheSizeFlag = &cli.Int64Flag{
@@ -263,4 +266,50 @@ var syntheticFlags = []cli.Flag{
 		Aliases:  []string{"s"},
 		Required: false,
 	},
+}
+
+// cliIndexer reads the indexer host from CLI flag or from config.
+func cliIndexer(cctx *cli.Context, addrType string) string {
+	idxr := cctx.String("indexer")
+	if idxr != "" {
+		return idxr
+	}
+
+	// No indexer given on command line, get from config.
+	cfg, err := config.Load("")
+	if err != nil {
+		return ""
+	}
+	if cfg.Addresses.Finder == "" {
+		return ""
+	}
+	var maddr multiaddr.Multiaddr
+	switch addrType {
+	case "finder":
+		maddr, err = multiaddr.NewMultiaddr(cfg.Addresses.Finder)
+	case "admin":
+		maddr, err = multiaddr.NewMultiaddr(cfg.Addresses.Admin)
+	case "ingest":
+		maddr, err = multiaddr.NewMultiaddr(cfg.Addresses.Ingest)
+	default:
+		return ""
+	}
+	if err != nil {
+		return ""
+	}
+	return multiaddrHost(maddr)
+}
+
+func multiaddrHost(maddr multiaddr.Multiaddr) string {
+	for _, proto := range []int{multiaddr.P_IP4, multiaddr.P_IP6} {
+		addr, err := maddr.ValueForProtocol(proto)
+		if err == nil {
+			port, err := maddr.ValueForProtocol(multiaddr.P_TCP)
+			if err == nil {
+				addr = fmt.Sprint(addr, ":", port)
+			}
+			return addr
+		}
+	}
+	return ""
 }

--- a/command/import.go
+++ b/command/import.go
@@ -43,7 +43,7 @@ var ImportCmd = &cli.Command{
 func importListCmd(cctx *cli.Context) error {
 	// NOTE: Importing manually from CLI only supported for http protocol
 	// for now. This feature is mainly for testing purposes
-	cl, err := httpclient.New(cctx.String("indexer"))
+	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func importCarCmd(c *cli.Context) error {
 }
 
 func importManifestCmd(cctx *cli.Context) error {
-	cl, err := httpclient.New(cctx.String("indexer"))
+	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err
 	}

--- a/command/providers.go
+++ b/command/providers.go
@@ -33,7 +33,7 @@ var list = &cli.Command{
 }
 
 func getProvidersCmd(cctx *cli.Context) error {
-	cl, err := httpclient.New(cctx.String("indexer"))
+	cl, err := httpclient.New(cliIndexer(cctx, "finder"))
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func getProvidersCmd(cctx *cli.Context) error {
 }
 
 func listProvidersCmd(cctx *cli.Context) error {
-	cl, err := httpclient.New(cctx.String("indexer"))
+	cl, err := httpclient.New(cliIndexer(cctx, "finder"))
 	if err != nil {
 		return err
 	}

--- a/command/register.go
+++ b/command/register.go
@@ -30,7 +30,8 @@ func registerCommand(cctx *cli.Context) error {
 		return err
 	}
 
-	client, err := v0client.New(cctx.String("indexer"))
+	indexerHost := cliIndexer(cctx, "admin")
+	client, err := v0client.New(indexerHost)
 	if err != nil {
 		return err
 	}
@@ -40,6 +41,6 @@ func registerCommand(cctx *cli.Context) error {
 		return fmt.Errorf("failed to register providers: %s", err)
 	}
 
-	fmt.Println("Registered provider", cfg.Identity.PeerID, "at indexer", cctx.String("indexer"))
+	fmt.Println("Registered provider", cfg.Identity.PeerID, "at indexer", indexerHost)
 	return nil
 }


### PR DESCRIPTION
This removes the need to specify the `indexer` CLI flag when running commands against a local indexer.

Usually, the indexer listens on a port other than 80, but if the `indexer` flag is not specified for CLI commands, then localhost:80 is used as the default.  This PR changes CLI the behavior so that when no `indexer` flag is given, the value is read from the config file if available.  Depending on the command, either the finder address or the admin address is read.
