### PR TITLE
Reduce verbose logging of HTTP sync requests

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -162,6 +162,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 	rclient.RetryMax = cfg.HttpSyncRetryMax
 	rclient.RetryWaitMin = time.Duration(cfg.HttpSyncRetryWaitMin)
 	rclient.RetryWaitMax = time.Duration(cfg.HttpSyncRetryWaitMax)
+	rclient.Logger = nil // Disable default verbose logging of every HTTP request.
 
 	// Create and start pubsub subscriber. This also registers the storage hook
 	// to index data as it is received.


### PR DESCRIPTION
`retriablehttp` log every request by default in DEBUG level. Disable it
to reduce noise in logs since HTTP failures are what we want to see in
logs, not access logs and that is already being logged by go-legs
loggers.
