### PR TITLE
Onboard `autoretrieve` as a temporary tenant of sti `dev` cluster

### DIFF
--- a/deploy/infrastructure/common/ecr.tf
+++ b/deploy/infrastructure/common/ecr.tf
@@ -4,6 +4,7 @@ module "ecr_ue2" {
   repositories = [
     "storetheindex/storetheindex",
     "index-observer/index-observer",
+    "autoretrieve/autoretrieve",
   ]
   tags = local.tags
 }

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/.sops.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/.sops.yaml
@@ -1,0 +1,6 @@
+creation_rules:
+  - path_regex: '.+\.env'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/cluster'
+  - path_regex: '.+\.y(a)?ml'
+    encrypted_regex: '^(data|stringData)$'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/cluster'

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/README.md
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/README.md
@@ -1,0 +1,17 @@
+# Autoretrieve
+
+This directory contains a temporary `autoretrieve` _cluster-level_ Flux tenancy configuration that
+creates a K8S namespace dedicated to `autoretrieve`, along with all Flux CRDs to set up and manage
+continuous delivery for it.
+
+The rationale is to set up an automated continuous delivery pipeline to facilitate a tight debug
+loop while the long term plans are being decided. This deployment also facilitates metrics
+forwarding to the PL grafana for `autoretrieve`.
+
+Note that the [_application
+level_ manifests](https://github.com/application-research/autoretrieve/tree/main/deploy/manifests/dev/us-east-2)
+are located at the `autoretrieve` repo itself.
+
+See:
+
+- https://github.com/application-research/autoretrieve

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-cd.yaml
@@ -1,0 +1,91 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: autoretrieve
+spec:
+  interval: 5m
+  url: https://github.com/application-research/autoretrieve.git
+  ref:
+    branch: main
+  secretRef:
+    name: github-auth
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: autoretrieve
+spec:
+  serviceAccountName: flux
+  decryption:
+    provider: sops
+  interval: 5m
+  path: "./deploy/manifests/dev/us-east-2"
+  sourceRef:
+    kind: GitRepository
+    name: autoretrieve
+  prune: true
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: autoretrieve
+spec:
+  interval: 5m
+  image: 407967248065.dkr.ecr.us-east-2.amazonaws.com/autoretrieve/autoretrieve
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1alpha1
+kind: ImagePolicy
+metadata:
+  name: autoretrieve
+spec:
+  filterTags:
+    pattern: '^(?P<timestamp>\d+)-.+$'
+    extract: '$timestamp'
+  policy:
+    numerical:
+      order: asc
+  imageRepositoryRef:
+    name: autoretrieve
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: autoretrieve
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: autoretrieve
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        name: sti-bot
+        email: sti-bot@protocol.ai
+      messageTemplate: |
+        Update {{ .AutomationObject.Namespace }}/{{ .AutomationObject.Name }} in `dev` environment
+        
+        Files:
+        {{ range $filename, $_ := .Updated.Files -}}
+        - {{ $filename }}
+        {{ end -}}
+        
+        Objects:
+        {{ range $resource, $_ := .Updated.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+        
+        Images:
+        {{ range .Updated.Images -}}
+        - {{.}}
+        {{ end -}}
+    push:
+      branch: 'cd/dev'
+  update:
+    strategy: Setters
+    path: "./deploy/manifests/dev/us-east-2"

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-rbac.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flux
+rules:
+  - apiGroups: [ '*' ]
+    resources: [ '*' ]
+    verbs: [ '*' ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flux
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: autoretrieve

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/github-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/github-auth.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: github-auth
+    namespace: autoretrieve
+type: Opaque
+stringData:
+    username: ENC[AES256_GCM,data:uU+Je06igg==,iv:irfMIUykbIy3P+mwXSFpU/TVPmRBktO9BMS7OHNnGi4=,tag:F/zbhoO6bVgxpz3PBae/GA==,type:str]
+    password: ENC[AES256_GCM,data:hbLzoKQKm399LY0CgZY08J6r5+vCePwJPt8HNsKQSOgh9gDrF0sh2w==,iv:5DpBpO35JPM9S3YJ3NIMknRlA6rfD5KZGJp39SBvi7k=,tag:zt8BXw9t59KNZMSQ86b2bg==,type:str]
+sops:
+    kms:
+        - arn: arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/cluster
+          created_at: "2022-05-09T15:17:50Z"
+          enc: AQICAHjPLKH8p/5QB+TsPnURNgsbMMOlVWn14S9WvEpahS2p4wHyFtdNZ2OzCx43PYeEDvL8AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMq1emCpt+Awdbu1FmAgEQgDvmUzvUqdtRzZNkIiH+iBeZQoMd+x7hDF6j+BBNQoUso1HLfbXJOCd1tNj78SY/1jydnGXj+4MoU28dVQ==
+          aws_profile: ""
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-05-11T11:35:05Z"
+    mac: ENC[AES256_GCM,data:WocQfI6BLI/7EsnugjGI7ykdiAduS92lvb0x4B/IO6Nh2RvGQBlhmeQezVhDqmbv08UgAxsOaMnuox2MoIESjYtjUiu+Am2v1reoR7ox82v8awhLwXa/N7VEZTXSJKTCHXImJZ6mZKdY3h2423ybx6bfkEMXfi7KsIap8H6Swzs=,iv:yyeOHP2iPMEUd0JfH8Hc2BItaZQxlWBEAHdRCRnH/CU=,tag:MNB6MySUWngiJl8KSu2X4w==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.2

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: autoretrieve
+
+commonLabels:
+  toolkit.fluxcd.io/tenant: autoretrieve
+
+resources:
+  - namespace.yaml
+  - flux-cd.yaml
+  - flux-rbac.yaml
+  - github-auth.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/namespace.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: autoretrieve

--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - aws-ebs-csi-driver
   - promtail
   - index-observer
+  - autoretrieve


### PR DESCRIPTION
While `autoretrieve` is being developed, provide a temporary place it
can be deployed in such that metrics could be forwarded to PL grafana
along with logs etc. All of this is already set up in sti EKS clusters.

Create a dedicated ECR repository for automating the build and push of
`autoretrieve` container images. It looks like the exising one is
manually created and pushed to. Here we create a separate one to avoid
any conflicts.

