### PR TITLE
Log and config update

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -155,7 +155,7 @@ var adminSyncFlags = []cli.Flag{
 	},
 	&cli.Int64Flag{
 		Name:  "depth",
-		Usage: "Depth limit of advertisements (distance from current) to sync. No limit if unspecified.",
+		Usage: "Depth limit of advertisements (distance from current) to sync. No limit if -1. Unspecified or 0 defaults to indexer config.",
 	},
 	&cli.BoolFlag{
 		Name:  "resync",

--- a/command/init.go
+++ b/command/init.go
@@ -38,15 +38,11 @@ func initCommand(cctx *cli.Context) error {
 			return err
 		}
 		prevVer := cfg.Version
-		upgraded, err := cfg.UpgradeConfig(configFile)
+		err = cfg.UpgradeConfig(configFile)
 		if err != nil {
 			return fmt.Errorf("cannot upgrade: %s", err)
 		}
-		if upgraded {
-			fmt.Println("Upgraded", configFile, "from version", prevVer, "to", cfg.Version)
-		} else {
-			fmt.Println("Config at current version, nothing to upgrade")
-		}
+		fmt.Println("Upgraded", configFile, "from version", prevVer, "to", cfg.Version)
 		return nil
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -121,22 +121,22 @@ func (c *Config) CanUpgrade() bool {
 	return c.Version != version
 }
 
-// UpgradeConfig upgrades (or downgrades) the config file to the current version.
-func (c *Config) UpgradeConfig(filePath string) (bool, error) {
-	if c.Version == version {
-		return false, nil
-	}
+// UpgradeConfig upgrades (or downgrades) the config file to the current
+// version. If the config file is at the current version a backup is still
+// created and the config rewritten with any unconfigured values set to their
+// defaults.
+func (c *Config) UpgradeConfig(filePath string) error {
 	prevName := fmt.Sprintf("%s.v%d", filePath, c.Version)
 	err := os.Rename(filePath, prevName)
 	if err != nil {
-		return false, err
+		return err
 	}
 	c.Version = version
 	err = c.Save(filePath)
 	if err != nil {
-		return false, err
+		return err
 	}
-	return true, nil
+	return nil
 }
 
 // Save writes the json-serialized config to the specified path.

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -125,7 +126,7 @@ func (c *Config) UpgradeConfig(filePath string) (bool, error) {
 	if c.Version == version {
 		return false, nil
 	}
-	prevName := filePath + ".prev"
+	prevName := fmt.Sprintf("%s.v%d", filePath, c.Version)
 	err := os.Rename(filePath, prevName)
 	if err != nil {
 		return false, err

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -2,19 +2,19 @@ package config
 
 // Datastore tracks the configuration of the datastore.
 type Datastore struct {
-	// Type is the type of datastore.
-	Type string
 	// Dir is the directory where the datastore is kept. If this is not an
 	// absolute path then the location is relative to the indexer repo
 	// directory.
 	Dir string
+	// Type is the type of datastore.
+	Type string
 }
 
 // NewDatastore returns Datastore with values set to their defaults.
 func NewDatastore() Datastore {
 	return Datastore{
-		Type: "levelds",
 		Dir:  "datastore",
+		Type: "levelds",
 	}
 }
 
@@ -22,10 +22,10 @@ func NewDatastore() Datastore {
 func (c *Datastore) populateUnset() {
 	def := NewDatastore()
 
-	if c.Type == "" {
-		c.Type = def.Type
-	}
 	if c.Dir == "" {
 		c.Dir = def.Dir
+	}
+	if c.Type == "" {
+		c.Type = def.Type
 	}
 }

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -8,23 +8,23 @@ import (
 type Indexer struct {
 	// Maximum number of CIDs that cache can hold. Setting to 0 disables cache.
 	CacheSize int
+	// GCInterval configures the garbage collection interval for valuestores
+	// that support it.
+	GCInterval Duration
 	// Directory where value store is kept. If this is not an absolute path
 	// then the location is relative to the indexer repo directory.
 	ValueStoreDir string
 	// Type of valuestore to use, such as "sth" or "pogreb".
 	ValueStoreType string
-	// GCInterval configures the garbage collection interval for valuestores
-	// that support it.
-	GCInterval Duration
 }
 
 // NewIndexer returns Indexer with values set to their defaults.
 func NewIndexer() Indexer {
 	return Indexer{
 		CacheSize:      300000,
+		GCInterval:     Duration(30 * time.Minute),
 		ValueStoreDir:  "valuestore",
 		ValueStoreType: "sth",
-		GCInterval:     Duration(30 * time.Minute),
 	}
 }
 
@@ -35,13 +35,13 @@ func (c *Indexer) populateUnset() {
 	if c.CacheSize == 0 {
 		c.CacheSize = def.CacheSize
 	}
+	if c.GCInterval == 0 {
+		c.GCInterval = def.GCInterval
+	}
 	if c.ValueStoreDir == "" {
 		c.ValueStoreDir = def.ValueStoreDir
 	}
 	if c.ValueStoreType == "" {
 		c.ValueStoreType = def.ValueStoreType
-	}
-	if c.GCInterval == 0 {
-		c.GCInterval = def.GCInterval
 	}
 }

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -7,12 +7,14 @@ import (
 // Ingest tracks the configuration related to the ingestion protocol.
 type Ingest struct {
 	// The recursion depth limit when syncing advertisements. The value -1
-	// means no limit and zero means use the default value. This prupose is to
-	// prevent overload from endless advertisement chains.
+	// means no limit and zero means use the default value. Limiting the depth
+	// of advertisements can be done if there is a need to prevent an indexer
+	// from ingesting long chains of advertisements.
 	AdvertisementDepthLimit int
 	// The recursion depth limit when syncing advertisement entries. The value
-	// -1 means no limit and zero means use the default value. This prupose is
-	// to prevent overload from endless entries chains.
+	// -1 means no limit and zero means use the default value. The purpose is
+	// to prevent overload from extremely long entry chains resulting from
+	// publisher misconfiguration.
 	EntriesDepthLimit int
 	// How many ingest worker goroutines to spawn. This controls how many
 	// concurrent ingest from different providers we can handle.
@@ -20,8 +22,8 @@ type Ingest struct {
 	// PubSubTopic used to advertise ingestion announcements.
 	PubSubTopic string
 	// StoreBatchSize is the number of entries in each write to the value
-	// store.  Specifying a value less than 2 disables batching. This should
-	// be smaller than the maximum number of multihashes in an entry block to
+	// store. Specifying a value less than 2 disables batching. This should be
+	// smaller than the maximum number of multihashes in an entry block to
 	// write concurrently to the value store.
 	StoreBatchSize int
 	// SyncTimeout is the maximum amount of time allowed for a sync to complete
@@ -34,7 +36,7 @@ type Ingest struct {
 // NewIngest returns Ingest with values set to their defaults.
 func NewIngest() Ingest {
 	return Ingest{
-		AdvertisementDepthLimit: 65536,
+		AdvertisementDepthLimit: -1,
 		EntriesDepthLimit:       65536,
 		IngestWorkerCount:       10,
 		PubSubTopic:             "/indexer/ingest/mainnet",

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -36,7 +36,7 @@ type Ingest struct {
 // NewIngest returns Ingest with values set to their defaults.
 func NewIngest() Ingest {
 	return Ingest{
-		AdvertisementDepthLimit: -1,
+		AdvertisementDepthLimit: 33554432,
 		EntriesDepthLimit:       65536,
 		IngestWorkerCount:       10,
 		PubSubTopic:             "/indexer/ingest/mainnet",

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -6,30 +6,40 @@ import (
 
 // Ingest tracks the configuration related to the ingestion protocol.
 type Ingest struct {
+	// The recursion depth limit when syncing advertisements. The value -1
+	// means no limit and zero means use the default value. This prupose is to
+	// prevent overload from endless advertisement chains.
+	AdvertisementDepthLimit int
+	// The recursion depth limit when syncing advertisement entries. The value
+	// -1 means no limit and zero means use the default value. This prupose is
+	// to prevent overload from endless entries chains.
+	EntriesDepthLimit int
+	// How many ingest worker goroutines to spawn. This controls how many
+	// concurrent ingest from different providers we can handle.
+	IngestWorkerCount int
 	// PubSubTopic used to advertise ingestion announcements.
 	PubSubTopic string
 	// StoreBatchSize is the number of entries in each write to the value
-	// store.  Specifying a value less than 2 disables batching.  This should
+	// store.  Specifying a value less than 2 disables batching. This should
 	// be smaller than the maximum number of multihashes in an entry block to
 	// write concurrently to the value store.
 	StoreBatchSize int
 	// SyncTimeout is the maximum amount of time allowed for a sync to complete
 	// before it is canceled. This can be a sync of a chain of advertisements
-	// or a chain of advertisement entries.  The value is an integer string
+	// or a chain of advertisement entries. The value is an integer string
 	// ending in "s", "m", "h" for seconds. minutes, hours.
 	SyncTimeout Duration
-	// How many ingest worker goroutines to spawn. This controls how many
-	// concurrent ingest from different providers we can handle.
-	IngestWorkerCount int
 }
 
 // NewIngest returns Ingest with values set to their defaults.
 func NewIngest() Ingest {
 	return Ingest{
-		PubSubTopic:       "/indexer/ingest/mainnet",
-		StoreBatchSize:    4096,
-		SyncTimeout:       Duration(2 * time.Hour),
-		IngestWorkerCount: 10,
+		AdvertisementDepthLimit: 65536,
+		EntriesDepthLimit:       65536,
+		IngestWorkerCount:       10,
+		PubSubTopic:             "/indexer/ingest/mainnet",
+		StoreBatchSize:          4096,
+		SyncTimeout:             Duration(2 * time.Hour),
 	}
 }
 
@@ -37,6 +47,15 @@ func NewIngest() Ingest {
 func (c *Ingest) populateUnset() {
 	def := NewIngest()
 
+	if c.AdvertisementDepthLimit == 0 {
+		c.AdvertisementDepthLimit = def.AdvertisementDepthLimit
+	}
+	if c.EntriesDepthLimit == 0 {
+		c.EntriesDepthLimit = def.EntriesDepthLimit
+	}
+	if c.IngestWorkerCount == 0 {
+		c.IngestWorkerCount = def.IngestWorkerCount
+	}
 	if c.PubSubTopic == "" {
 		c.PubSubTopic = def.PubSubTopic
 	}
@@ -45,8 +64,5 @@ func (c *Ingest) populateUnset() {
 	}
 	if c.SyncTimeout == 0 {
 		c.SyncTimeout = def.SyncTimeout
-	}
-	if c.IngestWorkerCount == 0 {
-		c.IngestWorkerCount = def.IngestWorkerCount
 	}
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -43,11 +43,11 @@ const (
 
 type adProcessedEvent struct {
 	publisher peer.ID
-	// The head of the chain we're proecessing.
+	// Head of the chain being proecessed.
 	headAdCid cid.Cid
-	// The actual adCid we're processing.
+	// Actual adCid being processing.
 	adCid cid.Cid
-	// if not nil we failed to process the ad for adCid
+	// A non-nil value indicates failure to process the ad for adCid.
 	err error
 }
 
@@ -85,12 +85,13 @@ type Ingester struct {
 
 	cancelOnSyncFinished context.CancelFunc
 
-	// A map of providers currently being processed. A worker holds the lock of a
-	// provider while ingesting ads for that provider.
+	// A map of providers currently being processed. A worker holds the lock of
+	// a provider while ingesting ads for that provider.
 	providersBeingProcessed   map[peer.ID]*sync.Mutex
 	providersBeingProcessedMu sync.Mutex
 	providerAdChainStaging    map[peer.ID]*atomic.Value
-	// toWorkers is a channel used to ask the worker pool to start processing the ad chain for a given provider
+	// toWorkers is a channel used to ask the worker pool to start processing
+	// the ad chain for a given provider
 	toWorkers      chan providerID
 	closeWorkers   chan struct{}
 	waitForWorkers sync.WaitGroup
@@ -103,9 +104,9 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 	lsys := mkLinkSystem(ds, reg)
 
 	// Construct a selector that recursively looks for nodes with field
-	// "PreviousID" as per Advertisement schema.  Note that the entries within
-	// an advertisement are synced separately triggered by storage hook, so
-	// that we can check if a chain of chunks exist already before syncing it.
+	// "PreviousID" as per Advertisement schema. Note that the entries within
+	// an advertisement are synced separately, triggered by storage hook. This
+	// allows checking if a chain of chunks already exists before syncing it.
 	ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
 	adSel := ssb.ExploreFields(
 		func(efsb builder.ExploreFieldsSpecBuilder) {
@@ -139,8 +140,8 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 		closeWorkers:            make(chan struct{}),
 	}
 
-	// Create and start pubsub subscriber.  This also registers the storage
-	// hook to index data as it is received.
+	// Create and start pubsub subscriber. This also registers the storage hook
+	// to index data as it is received.
 	sub, err := legs.NewSubscriber(h, ds, lsys, cfg.PubSubTopic, adSel, legs.AllowPeer(reg.Allowed), legs.SyncRecursionLimit(recursionLimit(cfg.AdvertisementDepthLimit)), legs.UseLatestSyncHandler(&syncHandler{ing}))
 	if err != nil {
 		log.Errorw("Failed to start pubsub subscriber", "err", err)
@@ -198,13 +199,13 @@ func (ing *Ingester) Close() error {
 }
 
 // Sync syncs advertisements, up to the the latest advertisement, from a
-// publisher.  A channel is returned that gives the caller the option to wait
-// for Sync to complete.  The channel returns the final CID that was synced by
+// publisher. A channel is returned that gives the caller the option to wait
+// for Sync to complete. The channel returns the final CID that was synced by
 // the call to Sync.
 //
 // Sync works by first fetching each advertisement from the specidief peer
 // starting at the most recent and traversing to the advertisement last seen by
-// the indexer, or until the advertisement depth limit is reached.  Then the
+// the indexer, or until the advertisement depth limit is reached. Then the
 // entries in each advertisement are synced and the multihashes in each entry
 // are indexed.
 //
@@ -212,8 +213,8 @@ func (ing *Ingester) Close() error {
 // parameters: depth, and resync.
 //
 // The depth argument specifies the recursion depth limit to use during sync.
-// Its value may less than 1 for no limit, or greater than 1 for an explicit
-// limit.
+// Its value may less than -1 for no limit, 0 to use the indexer's configured
+// value, or greater than 1 for an explicit limit.
 //
 // The resync argument specifies whether to stop the traversal at the latest
 // known advertisement that is already synced. If set to true, the traversal
@@ -225,8 +226,8 @@ func (ing *Ingester) Close() error {
 // false. Otherwise, a custom selector with the given depth limit and stop link
 // is constructed and used for traversal. See legs.Subscriber.Sync.
 //
-// The Context argument controls the lifetime of the sync.  Canceling it
-// cancels the sync and causes the multihash channel to close without any data.
+// The Context argument controls the lifetime of the sync. Canceling it cancels
+// the sync and causes the multihash channel to close without any data.
 func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Multiaddr, depth int, resync bool) (<-chan cid.Cid, error) {
 	if err := peerID.Validate(); err != nil {
 		return nil, err
@@ -243,8 +244,8 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 		log.Info("Explicitly syncing the latest advertisement from peer")
 
 		var sel ipld.Node
-		// If depth is non-zero or traversal should not stop at the latest synced, then construct a
-		// selector to behave accordingly.
+		// If depth is non-zero or traversal should not stop at the latest
+		// synced, then construct a selector to behave accordingly.
 		if depth != 0 || resync {
 			var err error
 			sel, err = ing.makeLimitedDepthSelector(peerID, depth, resync)
@@ -264,7 +265,7 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 		}
 
 		// Start syncing. Notifications for the finished sync are sent
-		// asynchronously.  Sync with cid.Undef so that the latest head is
+		// asynchronously. Sync with cid.Undef so that the latest head is
 		// queried by go-legs via head-publisher.
 		//
 		// Note that if the selector is nil the default selector is used where
@@ -278,7 +279,7 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 		if resync {
 			// If this is a resync, then it is necessary to mark the ad as
 			// unprocessed so that everything can be reingested from the start
-			// of this sync.  Create a scoped block-hook to do this.
+			// of this sync. Create a scoped block-hook to do this.
 			opts = append(opts, legs.ScopedBlockHook(func(i peer.ID, c cid.Cid) {
 				err := ing.markAdUnprocessed(c)
 				if err != nil {
@@ -291,11 +292,11 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 			log.Errorw("Failed to sync with provider", "err", err)
 			return
 		}
-		// Do not persist the latest sync here, because that is done in
-		// after we've processed the ad.
+		// Do not persist the latest sync here, because that is done after
+		// processing the ad.
 
-		// If latest head had already finished syncing, then do not wait
-		// for syncDone since it will never happen.
+		// If latest head had already finished syncing, then do not wait for
+		// syncDone since it will never happen.
 		if latest == c && !resync {
 			log.Infow("Latest advertisement already processed", "adCid", c)
 			out <- c
@@ -308,10 +309,10 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 			case adProcessedEvent := <-syncDone:
 				log.Debugw("Synced advertisement", "adCid", adProcessedEvent.adCid)
 				if adProcessedEvent.adCid == c || adProcessedEvent.err != nil && adProcessedEvent.headAdCid == c {
-					// If we had an error than the adProcessedEvent.adCid will be the cid
-					// that caused the error, and we won't get any future
-					// adProcessedEvents. Therefore we check the headAdCid to see if this
-					// was the sync we started.
+					// If an error occurred then the adProcessedEvent.adCid
+					// will be the cid that caused the error, and there will
+					// not be any future adProcessedEvents. Therefore check the
+					// headAdCid to see if this was the sync that was started.
 					out <- c
 					ing.signalMetricsUpdate()
 					return
@@ -328,7 +329,8 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 	return out, nil
 }
 
-// Announce send an annouce message to directly to go-legs, instead of through pubsub.
+// Announce send an annouce message to directly to go-legs, instead of through
+// pubsub.
 func (ing *Ingester) Announce(ctx context.Context, nextCid cid.Cid, addrInfo peer.AddrInfo) error {
 	log.Infow("Handling direct announce request", "peer", addrInfo.ID)
 	return ing.sub.Announce(ctx, nextCid, addrInfo.ID, addrInfo.Addrs)
@@ -365,14 +367,14 @@ func (ing *Ingester) makeLimitedDepthSelector(peerID peer.ID, depth int, resync 
 }
 
 // markAdUnprocessed takes an advertisement CID and marks it as
-// unprocessed. This lets the ad be re-ingested in case we want to re-ingest
-// with different depths or are processing even earlier ads and need to
-// reprocess later ones so that the indexer re-ingests the later ones in the
-// context of the earlier ads, and thus become consistent.
+// unprocessed. This lets the ad be re-ingested in case we re-ingesting with
+// different depths or are processing even earlier ads and need to reprocess
+// later ones so that the indexer re-ingests the later ones in the context of
+// the earlier ads, and thus become consistent.
 //
 // During a sync, this should be called be in order from newest to oldest
-// ad. This is so that if an something fails to get marked as unprocessed we
-// still hold the constraint that if an ad is processed, all older ads are also
+// ad. This is so that if an something fails to get marked as unprocessed the
+// constraint is maintained that if an ad is processed, all older ads are also
 // processed.
 func (ing *Ingester) markAdUnprocessed(adCid cid.Cid) error {
 	return ing.ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+adCid.String()), []byte{0})
@@ -395,7 +397,7 @@ func (ing *Ingester) markAdProcessed(publisher peer.ID, adCid cid.Cid) error {
 	if err != nil {
 		return err
 	}
-	// We've processed this ad, so we can remove it from our datastore.
+	// This ad is processed, so remove it from the datastore.
 	err = ing.ds.Delete(context.Background(), dsKey(adCid.String()))
 	if err != nil {
 		// Log the error, but do not return. Continue on to save the procesed ad.
@@ -404,9 +406,9 @@ func (ing *Ingester) markAdProcessed(publisher peer.ID, adCid cid.Cid) error {
 	return ing.ds.Put(context.Background(), datastore.NewKey(syncPrefix+publisher.String()), adCid.Bytes())
 }
 
-// distributeEvents reads a adProcessedEvent, sent by a peer handler, and copies
-// the event to all channels in outEventsChans. This delivers the event to all
-// onAdProcessed channel readers.
+// distributeEvents reads a adProcessedEvent, sent by a peer handler, and
+// copies the event to all channels in outEventsChans. This delivers the event
+// to all onAdProcessed channel readers.
 func (ing *Ingester) distributeEvents() {
 	for event := range ing.inEvents {
 		// Send update to all change notification channels.
@@ -484,7 +486,7 @@ func (ing *Ingester) signalMetricsUpdate() {
 	}
 }
 
-// metricsUpdate periodically updates metrics.  This goroutine exits when the
+// metricsUpdate periodically updates metrics. This goroutine exits when the
 // sigUpdate channel is closed, when Close is called.
 func (ing *Ingester) metricsUpdater() {
 	hasUpdate := true
@@ -553,7 +555,8 @@ type adInfo struct {
 }
 
 type workerAssignment struct {
-	// none represents a nil assignment. Used because we can't store nil in atomic.Value.
+	// none represents a nil assignment. Used because a nil in atomic.Value
+	// cannot be stored.
 	none      bool
 	adInfos   []adInfo
 	publisher peer.ID
@@ -582,8 +585,9 @@ func (ing *Ingester) runIngestStep(syncFinishedEvent legs.SyncFinished) {
 	// 1. Group the incoming CIDs by provider.
 	adsGroupedByProvider := map[peer.ID][]adInfo{}
 	for _, c := range syncFinishedEvent.SyncedCids {
-		// Group the CIDs by the provider. Most of the time a publisher will only
-		// publish Ads for one provider, but it's possible that an ad chain can include multiple providers.
+		// Group the CIDs by the provider. Most of the time a publisher will
+		// only publish Ads for one provider, but it's possible that an ad
+		// chain can include multiple providers.
 
 		if ing.adAlreadyprocessed(c) {
 			// This ad has been processed so all earlier ads already have been
@@ -627,8 +631,8 @@ func (ing *Ingester) runIngestStep(syncFinishedEvent legs.SyncFinished) {
 		})
 
 		if oldAssignment == nil || oldAssignment.(workerAssignment).none {
-			// No previous run scheduled a worker to handle this provider, so let's
-			// schedule one
+			// No previous run scheduled a worker to handle this provider, so
+			// schedule one.
 			ing.toWorkers <- providerID(p)
 		}
 	}
@@ -646,31 +650,31 @@ func (ing *Ingester) ingestWorker() {
 }
 
 func (ing *Ingester) ingestWorkerLogic(provider peer.ID) {
-
-	// It's assumed that the runIngestStep puts a mutex in this map.
+	// It is assumed that the runIngestStep puts a mutex in this map.
 	ing.providersBeingProcessed[provider].Lock()
 	defer ing.providersBeingProcessed[provider].Unlock()
 
-	// Pull out the assignment for this provider. Note that runIngestStep populates this atomic.Value.
+	// Pull out the assignment for this provider. Note that runIngestStep
+	// populates this atomic.Value.
 	assignmentInterface := ing.providerAdChainStaging[provider].Swap(workerAssignment{none: true})
 	if assignmentInterface == nil || assignmentInterface.(workerAssignment).none {
-		// Note this is here for completeness. This wouldn't happen normally.  We
-		// could get here if someone manually calls this function outside the ingest
-		// loop.
-		// Nothing to do – no assignment.
+		// Note this is here for completeness. This would not happen
+		// normally. Execution could get here if someone manually calls this
+		// function outside the ingest loop. Nothing to do – no assignment.
 		return
 	}
 	assignment := assignmentInterface.(workerAssignment)
 
-	// Filter out ads that we've already processed and any earlier ads
+	// Filter out ads that are already processed, and any earlier ads.
 	splitAtIndex := len(assignment.adInfos)
 	for i, ai := range assignment.adInfos {
-		// iterate latest to earliest
+		// Iterate latest to earliest.
 		if ing.adAlreadyprocessed(ai.cid) {
-			// We've process this ad already, so we know we've processed all
-			// earlier ads too. Break here and split at this index later. The cids
-			// before this index are newer and we haven't processed them, the cids
-			// after are older and we already have processed them.
+			// This ad is already processed, which means that all earlier ads
+			// are also processed. Break here and split at this index
+			// later. The cids before this index are newer and have not been
+			// processed yet; the cids after are older and have already been
+			// processed.
 			splitAtIndex = i
 			break
 		}
@@ -679,7 +683,7 @@ func (ing *Ingester) ingestWorkerLogic(provider peer.ID) {
 	log.Infow("Running worker on ad stack", "headAdCid", assignment.adInfos[0].cid, "publisher", assignment.publisher, "numAdsToProcess", splitAtIndex)
 	var count int
 	for i := splitAtIndex - 1; i >= 0; i-- {
-		// Note that we are iterating backwards here. Earliest to newest.
+		// Note that iteration proceeds backwards here. Earliest to newest.
 		ai := assignment.adInfos[i]
 
 		count++
@@ -690,7 +694,7 @@ func (ing *Ingester) ingestWorkerLogic(provider peer.ID) {
 
 		err := ing.ingestAd(assignment.publisher, ai.cid, ai.ad)
 		if err == nil {
-			// No error at all, we processed this ad successfully.
+			// No error at all, this ad was processed successfully.
 			stats.Record(context.Background(), metrics.AdIngestSuccessCount.M(1))
 		}
 
@@ -716,8 +720,8 @@ func (ing *Ingester) ingestWorkerLogic(provider peer.ID) {
 		if err != nil {
 			log.Errorw("Error while ingesting ad. Bailing early, not ingesting later ads.", "adCid", ai.cid, "publisher", assignment.provider, "err", err, "adsLeftToProcess", i+1)
 
-			// Tell anyone who's waiting that the sync finished for this head because we errored.
-			// TODO(mm) would be better to propagate the error.
+			// Tell anyone waiting that the sync finished for this head because
+			// of error.  TODO(mm) would be better to propagate the error.
 			ing.inEvents <- adProcessedEvent{
 				publisher: assignment.publisher,
 				headAdCid: assignment.adInfos[0].cid,
@@ -740,7 +744,7 @@ func (ing *Ingester) ingestWorkerLogic(provider peer.ID) {
 	}
 }
 
-// recursionLimit returns the recursion limit for the given depth..
+// recursionLimit returns the recursion limit for the given depth.
 func recursionLimit(depth int) selector.RecursionLimit {
 	if depth < 1 {
 		return selector.RecursionLimitNone()

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -73,7 +73,8 @@ func TestSubscribe(t *testing.T) {
 		}}.Build(t, te.publisherLinkSys, te.publisherPriv)
 
 	ctx := context.Background()
-	te.publisher.UpdateRoot(ctx, adHead.(cidlink.Link).Cid)
+	err := te.publisher.UpdateRoot(ctx, adHead.(cidlink.Link).Cid)
+	require.NoError(t, err)
 	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
 	<-wait
@@ -88,7 +89,8 @@ func TestSubscribe(t *testing.T) {
 			{ChunkCount: 10, EntriesPerChunk: 10, EntriesSeed: 3},
 			{ChunkCount: 10, EntriesPerChunk: 10, EntriesSeed: 4},
 		}}.Build(t, te.publisherLinkSys, someOtherProviderPriv)
-	te.publisher.UpdateRoot(ctx, adHead.(cidlink.Link).Cid)
+	err = te.publisher.UpdateRoot(ctx, adHead.(cidlink.Link).Cid)
+	require.NoError(t, err)
 
 	wait, err = te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
@@ -130,7 +132,8 @@ func TestSubscribe(t *testing.T) {
 	te.reg.BlockPeer(te.pubHost.ID())
 	te.reg.BlockPeer(someOtherProvider)
 
-	te.publisher.UpdateRoot(ctx, adHead.(cidlink.Link).Cid)
+	err = te.publisher.UpdateRoot(ctx, adHead.(cidlink.Link).Cid)
+	require.NoError(t, err)
 
 	// We are manually syncing here to not rely on the pubsub mechanism inside a test.
 	// This will fetch the add and put it into our datastore, but will not process it.
@@ -313,7 +316,8 @@ func TestRestartDuringSync(t *testing.T) {
 	te.ingester = ingester
 
 	// And sync to C
-	te.publisher.UpdateRoot(ctx, cCid.(cidlink.Link).Cid)
+	err = te.publisher.UpdateRoot(ctx, cCid.(cidlink.Link).Cid)
+	require.NoError(t, err)
 
 	end, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
@@ -382,7 +386,8 @@ func TestFailDuringSync(t *testing.T) {
 	require.Error(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), bMhs), "bMHs should not be indexed yet")
 
 	// And sync to C
-	te.publisher.UpdateRoot(ctx, cCid.(cidlink.Link).Cid)
+	err = te.publisher.UpdateRoot(ctx, cCid.(cidlink.Link).Cid)
+	require.NoError(t, err)
 
 	end, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
@@ -516,7 +521,8 @@ func TestWithDuplicatedEntryChunks(t *testing.T) {
 
 	ctx := context.Background()
 
-	te.publisher.SetRoot(ctx, chainHead.(cidlink.Link).Cid)
+	err = te.publisher.SetRoot(ctx, chainHead.(cidlink.Link).Cid)
+	require.NoError(t, err)
 
 	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
@@ -549,7 +555,8 @@ func TestSyncWithDepth(t *testing.T) {
 
 	ctx := context.Background()
 
-	te.publisher.SetRoot(ctx, chainHead.(cidlink.Link).Cid)
+	err = te.publisher.SetRoot(ctx, chainHead.(cidlink.Link).Cid)
+	require.NoError(t, err)
 
 	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 1, false)
 	require.NoError(t, err)
@@ -590,7 +597,8 @@ func TestRmWithNoEntries(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	te.publisher.UpdateRoot(context.Background(), chainHead.(cidlink.Link).Cid)
+	err = te.publisher.UpdateRoot(context.Background(), chainHead.(cidlink.Link).Cid)
+	require.NoError(t, err)
 
 	wait, err := te.ingester.Sync(ctx, te.pubHost.ID(), nil, 0, false)
 	require.NoError(t, err)
@@ -671,7 +679,8 @@ func TestReSyncWithDepth(t *testing.T) {
 		},
 	}.Build(t, te.publisherLinkSys, te.publisherPriv)
 
-	te.publisher.SetRoot(context.Background(), adHead.(cidlink.Link).Cid)
+	err := te.publisher.SetRoot(context.Background(), adHead.(cidlink.Link).Cid)
+	require.NoError(t, err)
 	wait, err := te.ingester.Sync(context.Background(), te.pubHost.ID(), te.pubHost.Addrs()[0], 1, false)
 	require.NoError(t, err)
 	<-wait
@@ -708,7 +717,8 @@ func TestSkipEarlierAdsIfAlreadyProcessedLaterAd(t *testing.T) {
 	cLink := allAdLinks[2]
 	allMHs := typehelpers.AllMultihashesFromAdLink(t, adHead, te.publisherLinkSys)
 
-	te.publisher.SetRoot(context.Background(), bLink.(cidlink.Link).Cid)
+	err := te.publisher.SetRoot(context.Background(), bLink.(cidlink.Link).Cid)
+	require.NoError(t, err)
 	wait, err := te.ingester.Sync(context.Background(), te.pubHost.ID(), te.pubHost.Addrs()[0], 0, false)
 	require.NoError(t, err)
 	<-wait
@@ -716,8 +726,10 @@ func TestSkipEarlierAdsIfAlreadyProcessedLaterAd(t *testing.T) {
 	require.NoError(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), allMHs[0:2]))
 	require.Error(t, checkAllIndexed(te.ingester.indexer, te.pubHost.ID(), allMHs[2:]))
 
-	te.ingester.sub.SetLatestSync(te.pubHost.ID(), aLink.(cidlink.Link).Cid)
-	te.publisher.SetRoot(context.Background(), cLink.(cidlink.Link).Cid)
+	err = te.ingester.sub.SetLatestSync(te.pubHost.ID(), aLink.(cidlink.Link).Cid)
+	require.NoError(t, err)
+	err = te.publisher.SetRoot(context.Background(), cLink.(cidlink.Link).Cid)
+	require.NoError(t, err)
 	wait, err = te.ingester.Sync(context.Background(), te.pubHost.ID(), te.pubHost.Addrs()[0], 0, false)
 	require.NoError(t, err)
 	<-wait

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -95,7 +95,7 @@ func verifyAdvertisement(n ipld.Node, reg *registry.Registry) (*schema.Advertise
 		log.Errorw("Cannot decode advertisement", "err", err)
 		return nil, "", errBadAdvert
 	}
-	// Verify advertisement signature
+	// Verify advertisement signature.
 	signerID, err := ad.VerifySignature()
 	if err != nil {
 		// stop exchange, verification of signature failed.
@@ -120,17 +120,17 @@ func verifyAdvertisement(n ipld.Node, reg *registry.Registry) (*schema.Advertise
 	return ad, provID, nil
 }
 
-// ingestEntryChunk determines the logic to run when a new block is received through
-// graphsync.
+// ingestEntryChunk determines the logic to run when a new block is received
+// through graphsync.
 //
 // For a chain of advertisements, the storage hook sees the advertisements from
 // newest to oldest, and starts an entries sync goroutine for each
-// advertisement.  These goroutines each wait for the sync goroutine associated
+// advertisement. These goroutines each wait for the sync goroutine associated
 // with the previous advertisement to complete before beginning their sync for
 // content blocks.
 //
 // When a non-advertisement block is received, it means that the entries sync
-// is running and is collecting content chunks for an advertisement.  Now this
+// is running and is collecting content chunks for an advertisement. Now this
 // hook is being called for each entry in an advertisement's chain of entries.
 // Process the entry and save all the multihashes in it as indexes in the
 // indexer-core.
@@ -145,8 +145,8 @@ func (ing *Ingester) ingestEntryChunk(publisher peer.ID, adCid cid.Cid, ad schem
 	}
 	defer func() {
 		// Remove the content block from the data store now that processing it
-		// has finished.  This prevents storing redundant information in
-		// several datastores.
+		// has finished. This prevents storing redundant information in several
+		// datastores.
 		err := ing.ds.Delete(context.Background(), entryChunkKey)
 		if err != nil {
 			log.Errorw("Error deleting index from datastore", "err", err)
@@ -185,8 +185,8 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		return adIngestError{adIngestDecodingErr, fmt.Errorf("failed to read provider id: %w", err)}
 	}
 
-	// Register provider or update existing registration.  The
-	// provider must be allowed by policy to be registered.
+	// Register provider or update existing registration. The provider must be
+	// allowed by policy to be registered.
 	var pubInfo peer.AddrInfo
 	peerStore := ing.sub.HttpPeerStore()
 	if peerStore != nil {
@@ -275,15 +275,15 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 	return nil
 }
 
-// indexContentBlock indexes the content multihashes in a block of data.  First
-// the advertisement is loaded to get the context ID and metadata.  Then the
+// indexContentBlock indexes the content multihashes in a block of data. First
+// the advertisement is loaded to get the context ID and metadata. Then the
 // metadata and multihashes in the content block are indexed by the
 // indexer-core.
 //
-// The pubID is the peer ID of the message publisher.  This is not necessarily
-// the same as the provider ID in the advertisement.  The publisher is the
+// The pubID is the peer ID of the message publisher. This is not necessarily
+// the same as the provider ID in the advertisement. The publisher is the
 // source of the indexed content, the provider is where content can be
-// retrieved from.  It is the provider ID that needs to be stored by the
+// retrieved from. It is the provider ID that needs to be stored by the
 // indexer.
 func (ing *Ingester) indexContentBlock(adCid cid.Cid, ad schema.Advertisement, pubID peer.ID, nentries ipld.Node) error {
 	log := log.With("publisher", pubID, "adCid", adCid)
@@ -294,7 +294,7 @@ func (ing *Ingester) indexContentBlock(adCid cid.Cid, ad schema.Advertisement, p
 		return fmt.Errorf("cannot decode entries: %w", err)
 	}
 
-	// Load the advertisement data for this chunk.  If there are more chunks to
+	// Load the advertisement data for this chunk. If there are more chunks to
 	// follow, then cache the ad data.
 	value, isRm, err := getAdData(ad)
 	if err != nil {
@@ -413,8 +413,8 @@ func getAdData(ad schema.Advertisement) (value indexer.Value, isRm bool, err err
 
 // decodeIPLDNode decodes an ipld.Node from bytes read from an io.Reader.
 func decodeIPLDNode(codec uint64, r io.Reader, prototype ipld.NodePrototype) (ipld.Node, error) {
-	// NOTE: Considering using the schema prototypes.  This was failing, using
-	// a map gives flexibility.  Maybe is worth revisiting this again in the
+	// NOTE: Considering using the schema prototypes. This was failing, using a
+	// map gives flexibility. Maybe is worth revisiting this again in the
 	// future.
 	nb := prototype.NewBuilder()
 	decoder, err := multicodec.LookupDecoder(codec)
@@ -429,7 +429,7 @@ func decodeIPLDNode(codec uint64, r io.Reader, prototype ipld.NodePrototype) (ip
 }
 
 // Checks if an IPLD node is an advertisement, by looking to see if it has a
-// "Signature" field.  We may need additional checks if we extend the schema
+// "Signature" field. Additional checks may be needed if the schema is extended
 // with new types that are traversable.
 func isAdvertisement(n ipld.Node) bool {
 	indexID, _ := n.LookupByString("Signature")

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -80,7 +80,7 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 	depthStr := query.Get("depth")
 	if depthStr != "" {
 		var err error
-		depth, err = strconv.ParseInt(depthStr, 10, 64)
+		depth, err = strconv.ParseInt(depthStr, 10, 0)
 		if err != nil {
 			log.Errorw("Cannot unmarshal recursion depth as integer", "depthStr", depthStr, "err", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -129,7 +129,7 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 	// Start the sync, but do not wait for it to complete.
 	//
 	// TODO: Provide some way for the client to see if the indexer has synced.
-	_, err = h.ingester.Sync(h.ctx, peerID, syncAddr, depth, resync)
+	_, err = h.ingester.Sync(h.ctx, peerID, syncAddr, int(depth), resync)
 	if err != nil {
 		msg := "Cannot sync with peer"
 		log.Errorw(msg, "err", err)

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -23,10 +23,7 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
-const (
-	providerID = "12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA"
-	protocolID = 0x300000
-)
+const providerID = "12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA"
 
 var rng = rand.New(rand.NewSource(1413))
 


### PR DESCRIPTION
## Context

* Put depth limit settings back into config as means to protect against endless chains.
It may be necessary to have depth limits to protect against unreasonably long chains of advertisements and entries.  Might as well make this configurable, so added them back to config.

* Log publisher of advertisements that fail to parse.
If publishers create advertisements that fail to decode, logs should indicate who that publisher is.

* Upgrading the config works even if config file is at current version.
If items from a config are missing or have been removed so that default values are used, it can be useful to recreate those items in the config file to see what values are available.  This can now be done by running `./storetheindex init --upgrade`  at anytime.

* Config upgrade renames previous config file with version suffix.
* Order config items alphabetically to make them easier to find.
* Remove unused constants and perform additional error checks
