### PR TITLE
Ignore invalid multihashes

### DIFF
--- a/internal/ingest/invalid_mh_ingest_test.go
+++ b/internal/ingest/invalid_mh_ingest_test.go
@@ -1,0 +1,61 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/storetheindex/test/typehelpers"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidMultihashesAreNotIngested(t *testing.T) {
+	te := setupTestEnv(t, true)
+	defer te.Close(t)
+
+	headAd := typehelpers.RandomAdBuilder{
+		EntryChunkBuilders: []typehelpers.RandomEntryChunkBuilder{
+			{ChunkCount: 1, EntriesPerChunk: 1, EntriesSeed: 1, WithInvalidMultihashes: true},
+			{ChunkCount: 1, EntriesPerChunk: 1, EntriesSeed: 2, WithInvalidMultihashes: false},
+			{ChunkCount: 1, EntriesPerChunk: 1, EntriesSeed: 3, WithInvalidMultihashes: true},
+		},
+	}.Build(t, te.publisherLinkSys, te.publisherPriv)
+	headAdCid := headAd.(cidlink.Link).Cid
+	ctx := context.Background()
+	err := te.publisher.SetRoot(ctx, headAdCid)
+	require.NoError(t, err)
+	mhs := typehelpers.AllMultihashesFromAdLink(t, headAd, te.publisherLinkSys)
+
+	providerID := te.pubHost.ID()
+	subject := te.ingester
+
+	wait, err := subject.Sync(ctx, providerID, nil, 0, false)
+	require.NoError(t, err)
+	gotHeadAd := <-wait
+
+	require.Equal(t, headAdCid, gotHeadAd, "Expected latest synced cid to match head of ad chain")
+
+	requireTrueEventually(t, func() bool {
+		return checkAllIndexed(subject.indexer, providerID, mhs[1:2]) == nil
+	}, testRetryInterval, testRetryTimeout, "Expected only valid multihashes to be indexed")
+
+	requireTrueEventually(t, func() bool {
+		latestSync, err := subject.GetLatestSync(providerID)
+		require.NoError(t, err)
+		return latestSync.Equals(headAdCid)
+	}, testRetryInterval, testRetryTimeout, "Expected all ads from publisher to have been indexed")
+
+	_, b, err := subject.indexer.Get(mhs[0])
+	require.NoError(t, err)
+	require.False(t, b)
+
+	get, b, err := subject.indexer.Get(mhs[1])
+	require.NoError(t, err)
+	require.True(t, b)
+	require.Equal(t, 1, len(get))
+	require.Equal(t, providerID, get[0].ProviderID)
+
+	_, b, err = subject.indexer.Get(mhs[2])
+	require.NoError(t, err)
+	require.False(t, b)
+}

--- a/test/typehelpers/typehelpers.go
+++ b/test/typehelpers/typehelpers.go
@@ -2,11 +2,11 @@ package typehelpers
 
 import (
 	"fmt"
-	"github.com/filecoin-project/storetheindex/test/util"
 	"math/rand"
 	"testing"
 
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/filecoin-project/storetheindex/test/util"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/linking"
@@ -209,12 +209,7 @@ func AllMultihashesFromAdChainDepth(t *testing.T, ad *schema.Advertisement, lsys
 			if err != nil {
 				return err
 			}
-			mh := multihash.Multihash(b)
-			//_, mh, err := multihash.MHFromBytes(b)
-			//if err != nil {
-			//	return err
-			//}
-			out = append(out, mh)
+			out = append(out, multihash.Multihash(b))
 			return nil
 		})
 	require.NoError(t, err)


### PR DESCRIPTION
Test that invalid multihashes are ignored.

**Only merge this if we _do not want_ to allow invalid multihashes**. Compare with #554