### PR TITLE
Increase CPU resources in `prod` to `3.5`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -23,10 +23,10 @@ spec:
               mountPath: /identity
           resources:
             limits:
-              cpu: "2"
+              cpu: "3.5"
               memory: 25Gi
             requests:
-              cpu: "2"
+              cpu: "3.5"
               memory: 25Gi
       # Require r5b instance types to run index provider pods.
       tolerations:


### PR DESCRIPTION
The CPU usage in `prod` is at limit and the advertisement processing
is relatively slow. The worker nodes running the `prod` instances have
4 compute capacity and we can increase the CPU limit for indexers to
3.5, leaving 0.5 for the cluster related pods.

The `dev` environment is using the same worker type as prod with the
same cluster set up. Earlier commits confirmed that 3.5 CPU was
successfully scheduled by the K8S cluster.

Relates to: https://github.com/filecoin-project/storetheindex/issues/523