### PR TITLE
Add `index-observer` to dev cluster manifests

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - monitoring
   - aws-ebs-csi-driver
   - promtail
+  - index-observer


### PR DESCRIPTION
Add the index-observer to the list of manifests applied to the dev
cluster.

