### PR TITLE
Increase CPU limit in `dev` to `3.5`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -23,10 +23,10 @@ spec:
               mountPath: /identity
           resources:
             limits:
-              cpu: "2"
+              cpu: "3.5"
               memory: 25Gi
             requests:
-              cpu: "2"
+              cpu: "3.5"
               memory: 25Gi
       # Require r5b instance types to run index provider pods.
       tolerations:


### PR DESCRIPTION
The worker nodes dedicated to indexer nodes in `dev` have 4 compute
capacity. Around 500 millicpu is spent on daemon sets and other cluster
related pods.
Up the CPU to 3.5 in dev first to make sure the new CPU demand is
scheduled as expected before rolling the same changes on prod.

