### PR TITLE
Add command to import providers from another indexer

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -220,6 +220,16 @@ var providersListFlags = []cli.Flag{
 	indexerHostFlag,
 }
 
+var importProvidersFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:     "from",
+		Usage:    "Host or host:port of indexer to get providers from",
+		Aliases:  []string{"f"},
+		Required: true,
+	},
+	indexerHostFlag,
+}
+
 var registerFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:     "config",

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -62,6 +62,7 @@ func New(listen string, indexer indexer.Interface, ingester *ingest.Ingester, re
 
 	// Admin routes
 	r.HandleFunc("/healthcheck", h.healthCheckHandler).Methods(http.MethodGet)
+	r.HandleFunc("/importproviders", h.importProviders).Methods(http.MethodPost)
 	r.HandleFunc("/reloadconfig", h.reloadConfig).Methods(http.MethodPost)
 
 	// Ingester routes


### PR DESCRIPTION
The "admin import-providers" subcommand imports providers from another indexer. The other indexer is specified using the `--from` flag and specifying the host:port of the other indexer.

After importing publishers, sync with them immediately.