### PR TITLE
Sync ads and entries in configurable segments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.15
-	github.com/filecoin-project/go-legs v0.3.14
+	github.com/filecoin-project/go-legs v0.3.15-0.20220523114716-031a27fc689d
 	github.com/frankban/quicktest v1.14.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.15 h1:oT1W98tJnT83cv9VvbhCmI18LU2kOCIddyYDek1AN9g=
 github.com/filecoin-project/go-indexer-core v0.2.15/go.mod h1:7TD8AtIESAjIC1dd6avC2pvAyN/7edlQYsLexRrlI1w=
-github.com/filecoin-project/go-legs v0.3.14 h1:h95posJf87pAqwsD/qXAn9aW2sK+05roHZSUZ2/L410=
-github.com/filecoin-project/go-legs v0.3.14/go.mod h1:Ve7iMWBvXm8yQ7k07RFjPkbFsi9wrsCqixV2oWIfkWM=
+github.com/filecoin-project/go-legs v0.3.15-0.20220523114716-031a27fc689d h1:5kgVJZ5ZudaHbPxeX6kT9k2YznEx/sLUK38BYHddmE0=
+github.com/filecoin-project/go-legs v0.3.15-0.20220523114716-031a27fc689d/go.mod h1:Ve7iMWBvXm8yQ7k07RFjPkbFsi9wrsCqixV2oWIfkWM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd h1:Ykxbz+LvSCUIl2zFaaPGmF8KHXTJu9T/PymgHr7IHjs=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=

--- a/internal/ingest/seg_sync_test.go
+++ b/internal/ingest/seg_sync_test.go
@@ -1,0 +1,58 @@
+package ingest
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/filecoin-project/storetheindex/config"
+	"github.com/filecoin-project/storetheindex/test/typehelpers"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdsSyncedViaSegmentsAreProcessed(t *testing.T) {
+	cfg := config.NewIngest()
+	cfg.PubSubTopic = defaultTestIngestConfig.PubSubTopic
+	cfg.SyncSegmentDepthLimit = 7
+
+	te := setupTestEnv(t, true, func(opts *testEnvOpts) {
+		opts.ingestConfig = &cfg
+	})
+	defer te.Close(t)
+	rng := rand.New(rand.NewSource(1413))
+	var cb []typehelpers.RandomEntryChunkBuilder
+	for i := 0; i < 50; i++ {
+		chunkCount := rng.Int31n(100)
+		ePerChunk := rng.Int31n(100)
+		cb = append(cb, typehelpers.RandomEntryChunkBuilder{ChunkCount: uint8(uint32(chunkCount)), EntriesPerChunk: uint8(ePerChunk), EntriesSeed: rng.Int63()})
+	}
+
+	headAd := typehelpers.RandomAdBuilder{
+		EntryChunkBuilders: cb,
+	}.Build(t, te.publisherLinkSys, te.publisherPriv)
+	headAdCid := headAd.(cidlink.Link).Cid
+
+	ctx := context.Background()
+	err := te.publisher.UpdateRoot(ctx, headAdCid)
+	require.NoError(t, err)
+	mhs := typehelpers.AllMultihashesFromAdLink(t, headAd, te.publisherLinkSys)
+
+	providerID := te.pubHost.ID()
+	subject := te.ingester
+
+	wait, err := subject.Sync(ctx, providerID, nil, 0, false)
+	require.NoError(t, err)
+	gotHeadAd := <-wait
+	require.Equal(t, headAdCid, gotHeadAd, "Expected latest synced cid to match head of ad chain")
+
+	requireTrueEventually(t, func() bool {
+		return checkAllIndexed(subject.indexer, providerID, mhs) == nil
+	}, testRetryInterval, testRetryTimeout, "Expected all ads from publisher to have been indexed.")
+
+	requireTrueEventually(t, func() bool {
+		latestSync, err := subject.GetLatestSync(providerID)
+		require.NoError(t, err)
+		return latestSync.Equals(headAdCid)
+	}, testRetryInterval, testRetryTimeout, "Expected all ads from publisher to have been indexed.")
+}


### PR DESCRIPTION

Syncing excessively long advertisement or entry chunk chains from an
HTTP publisher results in out of memory error. This is caused by an
internal state maintained by IPLD during `traversal.Progress`, where the
traversal path is updated in memory until the traversal completes.

To avoid memory issues as a result of syncing long chains in one go
use the segmented sync mechanism introduced in go-legs, where a chain is
synced in segments with a configurable segment depth limit. The sync
process is then repeated until the desired total depth limit is
traversed or we reach the end of traversal. At each segmented sync
cycle, depending on the kind of node being synced, the latest synced
node is decoded, and based on its type (either `Advertisement` or
`EntryChunk`) the next segment link is determined.

By breaking up syncs across multiple smaller segments we will avoid
memory problems that seem to surface when syncing very long chains while
at the same time we retain the ability to fully sync such chains.

Note that storetheindex default selector only selects advertisements.
The syncing of the ads is either triggerred via an explicit sync call on
the ingester or in background via announce messages. Therefore, the
default segment block hook that determines the next link in segmented
sync is set to only decode cids as advertisements. The advertisement
entries are synced explicitly as part of processing logic and use a
scoped segment block hook to only decode entry chunks.

The default segment depth limit is set to 2K even though an indexer
instance can sync much larger DAGs in one go without hitting memory
issues. This is because the indexer could be syncing from many index
providers at the same time and the total sync time is not dramatically
impacted by the number of segments.

Fixes #487