### PR TITLE
Upgrade indexer config base layer

### DIFF
--- a/deploy/manifests/base/storetheindex/config
+++ b/deploy/manifests/base/storetheindex/config
@@ -39,7 +39,7 @@
     "LotusGateway": "wss://api.chain.love",
     "Policy": {
       "Allow": true,
-      "Except": null,
+      "Except": ["QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC"],
       "Publish": true,
       "PublishExcept": null,
       "RateLimit": false,

--- a/deploy/manifests/base/storetheindex/config
+++ b/deploy/manifests/base/storetheindex/config
@@ -1,4 +1,5 @@
 {
+  "Version": 1,
   "Identity": {
     "PeerID": "",
     "PrivKey": ""
@@ -28,7 +29,7 @@
       "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
       "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
     ],
-    "MinimumPeers": 15
+    "MinimumPeers": 4
   },
   "Datastore": {
     "Type": "levelds",
@@ -39,23 +40,28 @@
     "Policy": {
       "Allow": true,
       "Except": null,
-      "Trust": true,
-      "TrustExcept": null
+      "Publish": true,
+      "PublishExcept": null,
+      "RateLimit": false,
+      "RateLimitExcept": null
     },
     "PollInterval": "24h0m0s",
     "PollRetryAfter": "5h0m0s",
     "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
     "RediscoverWait": "5m0s",
     "Timeout": "2m0s"
   },
   "Indexer": {
     "CacheSize": 300000,
     "ValueStoreDir": "/data/valuestore",
-    "ValueStoreType": "sth"
+    "ValueStoreType": "sth",
+    "GCInterval": "30m0s"
   },
   "Ingest": {
     "PubSubTopic": "/indexer/ingest/mainnet",
     "StoreBatchSize": 4096,
-    "SyncTimeout": "2h0m0s"
+    "SyncTimeout": "2h0m0s",
+    "IngestWorkerCount": 10
   }
 }


### PR DESCRIPTION
Upgrade configuration format to the latest, consistent with the config
used in lotus infra deployment. The change is applied to the `base`
overlay which will update the config in both `dev` and `prod`.

See:
- https://github.com/filecoin-project/lotus-infra/blob/master/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml

