### PR TITLE
Allow `put` via cloudfront sitting in front of `cid.contact`

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/dev/us-east-2/cloudfront.tf
@@ -30,7 +30,9 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   default_cache_behavior {
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    # We need to allow GET and PUT. CloudFront does not support configuring allowed methods selectively.
+    # Hence the complete method list.
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.cdn_origin_id
 

--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -34,7 +34,9 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   default_cache_behavior {
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    # We need to allow GET and PUT. CloudFront does not support configuring allowed methods selectively.
+    # Hence the complete method list.
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.cdn_origin_id
 


### PR DESCRIPTION
`cid.contact` should allow `PUT` to `/ingest/announce` for go-legs HTTP
publishers. Further, `cid.contact` is fronted by the cloudfront caching
and `PUT` was not allowed in the cloudfront behaviour, which was causing
`announce` requests from go-legs HTTP publishers to fail with `403`.

Allow all methods on cloudfront caching, because we need `GET` and `PUT`
to be allowed but they can't be configured explicitly. CloudFront only
supports `GET, HEAD` or` GET, HEAD, OPTIONS` or
`GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE` hence the exhaustive
allowed methods list.

Same is applied to `dev` while we are at it.
