### PR TITLE
Configure rate limit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const (
 	// EnvDir is the environment variable used to change the path root.
 	EnvDir = "STORETHEINDEX_PATH"
 
-	Version = 1
+	Version = 2
 )
 
 var (

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -21,6 +21,8 @@ type Ingest struct {
 	IngestWorkerCount int
 	// PubSubTopic used to advertise ingestion announcements.
 	PubSubTopic string
+	// RateLimit contains rate-limiting configuration.
+	RateLimit RateLimit
 	// StoreBatchSize is the number of entries in each write to the value
 	// store. Specifying a value less than 2 disables batching. This should be
 	// smaller than the maximum number of multihashes in an entry block to
@@ -40,6 +42,7 @@ func NewIngest() Ingest {
 		EntriesDepthLimit:       65536,
 		IngestWorkerCount:       10,
 		PubSubTopic:             "/indexer/ingest/mainnet",
+		RateLimit:               NewRateLimit(),
 		StoreBatchSize:          4096,
 		SyncTimeout:             Duration(2 * time.Hour),
 	}

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -61,6 +61,7 @@ func (c *Ingest) populateUnset() {
 	if c.IngestWorkerCount == 0 {
 		c.IngestWorkerCount = def.IngestWorkerCount
 	}
+	c.RateLimit.populateUnset()
 	if c.PubSubTopic == "" {
 		c.PubSubTopic = def.PubSubTopic
 	}

--- a/config/policy.go
+++ b/config/policy.go
@@ -1,9 +1,8 @@
 package config
 
-// Policy configures which peers are allowed, are rate-limited and which may
-// publish on behalf of others. Currently, the allow policy is applied to both
-// providers and publishers. The RateLimit and Publish policies applies to
-// publishers.
+// Policy configures which peers are allowed and which may publish on behalf of
+// others. Currently, the allow policy is applied to both providers and
+// publishers. The Publish policie applies only to publishers.
 //
 // Publishers and providers are not the same. Publishers are peers that supply
 // data to the indexer. Providers are the peers that appear in advertisements
@@ -28,16 +27,6 @@ type Policy struct {
 	// PublishExcept. If Publish is true, then all allowed peers can publish
 	// advertisements for any provider, unless listed in PublishExcept.
 	PublishExcept []string
-
-	// RateLimit is either false or true, and determines whether an allowed
-	// peer if subject to rate limiting (true) or not (false), by default.
-	RateLimit bool
-	// RateLimitExcept is a list of peer IDs that are exceptions to the
-	// RateLimit policy. If RateLimit is false then all allowed peers are not
-	// rate-limited unless they appear in the RateLimitExcept list. If
-	// RateLimit is true, then only the peers listed in RateLimitExcept are not
-	// rate-limited.
-	RateLimitExcept []string
 }
 
 // NewPolicy returns Policy with values set to their defaults.

--- a/config/ratelimit.go
+++ b/config/ratelimit.go
@@ -14,11 +14,27 @@ type RateLimit struct {
 	// as a block, so this limit applies to both. Setting a value of 0 disables
 	// rate limiting, meaning that the rate is infinite.
 	BlocksPerSecond int
+	// BurstSize is the maximum number of blocks that can be received at once.
+	// After this, BlocksPerSecond additional blocks maybe received each
+	// second, and any more results in rate limiting. With HTTP ingestion, rate
+	// limiting waits until more blocks are allowed to be received. With
+	// graphsync, rate limiting terminates the session and resumes it when
+	// sufficient time has passed to be able to receive BurstSize blocks. A
+	// value of 0 results in 10 times BlocksPerSecond.
+	BurstSize int
 }
 
 // NewRateLimit returns RateLimit with values set to their defaults.
 func NewRateLimit() RateLimit {
 	return RateLimit{
-		BlocksPerSecond: 1000,
+		BlocksPerSecond: 100,
+		BurstSize:       1000,
+	}
+}
+
+// populateUnset replaces zero-values in the config with default values.
+func (c *RateLimit) populateUnset() {
+	if c.BurstSize == 0 {
+		c.BurstSize = 10 * c.BlocksPerSecond
 	}
 }

--- a/config/ratelimit.go
+++ b/config/ratelimit.go
@@ -28,13 +28,13 @@ type RateLimit struct {
 func NewRateLimit() RateLimit {
 	return RateLimit{
 		BlocksPerSecond: 100,
-		BurstSize:       1000,
+		BurstSize:       500,
 	}
 }
 
 // populateUnset replaces zero-values in the config with default values.
 func (c *RateLimit) populateUnset() {
 	if c.BurstSize == 0 {
-		c.BurstSize = 10 * c.BlocksPerSecond
+		c.BurstSize = 5 * c.BlocksPerSecond
 	}
 }

--- a/config/ratelimit.go
+++ b/config/ratelimit.go
@@ -1,0 +1,24 @@
+package config
+
+type RateLimit struct {
+	// Apply is either false or true, and determines whether a peer is subject
+	// to rate limiting (true) or not (false), by default.
+	Apply bool
+	// Except is a list of peer IDs that are exceptions to the Apply rule. If
+	// Apply is false then peers are not rate-limited unless they appear in the
+	// Except list. If Apply is true, then only the peers listed in Except are
+	// not rate-limited.
+	Except []string
+	// BlocksPerSecond is the number of blocks allowed to be transferred per
+	// second. An advertisement and a block of multihashes are both represented
+	// as a block, so this limit applies to both. Setting a value of 0 disables
+	// rate limiting, meaning that the rate is infinite.
+	BlocksPerSecond int
+}
+
+// NewRateLimit returns RateLimit with values set to their defaults.
+func NewRateLimit() RateLimit {
+	return RateLimit{
+		BlocksPerSecond: 1000,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.15
-	github.com/filecoin-project/go-legs v0.3.13
+	github.com/filecoin-project/go-legs v0.3.14
 	github.com/frankban/quicktest v1.14.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	go.opencensus.io v0.23.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )
 
 require (
@@ -201,7 +202,6 @@ require (
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20211025112917-711f33c9992c // indirect
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.1.5 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.15 h1:oT1W98tJnT83cv9VvbhCmI18LU2kOCIddyYDek1AN9g=
 github.com/filecoin-project/go-indexer-core v0.2.15/go.mod h1:7TD8AtIESAjIC1dd6avC2pvAyN/7edlQYsLexRrlI1w=
-github.com/filecoin-project/go-legs v0.3.13 h1:MLOgJXQeT2JfdkUlEsZLz6W4hd0tsL4O/uzguG+RGH8=
-github.com/filecoin-project/go-legs v0.3.13/go.mod h1:Ve7iMWBvXm8yQ7k07RFjPkbFsi9wrsCqixV2oWIfkWM=
+github.com/filecoin-project/go-legs v0.3.14 h1:h95posJf87pAqwsD/qXAn9aW2sK+05roHZSUZ2/L410=
+github.com/filecoin-project/go-legs v0.3.14/go.mod h1:Ve7iMWBvXm8yQ7k07RFjPkbFsi9wrsCqixV2oWIfkWM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd h1:Ykxbz+LvSCUIl2zFaaPGmF8KHXTJu9T/PymgHr7IHjs=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -126,7 +126,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 			efsb.Insert("Next", ssb.ExploreRecursiveEdge()) // Next field in EntryChunk
 		})).Node()
 
-	rateApply, err := peerutil.NewPolicy(cfg.RateLimit.Apply, cfg.RateLimit.Except)
+	rateApply, err := peerutil.NewPolicyStrings(cfg.RateLimit.Apply, cfg.RateLimit.Except)
 	if err != nil {
 		log.Errorw("Bad setting rate limit for peers", "err", err)
 	}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/storetheindex/config"
 	"github.com/filecoin-project/storetheindex/internal/metrics"
 	"github.com/filecoin-project/storetheindex/internal/registry"
+	"github.com/filecoin-project/storetheindex/peerutil"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
@@ -29,6 +30,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
+	"golang.org/x/time/rate"
 )
 
 var log = logging.Logger("indexer/ingest")
@@ -96,6 +98,10 @@ type Ingester struct {
 	closeWorkers   chan struct{}
 	waitForWorkers sync.WaitGroup
 	toStaging      <-chan legs.SyncFinished
+
+	// RateLimiting
+	rateApply peerutil.Policy
+	rateLimit rate.Limit
 }
 
 // NewIngester creates a new Ingester that uses a go-legs Subscriber to handle
@@ -120,6 +126,11 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 			efsb.Insert("Next", ssb.ExploreRecursiveEdge()) // Next field in EntryChunk
 		})).Node()
 
+	rateApply, err := peerutil.NewPolicy(cfg.RateLimit.Apply, cfg.RateLimit.Except)
+	if err != nil {
+		log.Errorw("Bad setting rate limit for peers", "err", err)
+	}
+
 	ing := &Ingester{
 		host:        h,
 		ds:          ds,
@@ -138,11 +149,19 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 		providerAdChainStaging:  make(map[peer.ID]*atomic.Value),
 		toWorkers:               make(chan providerID),
 		closeWorkers:            make(chan struct{}),
+
+		rateApply: rateApply,
+		rateLimit: rate.Limit(cfg.RateLimit.BlocksPerSecond),
 	}
 
 	// Create and start pubsub subscriber. This also registers the storage hook
 	// to index data as it is received.
-	sub, err := legs.NewSubscriber(h, ds, lsys, cfg.PubSubTopic, adSel, legs.AllowPeer(reg.Allowed), legs.SyncRecursionLimit(recursionLimit(cfg.AdvertisementDepthLimit)), legs.UseLatestSyncHandler(&syncHandler{ing}))
+	sub, err := legs.NewSubscriber(h, ds, lsys, cfg.PubSubTopic, adSel,
+		legs.AllowPeer(reg.Allowed),
+		legs.SyncRecursionLimit(recursionLimit(cfg.AdvertisementDepthLimit)),
+		legs.UseLatestSyncHandler(&syncHandler{ing}),
+		legs.RateLimiter(ing.getRateLimiter))
+
 	if err != nil {
 		log.Errorw("Failed to start pubsub subscriber", "err", err)
 		return nil, errors.New("ingester subscriber failed")
@@ -166,6 +185,17 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 	log.Debugf("Ingester started and all hooks and linksystem registered")
 
 	return ing, nil
+}
+
+func (ing *Ingester) getRateLimiter(publisher peer.ID) *rate.Limiter {
+	// If rateLimiting disabled or publisher is not rate-limited, then return
+	// infinite rate limiter.
+	if ing.rateLimit == 0 || !ing.rateApply.Eval(publisher) {
+		return rate.NewLimiter(rate.Inf, 0)
+	}
+	// Retrun rate limiter with rate setting from config. Burst is set to 1
+	// since only single blocks are counted at a time.
+	return rate.NewLimiter(ing.rateLimit, 1)
 }
 
 func (ing *Ingester) Close() error {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -990,13 +990,13 @@ func mkTestHost(opts ...libp2p.Option) host.Host {
 
 // Make new indexer engine
 func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
-	valueStore, err := storethehash.New(t.TempDir())
+	valueStore, err := storethehash.New(t.TempDir(), storethehash.IndexBitSize(8))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var resultCache cache.Interface
 	if withCache {
-		resultCache = radixcache.New(100000)
+		resultCache = radixcache.New(1000)
 	}
 	return engine.New(resultCache, valueStore)
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -934,8 +934,11 @@ func TestMultiplePublishers(t *testing.T) {
 
 func TestRateLimitConfig(t *testing.T) {
 	store := dssync.MutexWrap(datastore.NewMapDatastore())
+	defer store.Close()
 	reg := mkRegistry(t)
+	defer reg.Close()
 	core := mkIndexer(t, true)
+	defer core.Close()
 	pubHost := mkTestHost()
 	h := mkTestHost()
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -58,7 +58,8 @@ var (
 		PubSubTopic: "test/ingest",
 		RateLimit: config.RateLimit{
 			Apply:           true,
-			BlocksPerSecond: 100000,
+			BlocksPerSecond: 100,
+			BurstSize:       1000,
 		},
 		StoreBatchSize:    256,
 		SyncTimeout:       config.Duration(time.Minute),

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -120,56 +120,13 @@ func verifyAdvertisement(n ipld.Node, reg *registry.Registry) (peer.ID, error) {
 	return provID, nil
 }
 
-// ingestEntryChunk determines the logic to run when a new block is received
-// through graphsync.
-//
-// For a chain of advertisements, the storage hook sees the advertisements from
-// newest to oldest, and starts an entries sync goroutine for each
-// advertisement. These goroutines each wait for the sync goroutine associated
-// with the previous advertisement to complete before beginning their sync for
-// content blocks.
-//
-// When a non-advertisement block is received, it means that the entries sync
-// is running and is collecting content chunks for an advertisement. Now this
-// hook is being called for each entry in an advertisement's chain of entries.
-// Process the entry and save all the multihashes in it as indexes in the
-// indexer-core.
-func (ing *Ingester) ingestEntryChunk(publisher peer.ID, adCid cid.Cid, ad schema.Advertisement, entryChunkCid cid.Cid) error {
-	log := log.With("publisher", publisher, "adCid", adCid, "cid", entryChunkCid)
-
-	// Get data corresponding to the block.
-	entryChunkKey := dsKey(entryChunkCid.String())
-	val, err := ing.ds.Get(context.Background(), entryChunkKey)
-	if err != nil {
-		return fmt.Errorf("cannot fetch the node from datastore: %w", err)
-	}
-	defer func() {
-		// Remove the content block from the data store now that processing it
-		// has finished. This prevents storing redundant information in several
-		// datastores.
-		err := ing.ds.Delete(context.Background(), entryChunkKey)
-		if err != nil {
-			log.Errorw("Error deleting index from datastore", "err", err)
-		}
-	}()
-
-	// Decode block to IPLD node
-	node, err := decodeIPLDNode(entryChunkCid.Prefix().Codec, bytes.NewBuffer(val), schema.EntryChunkPrototype)
-	if err != nil {
-		return fmt.Errorf("failed to decode ipldNode: %w", err)
-	}
-
-	err = ing.indexContentBlock(adCid, ad, publisher, node)
-	if err != nil {
-		return fmt.Errorf("failed processing entries for advertisement: %w", err)
-	}
-
-	ing.signalMetricsUpdate()
-	return nil
-}
-
 // ingestAd fetches all the entries for a single advertisement and processes
-// them.
+// them. This is called for each advertisement in a synced chain by an ingester
+// worker. The worker begins processing the synced advertisement chain when it
+// receives notification that a peer has finished a sync for advertisements.
+//
+// Advertisements are processed from oldest to newest, which is the reverse
+// order that they were received in.
 func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Advertisement) error {
 	stats.Record(context.Background(), metrics.IngestChange.M(1))
 	ingestStart := time.Now()
@@ -272,6 +229,47 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 	if len(errsIngestingEntryChunks) > 0 {
 		return adIngestError{adIngestEntryChunkErr, fmt.Errorf("failed to ingest entry chunks: %v", errsIngestingEntryChunks)}
 	}
+	return nil
+}
+
+// ingestEntryChunk ingests a block of entries as that block is received
+// through graphsync.
+//
+// When each advertisement on a chain is processed by ingestAd, that
+// advertisement's entries are synced in a spearate legs.Subscriber.Sync
+// operation. This function is used as a scoped block hook, and is called for
+// each block that is received.
+func (ing *Ingester) ingestEntryChunk(publisher peer.ID, adCid cid.Cid, ad schema.Advertisement, entryChunkCid cid.Cid) error {
+	log := log.With("publisher", publisher, "adCid", adCid, "cid", entryChunkCid)
+
+	// Get data corresponding to the block.
+	entryChunkKey := dsKey(entryChunkCid.String())
+	val, err := ing.ds.Get(context.Background(), entryChunkKey)
+	if err != nil {
+		return fmt.Errorf("cannot fetch the node from datastore: %w", err)
+	}
+	defer func() {
+		// Remove the content block from the data store now that processing it
+		// has finished. This prevents storing redundant information in several
+		// datastores.
+		err := ing.ds.Delete(context.Background(), entryChunkKey)
+		if err != nil {
+			log.Errorw("Error deleting index from datastore", "err", err)
+		}
+	}()
+
+	// Decode block to IPLD node
+	node, err := decodeIPLDNode(entryChunkCid.Prefix().Codec, bytes.NewBuffer(val), schema.EntryChunkPrototype)
+	if err != nil {
+		return fmt.Errorf("failed to decode ipldNode: %w", err)
+	}
+
+	err = ing.indexContentBlock(adCid, ad, publisher, node)
+	if err != nil {
+		return fmt.Errorf("failed processing entries for advertisement: %w", err)
+	}
+
+	ing.signalMetricsUpdate()
 	return nil
 }
 

--- a/internal/registry/policy/policy.go
+++ b/internal/registry/policy/policy.go
@@ -10,10 +10,9 @@ import (
 )
 
 type Policy struct {
-	allow     peerutil.Policy
-	publish   peerutil.Policy
-	rateLimit peerutil.Policy
-	rwmutex   sync.RWMutex
+	allow   peerutil.Policy
+	publish peerutil.Policy
+	rwmutex sync.RWMutex
 }
 
 func New(cfg config.Policy) (*Policy, error) {
@@ -59,13 +58,6 @@ func (p *Policy) PublishAllowed(publisherID, providerID peer.ID) bool {
 	return p.publish.Eval(publisherID)
 }
 
-// RateLimited determines if the peer is rate limited.
-func (p *Policy) RateLimited(peerID peer.ID) bool {
-	p.rwmutex.RLock()
-	defer p.rwmutex.RUnlock()
-	return p.rateLimit.Eval(peerID)
-}
-
 // Allow alters the policy to allow the specified peer.  Returns true if the
 // policy needed to be updated.
 func (p *Policy) Allow(peerID peer.ID) bool {
@@ -100,12 +92,10 @@ func (p *Policy) ToConfig() config.Policy {
 	defer p.rwmutex.RUnlock()
 
 	return config.Policy{
-		Allow:           p.allow.Default(),
-		Except:          p.allow.ExceptStrings(),
-		Publish:         p.publish.Default(),
-		PublishExcept:   p.publish.ExceptStrings(),
-		RateLimit:       p.rateLimit.Default(),
-		RateLimitExcept: p.rateLimit.ExceptStrings(),
+		Allow:         p.allow.Default(),
+		Except:        p.allow.ExceptStrings(),
+		Publish:       p.publish.Default(),
+		PublishExcept: p.publish.ExceptStrings(),
 	}
 }
 

--- a/internal/registry/policy/policy.go
+++ b/internal/registry/policy/policy.go
@@ -26,15 +26,9 @@ func New(cfg config.Policy) (*Policy, error) {
 		return nil, fmt.Errorf("bad publish policy: %s", err)
 	}
 
-	rateLimit, err := peerutil.NewPolicyStrings(cfg.RateLimit, cfg.RateLimitExcept)
-	if err != nil {
-		return nil, fmt.Errorf("bad rate limit policy: %s", err)
-	}
-
 	return &Policy{
-		allow:     allow,
-		publish:   publish,
-		rateLimit: rateLimit,
+		allow:   allow,
+		publish: publish,
 	}, nil
 }
 
@@ -82,7 +76,6 @@ func (p *Policy) Copy(other *Policy) {
 	other.rwmutex.RLock()
 	p.allow = other.allow
 	p.publish = other.publish
-	p.rateLimit = other.rateLimit
 	other.rwmutex.RUnlock()
 }
 

--- a/internal/registry/policy/policy_test.go
+++ b/internal/registry/policy/policy_test.go
@@ -158,9 +158,6 @@ func TestPolicyAccess(t *testing.T) {
 	if cfg.Publish != true {
 		t.Error("wrong config.Publish")
 	}
-	if cfg.RateLimit != true {
-		t.Error("wrong config.RateLimit")
-	}
 	if len(cfg.Except) != 1 {
 		t.Fatal("expected 1 item in cfg.Except")
 	}

--- a/internal/registry/policy/policy_test.go
+++ b/internal/registry/policy/policy_test.go
@@ -31,10 +31,10 @@ func init() {
 
 func TestNewPolicy(t *testing.T) {
 	policyCfg := config.Policy{
-		Allow:           false,
-		Except:          []string{exceptIDStr},
-		RateLimit:       false,
-		RateLimitExcept: []string{exceptIDStr},
+		Allow:         false,
+		Except:        []string{exceptIDStr},
+		Publish:       false,
+		PublishExcept: []string{exceptIDStr},
 	}
 
 	_, err := New(policyCfg)
@@ -49,13 +49,6 @@ func TestNewPolicy(t *testing.T) {
 	}
 
 	policyCfg.Allow = false
-	policyCfg.RateLimitExcept = append(policyCfg.RateLimitExcept, "bad ID")
-	_, err = New(policyCfg)
-	if err == nil {
-		t.Error("expected error with bad RateLimitExcept ID")
-	}
-	policyCfg.RateLimitExcept = nil
-
 	policyCfg.PublishExcept = append(policyCfg.PublishExcept, "bad ID")
 	_, err = New(policyCfg)
 	if err == nil {
@@ -84,12 +77,10 @@ func TestNewPolicy(t *testing.T) {
 
 func TestPolicyAccess(t *testing.T) {
 	policyCfg := config.Policy{
-		Allow:           false,
-		Except:          []string{exceptIDStr},
-		RateLimit:       false,
-		RateLimitExcept: []string{exceptIDStr},
-		Publish:         false,
-		PublishExcept:   []string{exceptIDStr},
+		Allow:         false,
+		Except:        []string{exceptIDStr},
+		Publish:       false,
+		PublishExcept: []string{exceptIDStr},
 	}
 
 	p, err := New(policyCfg)
@@ -114,13 +105,6 @@ func TestPolicyAccess(t *testing.T) {
 		t.Error("peer ID should be allowed to publish")
 	}
 
-	if p.RateLimited(otherID) {
-		t.Error("peer ID should not be rate-limited")
-	}
-	if !p.RateLimited(exceptID) {
-		t.Error("peer ID should be rate-limited")
-	}
-
 	p.Allow(otherID)
 	if !p.Allowed(otherID) {
 		t.Error("peer ID should be allowed by policy")
@@ -133,7 +117,6 @@ func TestPolicyAccess(t *testing.T) {
 
 	policyCfg.Allow = true
 	policyCfg.Publish = true
-	policyCfg.RateLimit = true
 
 	newPol, err := New(policyCfg)
 	if err != nil {
@@ -156,13 +139,6 @@ func TestPolicyAccess(t *testing.T) {
 	}
 	if !p.PublishAllowed(exceptID, exceptID) {
 		t.Error("peer ID be allowed to publish to self")
-	}
-
-	if !p.RateLimited(otherID) {
-		t.Error("peer ID should be rate-limited")
-	}
-	if p.RateLimited(exceptID) {
-		t.Error("peer ID should not be rate-limited")
 	}
 
 	p.Allow(exceptID)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -339,8 +339,8 @@ func (r *Registry) Register(ctx context.Context, info *ProviderInfo) error {
 }
 
 // Allowed checks if the peer is allowed by policy.
-func (r *Registry) Allowed(peerID peer.ID) (bool, error) {
-	return r.policy.Allowed(peerID), nil
+func (r *Registry) Allowed(peerID peer.ID) bool {
+	return r.policy.Allowed(peerID)
 }
 
 // PublishAllowed checks if a peer is allowed to publish for other providers.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -378,11 +378,7 @@ func TestAllowed(t *testing.T) {
 		t.Fatal("bad publisher ID:", err)
 	}
 
-	ok, err := r.Allowed(pubID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
+	if !r.Allowed(pubID) {
 		t.Fatal("peer should be allowed")
 	}
 	if !r.PublishAllowed(pubID, pubID) {
@@ -392,22 +388,14 @@ func TestAllowed(t *testing.T) {
 	if !r.BlockPeer(pubID) {
 		t.Error("should have update policy to block peer")
 	}
-	ok, err = r.Allowed(pubID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok {
+	if r.Allowed(pubID) {
 		t.Fatal("peer should be blocked")
 	}
 
 	if !r.AllowPeer(pubID) {
 		t.Error("should have update policy to allow peer")
 	}
-	ok, err = r.Allowed(pubID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
+	if !r.Allowed(pubID) {
 		t.Fatal("peer should be allowed")
 	}
 
@@ -426,11 +414,7 @@ func TestAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ok, err = r.Allowed(pubID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok {
+	if r.Allowed(pubID) {
 		t.Fatal("peer should be blocked")
 	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -33,12 +33,10 @@ const (
 
 var discoveryCfg = config.Discovery{
 	Policy: config.Policy{
-		Allow:           false,
-		Except:          []string{exceptID, limitedID, limitedID2, publisherID},
-		RateLimit:       false,
-		RateLimitExcept: []string{limitedID, limitedID2, publisherID},
-		Publish:         false,
-		PublishExcept:   []string{publisherID},
+		Allow:         false,
+		Except:        []string{exceptID, limitedID, limitedID2, publisherID},
+		Publish:       false,
+		PublishExcept: []string{publisherID},
 	},
 	PollInterval:   config.Duration(time.Minute),
 	RediscoverWait: config.Duration(time.Minute),

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -47,11 +47,9 @@ func InitIndex(t *testing.T, withCache bool) indexer.Interface {
 func InitRegistry(t *testing.T) *registry.Registry {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Allow:           false,
-			Except:          []string{providerID},
-			Publish:         false,
-			RateLimit:       false,
-			RateLimitExcept: []string{providerID},
+			Allow:   false,
+			Except:  []string{providerID},
+			Publish: false,
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -140,12 +140,7 @@ func (h *IngestHandler) Announce(r io.Reader) error {
 	}
 	addrInfo := ais[0]
 
-	allow, err := h.registry.Allowed(addrInfo.ID)
-	if err != nil {
-		err = fmt.Errorf("error checking if peer allowed: %w", err)
-		return v0.NewError(err, http.StatusInternalServerError)
-	}
-	if !allow {
+	if !h.registry.Allowed(addrInfo.ID) {
 		err = fmt.Errorf("announce requests not allowed from peer %s", addrInfo.ID)
 		return v0.NewError(err, http.StatusForbidden)
 	}

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -63,11 +63,10 @@ func (m *mockIndexer) Iter() (indexer.Iterator, error)                    { retu
 func init() {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Allow:           false,
-			Except:          []string{ident.PeerID},
-			Publish:         true,
-			RateLimit:       false,
-			RateLimitExcept: []string{ident.PeerID},
+			Allow:         false,
+			Except:        []string{ident.PeerID},
+			Publish:       true,
+			PublishExcept: []string{ident.PeerID},
 		},
 	}
 

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -48,11 +48,10 @@ func InitIndex(t *testing.T, withCache bool) indexer.Interface {
 func InitRegistry(t *testing.T, trustedID string) *registry.Registry {
 	var discoveryCfg = config.Discovery{
 		Policy: config.Policy{
-			Allow:           false,
-			Except:          []string{trustedID},
-			Publish:         false,
-			RateLimit:       false,
-			RateLimitExcept: []string{trustedID},
+			Allow:         false,
+			Except:        []string{trustedID},
+			Publish:       false,
+			PublishExcept: []string{trustedID},
 		},
 		PollInterval:   config.Duration(time.Minute),
 		RediscoverWait: config.Duration(time.Minute),


### PR DESCRIPTION
## Context
The indexer needs the rate limit rate, and the peers that rate limiting is applied, to be configurable.  See: #486 

## Proposed Changes
- Create new RateLimit config in `config.Ingest.RateLimit`
- Remove old rate limit config items in `config.Discovery.Policy`
- Add `BlocksPerSecond` to rate limit config
- Update config file version
- Add code in ingester to create late limiter for go-legs Subscriber

## Tests
- Add unit tests to check that limiter is created with values according to config

## Revert Strategy
Change is safe to revert.
