### PR TITLE
Reload policy and rate limit settings without restarting daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Administrative:
 - `admin` Perform admin activities with an indexer
   - `allow` Allow advertisements and content from peer
   - `block` Block advertisements and content from peer
-  - `reload` Reload the policy from the configuration file
+  - `reload` Reload the policy and ingest settings from the configuration file
   - `sync` Sync indexer with provider
 - `init` Initialize or upgrade indexer node config file
 

--- a/api/v0/admin/client/http/client.go
+++ b/api/v0/admin/client/http/client.go
@@ -120,9 +120,9 @@ func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Mu
 	return c.ingestRequest(ctx, peerID, "sync", http.MethodPost, data, q...)
 }
 
-// ReloadPolicy reloads the policy from the configuration file.
-func (c *Client) ReloadPolicy(ctx context.Context) error {
-	u := c.baseURL + path.Join(ingestResource, "reloadpolicy")
+// ReloadConfig reloads reloadable parts of the configuration file.
+func (c *Client) ReloadConfig(ctx context.Context) error {
+	u := c.baseURL + "/reloadconfig"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
 	if err != nil {

--- a/command/admin.go
+++ b/command/admin.go
@@ -32,7 +32,7 @@ var block = &cli.Command{
 
 var reload = &cli.Command{
 	Name:   "reload-config",
-	Usage:  "Reload policy and rate limit settings from the configuration file",
+	Usage:  "Reload policy, rate limit, workers, and batch settings from the configuration file",
 	Flags:  adminReloadConfigFlags,
 	Action: reloadConfigCmd,
 }

--- a/command/admin.go
+++ b/command/admin.go
@@ -31,10 +31,10 @@ var block = &cli.Command{
 }
 
 var reload = &cli.Command{
-	Name:   "reload-policy",
-	Usage:  "Reload the policy from the configuration file",
-	Flags:  adminReloadPolicyFlags,
-	Action: reloadPolicyCmd,
+	Name:   "reload-config",
+	Usage:  "Reload policy and rate limit settings from the configuration file",
+	Flags:  adminReloadConfigFlags,
+	Action: reloadConfigCmd,
 }
 
 var AdminCmd = &cli.Command{
@@ -107,15 +107,15 @@ func blockCmd(cctx *cli.Context) error {
 	return nil
 }
 
-func reloadPolicyCmd(cctx *cli.Context) error {
+func reloadConfigCmd(cctx *cli.Context) error {
 	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err
 	}
-	err = cl.ReloadPolicy(cctx.Context)
+	err = cl.ReloadConfig(cctx.Context)
 	if err != nil {
 		return err
 	}
-	fmt.Println("Reloaded policy from configuration file")
+	fmt.Println("Reloaded indexer configuration")
 	return nil
 }

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -493,6 +493,8 @@ func reloadConfig(filePath string, ingester *ingest.Ingester, reg *registry.Regi
 		if err != nil {
 			return fmt.Errorf("failed to set rate limit config: %w", err)
 		}
+		ingester.SetBatchSize(cfg.Ingest.StoreBatchSize)
+		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
 	}
 
 	fmt.Println("Reloaded policy and rate limit configuration")

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/filecoin-project/go-indexer-core"
@@ -15,7 +17,7 @@ import (
 	"github.com/filecoin-project/go-indexer-core/store/pogreb"
 	"github.com/filecoin-project/go-indexer-core/store/storethehash"
 	"github.com/filecoin-project/storetheindex/config"
-	legingest "github.com/filecoin-project/storetheindex/internal/ingest"
+	"github.com/filecoin-project/storetheindex/internal/ingest"
 	"github.com/filecoin-project/storetheindex/internal/lotus"
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	httpadminserver "github.com/filecoin-project/storetheindex/server/admin/http"
@@ -73,14 +75,14 @@ func daemonCommand(cctx *cli.Context) error {
 		logging.SetLogLevel("graphsync", "warn")
 	}
 
-	cfg, err := config.Load("")
+	cfg, err := loadConfig("")
 	if err != nil {
-		if err == config.ErrNotInitialized {
+		if errors.Is(err, config.ErrNotInitialized) {
 			fmt.Fprintln(os.Stderr, "storetheindex is not initialized")
 			fmt.Fprintln(os.Stderr, "To initialize, run the command: ./storetheindex init")
 			os.Exit(1)
 		}
-		return fmt.Errorf("cannot load config file: %w", err)
+		return err
 	}
 	if cfg.Version != config.Version {
 		log.Warn("Configuration file out-of-date. Upgrade by running: ./storetheindex init --upgrade")
@@ -162,7 +164,7 @@ func daemonCommand(cctx *cli.Context) error {
 
 	var (
 		cancelP2pServers context.CancelFunc
-		ingester         *legingest.Ingester
+		ingester         *ingest.Ingester
 		p2pHost          host.Host
 	)
 
@@ -201,7 +203,7 @@ func daemonCommand(cctx *cli.Context) error {
 		}
 
 		// Initialize ingester.
-		ingester, err = legingest.NewIngester(cfg.Ingest, p2pHost, indexerCore, reg, dstore)
+		ingester, err = ingest.NewIngester(cfg.Ingest, p2pHost, indexerCore, reg, dstore)
 		if err != nil {
 			return err
 		}
@@ -249,6 +251,8 @@ func daemonCommand(cctx *cli.Context) error {
 		}
 	}
 
+	reloadErrChan := make(chan chan error, 1)
+
 	// Create admin HTTP server
 	var adminSvr *httpadminserver.Server
 	if cfg.Addresses.Admin != "" && !cctx.Bool("noadmin") {
@@ -260,7 +264,7 @@ func daemonCommand(cctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		adminSvr, err = httpadminserver.New(adminAddr.String(), indexerCore, ingester, reg)
+		adminSvr, err = httpadminserver.New(adminAddr.String(), indexerCore, ingester, reg, reloadErrChan)
 		if err != nil {
 			return err
 		}
@@ -293,16 +297,36 @@ func daemonCommand(cctx *cli.Context) error {
 		fmt.Println("Ingest server:\t disabled")
 	}
 
+	reloadSig := make(chan os.Signal, 1)
+	signal.Notify(reloadSig, syscall.SIGHUP)
+
 	// Output message to user (not to log).
 	fmt.Println("Indexer is ready")
 
 	var finalErr error
-	select {
-	case <-cctx.Done():
-		// Command was canceled (ctrl-c)
-	case err = <-errChan:
-		log.Errorw("Failed to start server", "err", err)
-		finalErr = ErrDaemonStart
+	for endDaemon := false; !endDaemon; {
+		select {
+		case <-cctx.Done():
+			// Command was canceled (ctrl-c)
+			endDaemon = true
+		case err = <-errChan:
+			log.Errorw("Failed to start server", "err", err)
+			finalErr = ErrDaemonStart
+			endDaemon = true
+		case <-reloadSig:
+			reloadErrChan <- nil
+		case errChan := <-reloadErrChan:
+			err = reloadConfig("", ingester, reg)
+			if err != nil {
+				log.Errorw("Error reloading conifg", "err", err)
+				if errChan != nil {
+					err = errors.New("could not reload configuration")
+				}
+			}
+			if errChan != nil {
+				errChan <- err
+			}
+		}
 	}
 
 	log.Infow("Shutting down daemon")
@@ -382,4 +406,42 @@ func createValueStore(cfgIndexer config.Indexer) (indexer.Interface, error) {
 	}
 
 	return nil, fmt.Errorf("unrecognized store type: %s", cfgIndexer.ValueStoreType)
+}
+
+func loadConfig(filePath string) (*config.Config, error) {
+	cfg, err := config.Load(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load config file: %w", err)
+	}
+	if cfg.Version != config.Version {
+		log.Warn("Configuration file out-of-date. Upgrade by running: ./storetheindex init --upgrade")
+	}
+
+	if cfg.Datastore.Type != "levelds" {
+		return nil, fmt.Errorf("only levelds datastore type supported, %q not supported", cfg.Datastore.Type)
+	}
+
+	return cfg, nil
+}
+
+func reloadConfig(filePath string, ingester *ingest.Ingester, reg *registry.Registry) error {
+	cfg, err := loadConfig(filePath)
+	if err != nil {
+		return err
+	}
+
+	err = reg.SetPolicy(cfg.Discovery.Policy)
+	if err != nil {
+		return fmt.Errorf("failed to set policy config: %w", err)
+	}
+
+	if ingester != nil {
+		err = ingester.SetRateLimit(cfg.Ingest.RateLimit)
+		if err != nil {
+			return fmt.Errorf("failed to set rate limit config: %w", err)
+		}
+	}
+
+	fmt.Println("Reloaded policy and rate limit configuration")
+	return nil
 }

--- a/command/flags.go
+++ b/command/flags.go
@@ -79,6 +79,13 @@ var daemonFlags = []cli.Flag{
 		Value:    false,
 		Required: false,
 	},
+	&cli.BoolFlag{
+		Name:     "watch-config",
+		Usage:    "Watch for changes to config file and automatically reload",
+		EnvVars:  []string{"INDEXER_WATCH_CONFIG"},
+		Value:    false,
+		Required: false,
+	},
 }
 
 var findFlags = []cli.Flag{

--- a/command/flags.go
+++ b/command/flags.go
@@ -136,7 +136,7 @@ var adminPolicyFlags = []cli.Flag{
 	indexerHostFlag,
 }
 
-var adminReloadPolicyFlags = []cli.Flag{
+var adminReloadConfigFlags = []cli.Flag{
 	indexerHostFlag,
 }
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -112,6 +112,7 @@ Default:
   "NoResourceManager": false
 }
 ```
+
 ## `Bootstrap`
 Description: [Bootstrap](https://pkg.go.dev/github.com/filecoin-project/storetheindex/config#Bootstrap)
 
@@ -213,3 +214,10 @@ Default:
   "BurstSize": 500
 }
 ```
+
+## Runtime Reloadable Items
+The storetheindex daemon can reload some portions of its config without restarting the entire daemon. This is done by using the admin sub-command `reload-config`, send the daemon process a `SIGHUP` signal, or simply updating the config when the daemon is run with the `--watch-config` flag. The reloadable portions of the config files are:
+- [`Discovery.Policy`](#discoverypolicy)
+- [`Ingest.IngestWorkerCount`](#ingest)
+- [`Ingest.RateLimit`](#ingestratelimit)
+- [`Ingest.StoreBatchSize`](#ingest)

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -309,7 +309,9 @@ func (ing *Ingester) indexContentBlock(adCid cid.Cid, ad schema.Advertisement, p
 		}
 	}()
 
-	batch := make([]multihash.Multihash, 0, ing.batchSize)
+	batchSize := ing.BatchSize()
+
+	batch := make([]multihash.Multihash, 0, batchSize)
 	var prevBatch []multihash.Multihash
 
 	// Iterate over all entries and ingest (or remove) them.
@@ -330,7 +332,7 @@ func (ing *Ingester) indexContentBlock(adCid cid.Cid, ad schema.Advertisement, p
 			}
 			count += len(batch)
 			if prevBatch == nil {
-				prevBatch = make([]multihash.Multihash, 0, ing.batchSize)
+				prevBatch = make([]multihash.Multihash, 0, batchSize)
 			}
 			// Since batchChan is unbuffered, the goroutine is done reading the previous batch.
 			prevBatch, batch = batch, prevBatch

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -715,7 +715,7 @@ func (r *Registry) pollProviders(poll polling, pollOverrides map[peer.ID]polling
 				continue
 			}
 			poll.stopAfter += poll.interval
-			if noContactTime > poll.stopAfter {
+			if noContactTime >= poll.stopAfter {
 				// Too much time since last contact.
 				log.Warnw("Lost contact with provider's publisher", "publisher", info.Publisher, "provider", info.AddrInfo.ID, "since", info.lastContactTime)
 				// Remove the non-responsive publisher.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -569,16 +569,6 @@ func TestPollProviderOverrides(t *testing.T) {
 		t.Fatal("failed to register directly:", err)
 	}
 
-	r, err = NewRegistry(ctx, cfg, dstore, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = r.RegisterOrUpdate(ctx, peerID, []string{minerAddr}, cid.Undef, pub)
-	if err != nil {
-		t.Fatal("failed to register directly:", err)
-	}
-
 	poll := polling{
 		interval:   2 * time.Hour,
 		retryAfter: time.Hour,
@@ -587,6 +577,7 @@ func TestPollProviderOverrides(t *testing.T) {
 
 	overrides := make(map[peer.ID]polling)
 	overrides[peerID] = polling{
+		interval:   0,
 		retryAfter: time.Minute,
 		stopAfter:  time.Hour,
 	}


### PR DESCRIPTION
## Context
Use the admin sub-command `reload-config`, or send the daemon process a SIGHUP signal, to reload policy and rate limit settings from the config file.

## Proposed Changes
- New command `admin reload-config` to reload parts of config.
- Handles SIGHUP to signal daemon to reload portions of config.

## Tests
Manual testing for success and failure
 
## Revert Strategy
Change is safe to revert.
