### PR TITLE
Disable autoscaler in prod to investigate the selection policy

### DIFF
--- a/deploy/manifests/prod/us-east-2/cluster/cluster-autoscaler/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/cluster-autoscaler/kustomization.yaml
@@ -6,3 +6,7 @@ resources:
 
 patchesStrategicMerge:
   - patch.yaml
+
+replicas:
+  - name: cluster-autoscaler
+    count: 0


### PR DESCRIPTION
Extra worker nodes are span up and the ones running indexer get selected
as candidate for eviction. disable the autoscaler while investigating
why.

This will avoid unnecessary re-deployments in the meantime.

