### PR TITLE
Configure flux cd for `index-observer` on `dev` cluster

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/index-observer/README.md
+++ b/deploy/manifests/dev/us-east-2/cluster/index-observer/README.md
@@ -1,0 +1,8 @@
+# Index Observer
+
+This directory contains the `index-observer` _cluster-level_ Flux tenancy configuration that creates a K8S namespace dedicated to `index-observer`, along with all Flux CRDs to set up and manage continuous delivery for it.
+
+Note that the [_application level_ manifests](https://github.com/filecoin-shipyard/index-observer/tree/main/deploy/manifests/dev/us-east-2) are located at the `index-observer` repo itself.
+
+See:
+ - https://github.com/filecoin-shipyard/index-observer

--- a/deploy/manifests/dev/us-east-2/cluster/index-observer/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-observer/flux-cd.yaml
@@ -1,0 +1,91 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: index-observer
+spec:
+  interval: 5m
+  url: https://github.com/filecoin-shipyard/index-observer.git
+  ref:
+    branch: main
+  secretRef:
+    name: github-auth
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: index-observer
+spec:
+  serviceAccountName: flux
+  decryption:
+    provider: sops
+  interval: 5m
+  path: "./deploy/manifests/dev/us-east-2"
+  sourceRef:
+    kind: GitRepository
+    name: index-observer
+  prune: true
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: index-observer
+spec:
+  interval: 5m
+  image: 407967248065.dkr.ecr.us-east-2.amazonaws.com/index-observer/index-observer
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1alpha1
+kind: ImagePolicy
+metadata:
+  name: index-observer
+spec:
+  filterTags:
+    pattern: '^(?P<timestamp>\d+)-.+$'
+    extract: '$timestamp'
+  policy:
+    numerical:
+      order: asc
+  imageRepositoryRef:
+    name: index-observer
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: index-observer
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: index-observer
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        name: sti-bot
+        email: sti-bot@protocol.ai
+      messageTemplate: |
+        Update {{ .AutomationObject.Namespace }}/{{ .AutomationObject.Name }} in `dev` environment
+        
+        Files:
+        {{ range $filename, $_ := .Updated.Files -}}
+        - {{ $filename }}
+        {{ end -}}
+        
+        Objects:
+        {{ range $resource, $_ := .Updated.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+        
+        Images:
+        {{ range .Updated.Images -}}
+        - {{.}}
+        {{ end -}}
+    push:
+      branch: 'cd/dev'
+  update:
+    strategy: Setters
+    path: "./deploy/manifests/dev/us-east-2"

--- a/deploy/manifests/dev/us-east-2/cluster/index-observer/flux-rbac.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-observer/flux-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flux
+rules:
+  - apiGroups: [ '*' ]
+    resources: [ '*' ]
+    verbs: [ '*' ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flux
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: index-observer

--- a/deploy/manifests/dev/us-east-2/cluster/index-observer/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-observer/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: index-observer
+
+commonLabels:
+  toolkit.fluxcd.io/tenant: index-observer
+
+resources:
+  - namespace.yaml
+  - flux-cd.yaml
+  - flux-rbac.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/index-observer/namespace.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-observer/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: index-observer


### PR DESCRIPTION
Configure cluster-level Flux CRDs for `index-observer` with the same
policies used for `storetheindex`.

Add README to clarify that application-level manifests will live in the
`index-observer` repo.

