### PR TITLE
Scale up `dev` to 2 instances

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-1-identity.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-1-identity.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:n10oiHobvByLikWB5eXu93iUkk/KrbAQy26wWBNSjkSmiSo/8ttZoc2II1kWoYr01y7cFJ1QwTnNaYfDm4VVnIu3znc=,iv:aRvNUc3oygwJnrEYrSDIpsfyTqj93XiPby++GHOq3F4=,tag:qILPN3/cznHsQpJLgF+qfg==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2022-04-22T09:12:59Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAHeKyjdaIS3sdQ+pWfPiWtXAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMAw7ucumP7Rs0ARM3AgEQgDsjii6vnzPto0ZLdQf5wDAExv+vlEGTJT+q0V5IA/60ClOk7vVFMwGBA9AnyNCS1+njYYwrOqLpBtLRRQ==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-04-22T09:13:01Z",
+		"mac": "ENC[AES256_GCM,data:ShURvwpDPzf7PPOl1TcfyqaOlakaFE3jTC6zIxdYWM5WVOABCTBRq5XPZudb7SVVciWRzVsciDSvevP6tz1uu9E0J+1WpCa7U2t264MXBQZHOyaNeAiV7fG+mXxpqEHvxk9zKDjO29kxo7ujtLkletilG/9rjkpGulJ/zBGw8Cw=,iv:GNPFsHY+BCFMStssZx4p6fuxoweoR6FVLOhbUg1kewk=,tag:hGymhfaE8FwvtFts49d4Hg==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -12,6 +12,10 @@ secretGenerator:
 - name: indexer-identity
   files:
   - indexer-0.key=indexer-0-identity.encrypted
+  - indexer-1.key=indexer-1-identity.encrypted
+replicas:
+- name: indexer
+  count: 2
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
In order to match the number of replicas running in `prod` environment
and provide better resilience against AZ failure.

