### PR TITLE
use default cidlink length

### DIFF
--- a/api/v0/ingest/schema/schema.go
+++ b/api/v0/ingest/schema/schema.go
@@ -35,7 +35,7 @@ var (
 			Version:  1,
 			Codec:    uint64(multicodec.DagJson),
 			MhType:   uint64(multicodec.Sha2_256),
-			MhLength: 16,
+			MhLength: -1,
 		},
 	}
 


### PR DESCRIPTION
## Context
cids are truncated to the first half of the sha256 digest

## Proposed Changes
Use the default mhlength on the cid prototype

## Tests
go test continues to pass

## Revert Strategy
revert
