### PR TITLE
Log levels are configurable in config file and reloadable

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -491,8 +491,7 @@ func loadConfig(filePath string) (*config.Config, error) {
 }
 
 func reloadConfig(cctx *cli.Context, ingester *ingest.Ingester, reg *registry.Registry) error {
-	filePath := cctx.String("ConfigPath")
-	cfg, err := loadConfig(filePath)
+	cfg, err := loadConfig("")
 	if err != nil {
 		return err
 	}

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -65,13 +66,14 @@ var DaemonCmd = &cli.Command{
 }
 
 func daemonCommand(cctx *cli.Context) error {
-	err := logging.SetLogLevel("*", cctx.String("log-level"))
+	logLevel := strings.ToLower(cctx.String("log-level"))
+	err := logging.SetLogLevel("*", logLevel)
 	if err != nil {
 		return err
 	}
 	// Do not log some facilities at info or debug level, unless "log-all" flag
 	// is true.
-	if !cctx.Bool("log-all") && (cctx.String("log-level") == "info" || cctx.String("log-level") == "debug") {
+	if !cctx.Bool("log-all") && logLevel == "info" || logLevel == "debug" {
 		logging.SetLogLevel("basichost", "warn")
 		logging.SetLogLevel("bootstrap", "warn")
 		logging.SetLogLevel("dt_graphsync", "warn")

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -75,7 +75,7 @@ func daemonCommand(cctx *cli.Context) error {
 		return err
 	}
 
-	err = setLoggingConfig(cctx, cfg.Logging)
+	err = setLoggingConfig(cfg.Logging)
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,7 @@ func daemonCommand(cctx *cli.Context) error {
 		case <-reloadSig:
 			reloadErrChan <- nil
 		case errChan := <-reloadErrChan:
-			err = reloadConfig(cctx, ingester, reg)
+			err = reloadConfig(ingester, reg)
 			if err != nil {
 				log.Errorw("Error reloading conifg", "err", err)
 				if errChan != nil {
@@ -453,13 +453,9 @@ func createValueStore(cfgIndexer config.Indexer) (indexer.Interface, error) {
 	return nil, fmt.Errorf("unrecognized store type: %s", cfgIndexer.ValueStoreType)
 }
 
-func setLoggingConfig(cctx *cli.Context, cfgLogging config.Logging) error {
+func setLoggingConfig(cfgLogging config.Logging) error {
 	// Set overall log level.
-	logLevel := cctx.String("log-level")
-	if logLevel == "" {
-		logLevel = cfgLogging.Level
-	}
-	err := logging.SetLogLevel("*", logLevel)
+	err := logging.SetLogLevel("*", cfgLogging.Level)
 	if err != nil {
 		return err
 	}
@@ -490,7 +486,7 @@ func loadConfig(filePath string) (*config.Config, error) {
 	return cfg, nil
 }
 
-func reloadConfig(cctx *cli.Context, ingester *ingest.Ingester, reg *registry.Registry) error {
+func reloadConfig(ingester *ingest.Ingester, reg *registry.Registry) error {
 	cfg, err := loadConfig("")
 	if err != nil {
 		return err
@@ -510,7 +506,7 @@ func reloadConfig(cctx *cli.Context, ingester *ingest.Ingester, reg *registry.Re
 		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
 	}
 
-	err = setLoggingConfig(cctx, cfg.Logging)
+	err = setLoggingConfig(cfg.Logging)
 	if err != nil {
 		return fmt.Errorf("failed to configure logging: %w", err)
 	}

--- a/command/flags.go
+++ b/command/flags.go
@@ -49,13 +49,6 @@ var daemonFlags = []cli.Flag{
 	cacheSizeFlag,
 	logLevelFlag,
 	&cli.BoolFlag{
-		Name:     "log-all",
-		Usage:    "Log for subsystems that are normally only logged at warn level",
-		EnvVars:  []string{"LOG_ALL"},
-		Value:    false,
-		Required: false,
-	},
-	&cli.BoolFlag{
 		Name:     "noadmin",
 		Usage:    "Disable admin server",
 		Value:    false,

--- a/command/flags.go
+++ b/command/flags.go
@@ -30,14 +30,6 @@ var fileFlag = &cli.StringFlag{
 	Required: true,
 }
 
-var logLevelFlag = &cli.StringFlag{
-	Name:     "log-level",
-	Usage:    "Set the log level",
-	EnvVars:  []string{"GOLOG_LOG_LEVEL"},
-	Value:    "info",
-	Required: false,
-}
-
 var providerFlag = &cli.StringFlag{
 	Name:     "provider",
 	Usage:    "Provider's peer ID",
@@ -47,7 +39,6 @@ var providerFlag = &cli.StringFlag{
 
 var daemonFlags = []cli.Flag{
 	cacheSizeFlag,
-	logLevelFlag,
 	&cli.BoolFlag{
 		Name:     "noadmin",
 		Usage:    "Disable admin server",

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Discovery Discovery // provider pubsub peers
 	Indexer   Indexer   // indexer code configuration
 	Ingest    Ingest    // ingestion related configuration.
+	Logging   Logging   // logging configuration.
 }
 
 const (
@@ -105,6 +106,7 @@ func Load(filePath string) (*Config, error) {
 		Discovery: NewDiscovery(),
 		Indexer:   NewIndexer(),
 		Ingest:    NewIngest(),
+		Logging:   NewLogging(),
 	}
 
 	if err = json.NewDecoder(f).Decode(&cfg); err != nil {
@@ -178,4 +180,5 @@ func (c *Config) populateUnset() {
 	c.Discovery.populateUnset()
 	c.Indexer.populateUnset()
 	c.Ingest.populateUnset()
+	c.Logging.populateUnset()
 }

--- a/config/init.go
+++ b/config/init.go
@@ -29,6 +29,7 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		Identity:  identity,
 		Indexer:   NewIndexer(),
 		Ingest:    NewIngest(),
+		Logging:   NewLogging(),
 	}
 
 	return conf, nil

--- a/config/logging.go
+++ b/config/logging.go
@@ -1,0 +1,41 @@
+package config
+
+// Logging configures overall and logger-specific log levels. Level values are
+// case-insensitive and include the following in order of importance: "fatal",
+// "panic", "dpanic", ""error", "warn", "info", "debug"
+type Logging struct {
+	// Level sets the log level for all loggers that do not have a setting in
+	// Loggers. The default value is "info".
+	Level string
+	// Loggers sets log levels for individual loggers.
+	Loggers map[string]string
+}
+
+// NewLogging returns Logging with values set to their defaults.
+func NewLogging() Logging {
+	return Logging{
+		Level: "info",
+		Loggers: map[string]string{
+			"basichost":    "warn",
+			"bootstrap":    "warn",
+			"dt_graphsync": "warn",
+			"dt-impl":      "warn",
+			"graphsync":    "warn",
+		},
+	}
+}
+
+// populateUnset replaces zero-values in the config with default values.
+func (c *Logging) populateUnset() {
+	def := NewLogging()
+
+	if c.Level == "" {
+		c.Level = def.Level
+
+		// If not default logging level was set, and no level set for loggers,
+		// then set levels for certain loggers.
+		if len(c.Loggers) == 0 {
+			c.Loggers = def.Loggers
+		}
+	}
+}

--- a/config/logging.go
+++ b/config/logging.go
@@ -32,7 +32,7 @@ func (c *Logging) populateUnset() {
 	if c.Level == "" {
 		c.Level = def.Level
 
-		// If not default logging level was set, and no level set for loggers,
+		// If no overall logging level was set, and no level set for loggers,
 		// then set levels for certain loggers.
 		if len(c.Loggers) == 0 {
 			c.Loggers = def.Loggers


### PR DESCRIPTION
Log levels are now configurable in the config file. An overall log level setting is configurable, as well as the settings for any logger that should not have the same level as the overall setting. These config settings are reloaded when the config file is reloaded at runtime.

If there is no logging configuration, the default log level is set to "info" and the loggers "basichost", "bootstrap", "dt_graphsync", "dt-impl", and "graphsync" are set to level "warn".