### PR TITLE
Fix intermittent test failures

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -46,8 +46,12 @@ func (e *e2eTestRunner) run(name string, args ...string) []byte {
 
 	cmd := exec.CommandContext(e.ctx, name, args...)
 	cmd.Env = e.env
+	// Behaviour seems to be platform specific.
+	// Assure std in/err is not set otherwise combined output fails.
+	cmd.Stdin = nil
+	cmd.Stderr = nil
 	out, err := cmd.CombinedOutput()
-	qt.Assert(e.t, err, qt.IsNil, qt.Commentf("output: %s", out))
+	qt.Assert(e.t, err, qt.IsNil, qt.Commentf("err: %v, output: %s", err, out))
 	return out
 }
 
@@ -122,7 +126,7 @@ func TestEndToEndWithReferenceProvider(t *testing.T) {
 	case "windows":
 		t.Skip("skipping test on", runtime.GOOS)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	e := &e2eTestRunner{
 		t:   t,

--- a/internal/ingest/synchandler.go
+++ b/internal/ingest/synchandler.go
@@ -9,7 +9,7 @@ type syncHandler struct {
 	ing *Ingester
 }
 
-func (h *syncHandler) SetLatestSync(p peer.ID, c cid.Cid) {
+func (h *syncHandler) SetLatestSync(peer.ID, cid.Cid) {
 	// NOOP
 	// We don't care what go-legs tells us about it's latest sync, we are using
 	// the latestSync mechanism to traverse to the last processed Ad.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -438,6 +438,7 @@ func TestPollProvider(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer r.Close()
 
 	peerID, err := peer.Decode(limitedID)
 	if err != nil {
@@ -547,6 +548,7 @@ func TestPollProviderOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer r.Close()
 
 	peerID, err := peer.Decode(limitedID)
 	if err != nil {


### PR DESCRIPTION
In `TestEndToEndWithReferenceProvider` reset `Stdin` and `Stderr` for
the command before running it in a combined output. Otherwise,
`CombinedOutput` will return an error. Increase total E2E test timeout
to 2 minutes, since it seems to intermittently fail on MacOS.

In `TestMultiplePublishers`, assert indices from each test publisher are
eventually indexed since the background ad processing might not have
finished when the sync returns. Assert Synced CID is equal to the
expected head before checking reference to the latest synced.

In `TestPollProvider` registry tests close the registry to avoid failure
in Windows when tests attempt to remove temporary files that otherwise
will be in use and cannot be deleted.

