### PR TITLE
Assert ongoing announce does not deadlock ingestion

### DIFF
--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1093,6 +1093,68 @@ func TestAnnounceIsNotDeferredOnNoInProgressIngest(t *testing.T) {
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), mhs)
 }
 
+func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *testing.T) {
+	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
+	te := setupTestEnv(t, true, blockableLsysOpt)
+	defer te.Close(t)
+	headLink := typehelpers.RandomAdBuilder{
+		EntryChunkBuilders: []typehelpers.RandomEntryChunkBuilder{
+			{ChunkCount: 1, EntriesPerChunk: 1, EntriesSeed: 1}, // 0: A <- tail
+			{ChunkCount: 1, EntriesPerChunk: 1, EntriesSeed: 2}, // 1: B
+			{ChunkCount: 1, EntriesPerChunk: 1, EntriesSeed: 3}, // 2: C
+			{ChunkCount: 1, EntriesPerChunk: 1, EntriesSeed: 4}, // 3: D <- head
+		}}.Build(t, te.publisherLinkSys, te.publisherPriv)
+	headCid := headLink.(cidlink.Link).Cid
+	ads := typehelpers.AllAdLinks(t, headLink, te.publisherLinkSys)
+	mhs := typehelpers.AllMultihashesFromAdLink(t, headLink, te.publisherLinkSys)
+	pubAddrInfo := te.pubHost.Peerstore().PeerInfo(te.pubHost.ID())
+
+	// Block Ad C which should block the sync triggered by publisher.UpdateRoot.
+	adCCid := ads[2].(cidlink.Link).Cid
+	blockedReads.add(adCCid)
+
+	// Publish announce message on publisher side, which should trigger a background sync that
+	// gets blocked when attempting to sync ad C.
+	err := te.publisher.UpdateRoot(context.Background(), adCCid)
+	require.NoError(t, err)
+
+	// Assert that there is no announce pending processing since no explicit announce was made to
+	// storetheindex ingester.
+	_, found := te.ingester.providersPendingAnnounce.Load(te.pubHost.ID())
+	require.False(t, found)
+
+	// Block head ad which should block explicit Announce call made to the ingester.
+	blockedReads.add(headCid)
+
+	// Make an explicit announcement of head ad and assert that it was handled immediately since
+	// there is no in-progress entries processing yet; remember ad sync triggered by
+	// publisher.UpdateRoot is still blocked.
+	// Note that the background handling of the announce should get blocked since headCid is also
+	// in the block list.
+	err = te.ingester.Announce(context.Background(), headCid, pubAddrInfo)
+	require.NoError(t, err)
+	_, found = te.ingester.providersPendingAnnounce.Load(te.pubHost.ID())
+	require.False(t, found)
+
+	// Unblock the sync triggered by publisher.UpdateRoot which should:
+	// 1. cause the ad chain C->B->A to be downloaded.
+	// 2. work to be assigned to the ingest worker which should not be processed until the
+	//    blocked background sync started by the explicit announce is unblocked.
+	<-hitBlockedRead
+
+	// Assert that no multihashes are indexed since entries processing should be blocked.
+	requireNotIndexed(t, te.ingester.indexer, te.pubHost.ID(), mhs)
+
+	// Now unblock the background sync started by the explicit announce, which casues the head
+	// ad (D) to also be downloaded, and should eventually get indexed
+	<-hitBlockedRead
+
+	// Now that there is nothing blocked anymore, and the ingest has learn about all the ads,
+	// i,e, C->B->A through publisher.UpdateRoot, and D through explicit announce, all the entries
+	// should get indexed eventually.
+	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), mhs)
+}
+
 // Make new indexer engine
 func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
 	valueStore, err := storethehash.New(t.TempDir(), storethehash.IndexBitSize(8))


### PR DESCRIPTION
Add a test that asserts the entries ingestion pipeline does not deadlock
 when an announce is handled just after the ad chain sync has finished
and just before its entries are processed.

Relates to:
- https://github.com/filecoin-project/storetheindex/commit/cf70a62e2ece09f18021fa940cb0c9fe2238d045#r75038778

