### PR TITLE
Configure image update automation for `prod`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,9 @@
-name: Dev CD
+name: CD
 on:
   push:
     branches:
       - 'cd/dev'
+      - 'cd/prod'
 
 jobs:
   pull-request:
@@ -15,21 +16,25 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const head = process.env.GITHUB_REF_NAME;
+            const env = context.ref.replace(/cd\//g, '');
+            core.info(`Checking branch '${head}' for automated deployment to '${env}' environment...`);
+            
             const { repo, owner } = context.repo;
             try {
               const result = await github.rest.pulls.create({
-                title: 'Deploy latest to `dev` environment',
+                title: `Deploy latest to \`${env}\` environment`,
                 owner,
                 repo,
-                head: 'cd/dev',
+                head,
                 base: 'main',
-                body: 'Approve changes to trigger the latest deployment to `dev` environment'
+                body: `Approve changes and merge this PR to trigger deployment to \`${env}\` environment.`
               });
               await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: result.data.number,
-                labels: ['cd', 'env:dev']
+                labels: ['cd', `env:${env}`]
               });
             } catch (e) {
               if (!e.message.includes('A pull request already exists')) {

--- a/deploy/manifests/prod/us-east-2/cluster/storetheindex/flux-cd.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/storetheindex/flux-cd.yaml
@@ -7,7 +7,8 @@ spec:
   url: https://github.com/filecoin-project/storetheindex.git
   ref:
     branch: main
-
+  secretRef:
+    name: github-auth
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
@@ -30,5 +31,62 @@ kind: ImageRepository
 metadata:
   name: storetheindex
 spec:
-  interval: 10m
+  interval: 5m
   image: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1alpha1
+kind: ImagePolicy
+metadata:
+  name: storetheindex
+spec:
+  # Filter tags that match a concrete semver format.
+  filterTags:
+    pattern: '^\d+\.\d+\.\d+$'
+  policy:
+    # Select the latest semver in any range.
+    semver:
+      range: '*'
+  imageRepositoryRef:
+    name: storetheindex
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: storetheindex
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: storetheindex
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        name: sti-bot
+        email: sti-bot@protocol.ai
+      messageTemplate: |
+        Update {{ .AutomationObject.Namespace }}/{{ .AutomationObject.Name }} in `prod` environment
+        
+        Files:
+        {{ range $filename, $_ := .Updated.Files -}}
+        - {{ $filename }}
+        {{ end -}}
+        
+        Objects:
+        {{ range $resource, $_ := .Updated.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+        
+        Images:
+        {{ range .Updated.Images -}}
+        - {{.}}
+        {{ end -}}
+    push:
+      branch: 'cd/prod'
+  update:
+    strategy: Setters
+    path: "./deploy/manifests/prod/us-east-2/tenant/storetheindex"

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/github-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/github-auth.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: github-auth
+    namespace: storetheindex
+type: Opaque
+stringData:
+    username: ENC[AES256_GCM,data:FV7UM7smcQ==,iv:KDOCoqYik7QuEJu350jY1hVOtcBSeMcx+jgTEKdJbtg=,tag:vn9XVCJcPRsZy2zcq8pbHw==,type:str]
+    password: ENC[AES256_GCM,data:z16wzRK4fVj+tt+oCr87UusQMZkWyiSgTDMa6M/nvJI/N3S/KzRPPQ==,iv:mHwC3Z97Uso2P4r3PUBphdxBLlr8AGXH4j7aROmnklQ=,tag:mZaVcCq+ozjK9tcorhZk7w==,type:str]
+sops:
+    kms:
+        - arn: arn:aws:kms:us-east-2:407967248065:alias/prod/us-east-2/sti
+          created_at: "2022-04-22T10:59:40Z"
+          enc: AQICAHjmLCaDZ4fRYyty7669VvFjJmy9C7/Y4dwd6seUJHRobwFHge/an1wdNjSNfk7R5+mAAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQgpJZni4bPmQUpoPAgEQgDt9Wa4ieicIH+xNyjuayLNrRvnYqJdkgyQovN61SukaLvNaYG2hL5eNIcH83c1Dtw00nRVAujRdL43Q8w==
+          aws_profile: ""
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-04-22T10:59:41Z"
+    mac: ENC[AES256_GCM,data:d0pQvrFnnWDo1D6gjt95OF9Y9RrM9eQz9UUQxjg9DA/ZK94XWkjGKUPwZgjq8goLe8KZ3roGthRCzLhH5AYCRCFwrEMfQr/LG3Bg7J4jGjqCkcqJpIKp4kYIcOA+v+JfiqOs/krqcNRJEJYqptw1Aztyn6TnjAMXHgKEnOXotNk=,iv:8l2XBuNtuBAky/uQt3Z0ZzfFxjNyR433fC4KxWPMpKw=,tag:+ryJyCT8jq90DWcEanH5+g==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.2

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -1,29 +1,22 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: storetheindex
-
 resources:
-  - ../../../../base/storetheindex
-  - ingress.yaml
-  - pod-monitor.yaml
-
+- ../../../../base/storetheindex
+- ingress.yaml
+- pod-monitor.yaml
+- github-auth.yaml
 patchesStrategicMerge:
-  - patch-indexer.yaml
-
-replicas:
-  - name: indexer
-    count: 2
-
+- patch-indexer.yaml
 secretGenerator:
-  - name: indexer-identity
-    files:
-      - indexer-0.key=indexer-0-identity.encrypted
-      - indexer-1.key=indexer-1-identity.encrypted
-
-# This is to keep the production deployment unchanged as a result of base overlay changes until it 
-# is automated like dev. 
+- name: indexer-identity
+  files:
+  - indexer-0.key=indexer-0-identity.encrypted
+  - indexer-1.key=indexer-1-identity.encrypted
+replicas:
+- name: indexer
+  count: 2
 images:
-  - name: storetheindex
-    newName: filecoin/storetheindex
-    newTag: 1b16c2dd77b55cb83be99410b514068e059b952d
+- name: storetheindex
+  newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
+  newTag: 0.4.10 # {"$imagepolicy": "storetheindex:storetheindex:tag"}


### PR DESCRIPTION
## Context
Automate image update and deployment PR for `prod`.

## Proposed Changes

Configure an image update automation mechanism, so that it:
- scans the ECR repo for image tags in semver format
- updates the image tag of `prod` Kustomization with the latest found
  semver
- commits the changes to `cd/prod` branch
- opens a PR, the merge of which would result in the rollout of that
  semver to `prod` environment.

## Tests
Manually tested.

## Revert Strategy
`git revert`