### PR TITLE
Fix regex replacement in automated PR creation template

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           script: |
             const head = process.env.GITHUB_REF_NAME;
-            const env = context.ref.replace(/cd\//g, '');
+            const env = head.replace(/cd\//g, '');
             core.info(`Checking branch '${head}' for automated deployment to '${env}' environment...`);
             
             const { repo, owner } = context.repo;


### PR DESCRIPTION
Use branch name instead of full ref to extract environment name

