### PR TITLE
More config items

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -63,12 +63,10 @@ var daemonFlags = []cli.Flag{
 		Required: false,
 	},
 	&cli.BoolFlag{
-		Name:  "watch-config",
-		Usage: "Watch for changes to config file and automatically reload",
-		// Note: `INDEXER_WATCH_CONFIG` is added for backward compatibility.
-		//       Remove it once `STORETHEINDEX_WATCH_CONFIG` is rolled out in both environments.
-		EnvVars:  []string{"INDEXER_WATCH_CONFIG", "STORETHEINDEX_WATCH_CONFIG"},
-		Value:    false,
+		Name:     "watch-config",
+		Usage:    "Watch for changes to config file and automatically reload",
+		EnvVars:  []string{"STORETHEINDEX_WATCH_CONFIG"},
+		Value:    true,
 		Required: false,
 	},
 }

--- a/command/flags.go
+++ b/command/flags.go
@@ -18,9 +18,8 @@ var indexerHostFlag = &cli.StringFlag{
 
 var cacheSizeFlag = &cli.Int64Flag{
 	Name:     "cachesize",
-	Usage:    "Maximum number of multihashes that result cache can hold, 0 to disable cache",
+	Usage:    "Maximum number of multihashes that result cache can hold, -1 to disable cache",
 	Required: false,
-	Value:    -1,
 }
 
 var fileFlag = &cli.StringFlag{

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -4,13 +4,20 @@ import (
 	"time"
 )
 
-// Indexer holds configuration for the indexer core.
+// Indexer holds configuration for the indexer core. Setting any of these items
+// to their zero-value configures the default value.
 type Indexer struct {
-	// Maximum number of CIDs that cache can hold. Setting to 0 disables cache.
+	// Maximum number of CIDs that cache can hold. Setting to -1 disables the
+	// cache.
 	CacheSize int
+	// ConfigCheckInterval is the time between config file update checks.
+	ConfigCheckInterval Duration
 	// GCInterval configures the garbage collection interval for valuestores
 	// that support it.
 	GCInterval Duration
+	// ShutdownTimeout is the duration that a graceful shutdown has to complete
+	// before the daemon process is terminated.
+	ShutdownTimeout Duration
 	// Directory where value store is kept. If this is not an absolute path
 	// then the location is relative to the indexer repo directory.
 	ValueStoreDir string
@@ -21,10 +28,12 @@ type Indexer struct {
 // NewIndexer returns Indexer with values set to their defaults.
 func NewIndexer() Indexer {
 	return Indexer{
-		CacheSize:      300000,
-		GCInterval:     Duration(30 * time.Minute),
-		ValueStoreDir:  "valuestore",
-		ValueStoreType: "sth",
+		CacheSize:           300000,
+		ConfigCheckInterval: Duration(30 * time.Minute),
+		GCInterval:          Duration(30 * time.Minute),
+		ShutdownTimeout:     Duration(10 * time.Second),
+		ValueStoreDir:       "valuestore",
+		ValueStoreType:      "sth",
 	}
 }
 
@@ -35,8 +44,14 @@ func (c *Indexer) populateUnset() {
 	if c.CacheSize == 0 {
 		c.CacheSize = def.CacheSize
 	}
+	if c.ConfigCheckInterval == 0 {
+		c.ConfigCheckInterval = def.ConfigCheckInterval
+	}
 	if c.GCInterval == 0 {
 		c.GCInterval = def.GCInterval
+	}
+	if c.ShutdownTimeout == 0 {
+		c.ShutdownTimeout = def.ShutdownTimeout
 	}
 	if c.ValueStoreDir == "" {
 		c.ValueStoreDir = def.ValueStoreDir

--- a/doc/config.md
+++ b/doc/config.md
@@ -68,13 +68,19 @@ config file at runtime.
   },
   "Indexer": {
     "CacheSize": 300000,
+    "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
+    "ShutdownTimeout": "10s",
     "ValueStoreDir": "valuestore",
     "ValueStoreType": "sth"
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
     "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
     "IngestWorkerCount": 10,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {
@@ -85,11 +91,7 @@ config file at runtime.
     },
     "StoreBatchSize": 4096,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "HttpSyncRetryWaitMin": "1s",
-    "HttpSyncRetryWaitMax": "30s",
-    "HttpSyncRetryMax": 4,
-    "HttpSyncTimeout": "10s"
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",
@@ -211,15 +213,16 @@ Default:
 "Ingest": {
   "AdvertisementDepthLimit": 33554432,
   "EntriesDepthLimit": 65536,
+  "HttpSyncRetryMax": 4,
+  "HttpSyncRetryWaitMax": "30s",
+  "HttpSyncRetryWaitMin": "1s",
+  "HttpSyncTimeout": "10s",
   "IngestWorkerCount": 10,
   "PubSubTopic": "/indexer/ingest/mainnet",
   "RateLimit": {},
   "StoreBatchSize": 4096,
-  "SyncTimeout": "2h0m0s",
-  "HttpSyncRetryWaitMin": "1s",
-  "HttpSyncRetryWaitMax": "30s",
-  "HttpSyncRetryMax": 4,
-  "HttpSyncTimeout": "10s"
+  "SyncSegmentDepthLimit": 2000,
+  "SyncTimeout": "2h0m0s"
 }
 ```
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -84,7 +84,22 @@ config file at runtime.
       "BurstSize": 500
     },
     "StoreBatchSize": 4096,
-    "SyncTimeout": "2h0m0s"
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryMax": 4,
+    "HttpSyncTimeout": "10s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
   }
 }
 ```
@@ -180,7 +195,9 @@ Default:
 ```json
 "Indexer": {
   "CacheSize": 300000,
+  "ConfigCheckInterval": "30s",
   "GCInterval": "30m0s",
+  "ShutdownTimeout": "10s",
   "ValueStoreDir": "valuestore",
   "ValueStoreType": "sth"
 }
@@ -198,7 +215,11 @@ Default:
   "PubSubTopic": "/indexer/ingest/mainnet",
   "RateLimit": {},
   "StoreBatchSize": 4096,
-  "SyncTimeout": "2h0m0s"
+  "SyncTimeout": "2h0m0s",
+  "HttpSyncRetryWaitMin": "1s",
+  "HttpSyncRetryWaitMax": "30s",
+  "HttpSyncRetryMax": 4,
+  "HttpSyncTimeout": "10s"
 }
 ```
 
@@ -215,9 +236,30 @@ Default:
 }
 ```
 
+## `Logging`
+Description: [Logging](https://pkg.go.dev/github.com/filecoin-project/storetheindex/config#Logging)
+
+Default:
+```json
+"Logging": {
+  "Level": "info",
+  "Loggers": {
+    "basichost": "warn",
+    "bootstrap": "warn",
+    "dt-impl": "warn",
+    "dt_graphsync": "warn",
+    "graphsync": "warn"
+  }
+}
+```
+
 ## Runtime Reloadable Items
 The storetheindex daemon can reload some portions of its config without restarting the entire daemon. This is done by editing the config file and then using the admin sub-command `reload-config` or sending the daemon process a `SIGHUP` signal. The daemon will automatically reload the edited config after 30 seconds when the daemon is run with the `--watch-config` flag or with the environ variable `STORETHEINDEX_WATCH_CONFIG=true`. The reloadable portions of the config files are:
+
 - [`Discovery.Policy`](#discoverypolicy)
+- [`Indexer.ConfigCheckInterval`](#indexer)
+- [`Indexer.ShutdownTimeout`](#indexer)
 - [`Ingest.IngestWorkerCount`](#ingest)
 - [`Ingest.RateLimit`](#ingestratelimit)
 - [`Ingest.StoreBatchSize`](#ingest)
+- [`Logging`](#logging)


### PR DESCRIPTION
## Context
Some additional time settings were moved into the config file in order to change them without a software update. The `ShutdownTimeout` may need to be adjusted as it can take longer to shutdown an indexer if it is very busy.

Automatic config reload is now enabled by default.  There really is no reason to have this disabled, and it is much worse to accidentally not enable it should it become necessary to reload config items without a restart.

Fixed a problem configuring indexer core cache to be disabled.  Previously, setting the cache size to 0 was supposed to disable the cache, but instead only configured the default.  Now, `-1` is used to disable the cache, and the meaning of value 0 (use default) is consistent with all other `Indexer` config items.

## Proposed Changes
- Move `CheckConfigInterval` into config file
- Move `ShutdownTimeout` into config file
- Make the above values reloadable
- Fix the ability to configure disabled core cache
- Update config doc to describe logging config
- Enable `watch-config` by default

## Tests
- Manual tests of cache size configuration, `ConfigCheckInterval`, and `ShutdownTimeout`.
- Manual test to check the watch-config on by default.

## Revert Strategy
Change is safe to revert.
