### PR TITLE
Add memory optimized `r5a.2xlarge` workers to `dev`

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -27,6 +27,12 @@ module "eks" {
       desired_size   = 3
       instance_types = ["m4.xlarge"]
     }
+    dev-ue2-r5a-2xl = {
+      min_size       = 1
+      max_size       = 7
+      desired_size   = 1
+      instance_types = ["r5a.2xlarge"]
+    }
     dev-ue2-r5b-xl = {
       min_size       = 3
       max_size       = 3

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -12,6 +12,11 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2-r5a-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2-r5b-xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |


### PR DESCRIPTION
In order to accommodate resource limits for `autoretrieve` running in
`dev` environment, add new workers that can accommodate 32Gi memory for
pods.

Used `r5a.2xlarge` because it is the cheapest memory optimised instance
type with x86_64 arch needed by `autoretrieve`.

Relates to: https://github.com/application-research/autoretrieve/pull/61
