### PR TITLE
Allow GitHub Actions from ARG autoretrieve repo to publish to ECR

### DIFF
--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -49,6 +49,8 @@ module "github_actions_role" {
 
   oidc_subjects_with_wildcards = [
     "repo:filecoin-project/storetheindex:*",
-    "repo:filecoin-shipyard/index-observer:*"
+    "repo:filecoin-shipyard/index-observer:*",
+    "repo:application-research/autoretrieve:*",
+    "repo:masih/autoretrieve:*" # Allow work from da fork until access to the main repo is sorted.
   ]
 }


### PR DESCRIPTION
Allow the GitHub Actions running from
`application-research/autoretrieve` and push container images to ECR
repos at storeteindex AWS account.

While access on the repo is being granted, also allow builds from a
personal fork of `autoretrieve` so that progress can be made. This will
be removed once access is granted.
