### PR TITLE
Allow other randomly selected peer IDs in `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/config
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/config
@@ -40,7 +40,10 @@
     "Policy": {
       "Allow": false,
       "Except": [
-        "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC"
+        "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC",
+        "12D3KooWDtiA9w5c37MnFpGWr2M12m8neoUqDroHEMsJVuf3ELi7",
+        "12D3KooWBwUERBhJPtZ7hg5N3q1DesvJ67xx9RLdSaStBz9Y6Ny8",
+        "12D3KooWLDf6KCzeMv16qPRaJsTLKJ5fR523h65iaYSRNfrQy7eU"
       ],
       "Publish": true,
       "PublishExcept": null,


### PR DESCRIPTION
The only peer ID allowed belongs to a HTTP publisher. In order to
diversify the requests hitting `dev` environment add other peer IDs that
use data transfer publisher.

**Note that the PR is made to `cd/dev` branch to combine the changes on `dev` into a single deployment, instead of waiting for image update to roll out then the config change, since each pod restart takes about 30 minutes to rescan indices.**
