### PR TITLE
Only whitelist ingestion from a specific provider in `dev` for testing

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -28,9 +28,9 @@ module "eks" {
       instance_types = ["m4.xlarge"]
     }
     dev-ue2-r5b-xl = {
-      min_size       = 2
+      min_size       = 3
       max_size       = 3
-      desired_size   = 2
+      desired_size   = 3
       instance_types = ["r5b.xlarge"]
       taints         = {
         dedicated = {

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/config
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/config
@@ -40,9 +40,7 @@
     "Policy": {
       "Allow": false,
       "Except": [
-        "12D3KooWDtiA9w5c37MnFpGWr2M12m8neoUqDroHEMsJVuf3ELi7",
-        "12D3KooWBwUERBhJPtZ7hg5N3q1DesvJ67xx9RLdSaStBz9Y6Ny8",
-        "12D3KooWLDf6KCzeMv16qPRaJsTLKJ5fR523h65iaYSRNfrQy7eU"
+        "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC",
       ],
       "Publish": true,
       "PublishExcept": null,


### PR DESCRIPTION
In order to understand the scalability of ingest from high-volume
providers, only whitelist a specific high-volume provider so that we
learn whether a dedicated indexer instance can work through long chanins
of advertisement.

Increase r5b minimum instance count to assure that there is one in each
AZ otherwise the pods will fail to schedule since PVCs might be in AZs
that is different from the EC2 worker instance AZ.
