### PR TITLE
Increase memory and CPU for indexer on `prod`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -23,11 +23,11 @@ spec:
               mountPath: /identity
           resources:
             limits:
-              cpu: "1"
-              memory: 10Gi
+              cpu: "2"
+              memory: 25Gi
             requests:
-              cpu: 500m
-              memory: 10Gi
+              cpu: "2"
+              memory: 25Gi
       # Require r5b instance types to run index provider pods.
       tolerations:
         - key: dedicated


### PR DESCRIPTION
Worker node types are r5b.xl which have maximum of 32GB. The nodes are
dedicated to indexer but run other administrative daemonsets, like log
forwarder EBS controller and kubelet nodes.

Leaving some head room for other controllers.

