### PR TITLE
Use larger instance types and override config in dev to limit providers

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -27,6 +27,19 @@ module "eks" {
       desired_size   = 3
       instance_types = ["m4.xlarge"]
     }
+    dev-ue2-r5b-xl = {
+      min_size       = 2
+      max_size       = 3
+      desired_size   = 2
+      instance_types = ["r5b.xlarge"]
+      taints         = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5b"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
   }
 
   tags = local.tags

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -9,6 +9,11 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2-m4-xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2-r5b-xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/config
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/config
@@ -1,0 +1,71 @@
+{
+  "Version": 1,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": false,
+      "Except": [
+        "12D3KooWDtiA9w5c37MnFpGWr2M12m8neoUqDroHEMsJVuf3ELi7",
+        "12D3KooWBwUERBhJPtZ7hg5N3q1DesvJ67xx9RLdSaStBz9Y6Ny8",
+        "12D3KooWLDf6KCzeMv16qPRaJsTLKJ5fR523h65iaYSRNfrQy7eU"
+      ],
+      "Publish": true,
+      "PublishExcept": null,
+      "RateLimit": false,
+      "RateLimitExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5h0m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s"
+  },
+  "Indexer": {
+    "CacheSize": 300000,
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "sth",
+    "GCInterval": "30m0s"
+  },
+  "Ingest": {
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "StoreBatchSize": 4096,
+    "SyncTimeout": "2h0m0s",
+    "IngestWorkerCount": 10
+  }
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -13,6 +13,11 @@ secretGenerator:
   files:
   - indexer-0.key=indexer-0-identity.encrypted
   - indexer-1.key=indexer-1-identity.encrypted
+configMapGenerator:
+- name: indexer-config
+  behavior: replace
+  files:
+    - config 
 replicas:
 - name: indexer
   count: 2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -23,11 +23,17 @@ spec:
               mountPath: /identity
           resources:
             limits:
-              cpu: "1"
-              memory: 10Gi
+              cpu: "2"
+              memory: 25Gi
             requests:
-              cpu: 500m
-              memory: 10Gi
+              cpu: "2"
+              memory: 25Gi
+      # Require r5b instance types to run index provider pods.
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b
+          effect: NoSchedule
       volumes:
         - name: identity
           secret:


### PR DESCRIPTION
The dev instances are still running on 10GiB memory because the maximum
available on the worker node type is 16. It also uses a configuration
identical to prod, which means it would ingest everything prod does.

Here we whitelist only a selected number of providers to reduce load on
the `dev` instance since it is meant to be for development purposes.
This should shield it from failures that say prod instance goes through
due to excessive ingest load.

The memory given to the instances as well as the instance types are
upgraded to match production. Taint is set on the dev instance to use
r5b instance types just like prod. This will allow us to change the dev
config as we see fit to match the prod config or selectively ingest from
specific providers for debuging purposes without having to worry about
mismatching hardware requirements.

