### PR TITLE
Define `index-observer` ECR repo and CI to build and push images

### DIFF
--- a/deploy/infrastructure/common/ecr.tf
+++ b/deploy/infrastructure/common/ecr.tf
@@ -3,6 +3,7 @@ module "ecr_ue2" {
 
   repositories = [
     "storetheindex/storetheindex",
+    "index-observer/index-observer",
   ]
   tags = local.tags
 }

--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_openid_connect_provider" "github" {
   client_id_list = [
     "https://github.com/filecoin-project",
+    "https://github.com/filecoin-shipyard",
     "sts.amazonaws.com"
   ]
 
@@ -12,7 +13,7 @@ resource "aws_iam_openid_connect_provider" "github" {
 
 data "aws_iam_policy_document" "github_actions" {
   statement {
-    effect  = "Allow"
+    effect = "Allow"
     actions = [
       "ecr:GetAuthorizationToken",
       "ecr:BatchCheckLayerAvailability",
@@ -46,5 +47,8 @@ module "github_actions_role" {
     aws_iam_policy.github_actions.arn,
   ]
 
-  oidc_subjects_with_wildcards = ["repo:filecoin-project/storetheindex:*"]
+  oidc_subjects_with_wildcards = [
+    "repo:filecoin-project/storetheindex:*",
+    "repo:filecoin-shipyard/index-observer:*"
+  ]
 }

--- a/deploy/infrastructure/common/pl-grafana.tf
+++ b/deploy/infrastructure/common/pl-grafana.tf
@@ -20,7 +20,7 @@ module "metrics_reader_group" {
   source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
   version = "4.18.0"
 
-  name        = "metrics_viewer"
+  name = "metrics_viewer"
   group_users = [
     module.pl_grafana_user.iam_user_name
   ]


### PR DESCRIPTION
Define a dedicated ECR repository for `index-observer` in `us-east-2`
and allow GitHub Actions to assume the roles necessary to build and push
container images to it.

While at it reformat terraform files in `common` via `terraform fmt`.
