### PR TITLE
Define dedicated KMS keys used to encrypt autoretrieve secrets

### DIFF
--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -50,7 +50,6 @@ module "github_actions_role" {
   oidc_subjects_with_wildcards = [
     "repo:filecoin-project/storetheindex:*",
     "repo:filecoin-shipyard/index-observer:*",
-    "repo:application-research/autoretrieve:*",
-    "repo:masih/autoretrieve:*" # Allow work from da fork until access to the main repo is sorted.
+    "repo:application-research/autoretrieve:*"
   ]
 }

--- a/deploy/infrastructure/dev/us-east-2/autoretrieve.tf
+++ b/deploy/infrastructure/dev/us-east-2/autoretrieve.tf
@@ -1,0 +1,71 @@
+resource "aws_kms_alias" "kms_autoretrieve" {
+  target_key_id = aws_kms_key.kms_autoretrieve.key_id
+  name          = "alias${local.iam_path}autoretrieve"
+}
+
+resource "aws_kms_key" "kms_autoretrieve" {
+  description = "Key used to encrypt autoretrieve tenant secrets"
+  policy      = data.aws_iam_policy_document.kms_autoretrieve.json
+  is_enabled  = true
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "kms_autoretrieve" {
+  statement {
+    sid = "Enable IAM User Permissions"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::407967248065:root"]
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow access for Devs via sops"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::407967248065:user/masih",
+        "arn:aws:iam::407967248065:user/marco",
+        "arn:aws:iam::407967248065:user/gammazero",
+        "arn:aws:iam::407967248065:user/will.scott",
+        "arn:aws:iam::407967248065:user/kylehuntsman",
+        "arn:aws:iam::407967248065:user/steveFraser",
+        "arn:aws:iam::407967248065:user/cmharden",
+      ]
+    }
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+  }
+
+
+  statement {
+    sid = "Allow Flux to decrypt"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        module.kustomize_controller_role.iam_role_arn
+      ]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+  }
+}

--- a/deploy/infrastructure/dev/us-east-2/kms.tf
+++ b/deploy/infrastructure/dev/us-east-2/kms.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "kust_ctrlr" {
       "kms:DescribeKey",
     ]
 
-    resources = [aws_kms_key.kms_sti.arn, aws_kms_key.kms_cluster.arn]
+    resources = [aws_kms_key.kms_sti.arn, aws_kms_key.kms_cluster.arn, aws_kms_key.kms_autoretrieve.arn]
   }
 }
 

--- a/deploy/infrastructure/dev/us-east-2/outputs.tf
+++ b/deploy/infrastructure/dev/us-east-2/outputs.tf
@@ -1,8 +1,13 @@
 output "kms_sti_alias_arn" {
   value = aws_kms_alias.kms_sti.arn
 }
+
 output "kms_cluster_alias_arn" {
   value = aws_kms_alias.kms_cluster.arn
+}
+
+output "kms_autoretrieve_alias_arn" {
+  value = aws_kms_alias.kms_autoretrieve.arn
 }
 
 output "kustomize_controller_role_arn" {

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/README.md
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/README.md
@@ -9,7 +9,7 @@ loop while the long term plans are being decided. This deployment also facilitat
 forwarding to the PL grafana for `autoretrieve`.
 
 Note that the [_application
-level_ manifests](https://github.com/application-research/autoretrieve/tree/main/deploy/manifests/dev/us-east-2)
+level_ manifests](https://github.com/application-research/autoretrieve/tree/master/deploy/manifests/dev/us-east-2)
 are located at the `autoretrieve` repo itself.
 
 See:

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-cd.yaml
@@ -6,7 +6,7 @@ spec:
   interval: 5m
   url: https://github.com/application-research/autoretrieve.git
   ref:
-    branch: main
+    branch: master
   secretRef:
     name: github-auth
 ---
@@ -62,7 +62,7 @@ spec:
   git:
     checkout:
       ref:
-        branch: main
+        branch: master
     commit:
       author:
         name: sti-bot


### PR DESCRIPTION
Define dedicated KMS key to encrypt application level secrets for
autoretrieve.

Change `main` to `master` for autoretrieve, since that is the default
branch.

Remove temporarily granted access to autoretrieve fork now that access
to main repo is sorted out.

