### PR TITLE
Update storethehash to get index recovery fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.2.14
+	github.com/filecoin-project/go-indexer-core v0.2.15
 	github.com/filecoin-project/go-legs v0.3.12
 	github.com/frankban/quicktest v1.14.2
 	github.com/gogo/protobuf v1.3.2
@@ -103,7 +103,7 @@ require (
 	github.com/ipfs/go-unixfs v0.3.1 // indirect
 	github.com/ipfs/go-verifcid v0.0.1 // indirect
 	github.com/ipld/go-codec-dagpb v1.3.1 // indirect
-	github.com/ipld/go-storethehash v0.1.4 // indirect
+	github.com/ipld/go-storethehash v0.1.5 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/filecoin-project/go-data-transfer v1.15.1/go.mod h1:dXsUoDjR9tKN7aV6R
 github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.2.14 h1:W4UNtv6k0Cf/zt0ku9Pdmztr/7Qj65ZK7a8j+8F/794=
-github.com/filecoin-project/go-indexer-core v0.2.14/go.mod h1:7lK4Rl2obOK34KlCsI2RaKgNtKbeOpj1YoZrQFV6ar8=
+github.com/filecoin-project/go-indexer-core v0.2.15 h1:oT1W98tJnT83cv9VvbhCmI18LU2kOCIddyYDek1AN9g=
+github.com/filecoin-project/go-indexer-core v0.2.15/go.mod h1:7TD8AtIESAjIC1dd6avC2pvAyN/7edlQYsLexRrlI1w=
 github.com/filecoin-project/go-legs v0.3.12 h1:bxmV0y2WM2ERVJWk4fgWkuELpcjI0QHERMPK3ULOaOY=
 github.com/filecoin-project/go-legs v0.3.12/go.mod h1:Ve7iMWBvXm8yQ7k07RFjPkbFsi9wrsCqixV2oWIfkWM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -643,8 +643,8 @@ github.com/ipld/go-ipld-prime v0.16.0 h1:RS5hhjB/mcpeEPJvfyj0qbOj/QL+/j05heZ0qa9
 github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHPT2PjoiiU1qA=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.1.4 h1:U+GcNgT1/yQBqsQ3FfFkXp2gWq5IdL4OlspZeCYXRSQ=
-github.com/ipld/go-storethehash v0.1.4/go.mod h1:WJ8RJptWUJTVFQ2TtRdNVi3iQnOm6LXjqQF3wPr3ta8=
+github.com/ipld/go-storethehash v0.1.5 h1:ccdqepFiu/ek4wc1eplUcXsV7pnOQ1hup7Jp5IDQbFM=
+github.com/ipld/go-storethehash v0.1.5/go.mod h1:WJ8RJptWUJTVFQ2TtRdNVi3iQnOm6LXjqQF3wPr3ta8=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.4.8"
+  "version": "v0.4.9"
 }


### PR DESCRIPTION
## Context
Update storethehash to version with buffer flushing and corrupted index recovery logic.

## Proposed Changes
Storethehash was susceptible to corruption due to unflushed write buffers during non-graceful termination.  This parblem has been addressed, and code has been added to recover from corrupted index or primary.

## Tests
Unit tests included with storethehash

## Revert Strategy
Safe to revert