### PR TITLE
Add ability to configure re-publishing direct announce messages

### DIFF
--- a/config/ingest.go
+++ b/config/ingest.go
@@ -46,6 +46,11 @@ type Ingest struct {
 	PubSubTopic string
 	// RateLimit contains rate-limiting configuration.
 	RateLimit RateLimit
+	// ResendDirectAnnounce determines whether or not to re-publish direct
+	// announce messages over gossip pubsub. When a single indexer receives an
+	// announce message via HTTP, enabling this lets the indexers re-publish
+	// the announce so that other indexers can also receive it.
+	ResendDirectAnnounce bool
 	// StoreBatchSize is the number of entries in each write to the value
 	// store. Specifying a value less than 2 disables batching. This should be
 	// smaller than the maximum number of multihashes in an entry block to

--- a/doc/config.md
+++ b/doc/config.md
@@ -89,6 +89,7 @@ config file at runtime.
       "BlocksPerSecond": 100,
       "BurstSize": 500
     },
+    "ResendDirectAnnounce": true,
     "StoreBatchSize": 4096,
     "SyncSegmentDepthLimit": 2000,
     "SyncTimeout": "2h0m0s"
@@ -220,6 +221,7 @@ Default:
   "IngestWorkerCount": 10,
   "PubSubTopic": "/indexer/ingest/mainnet",
   "RateLimit": {},
+  "ResendDirectAnnounce": false,
   "StoreBatchSize": 4096,
   "SyncSegmentDepthLimit": 2000,
   "SyncTimeout": "2h0m0s"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.16
-	github.com/filecoin-project/go-legs v0.4.4
+	github.com/filecoin-project/go-legs v0.4.5
 	github.com/frankban/quicktest v1.14.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.16 h1:1SmJVhfHTsi0CC+U6JdyjIIQtOqmKvCl/tqpI3gI+18=
 github.com/filecoin-project/go-indexer-core v0.2.16/go.mod h1:5kCKyhtT9k1vephr9l9SFGX8B/HowXIvOhGCkmbxwbY=
-github.com/filecoin-project/go-legs v0.4.4 h1:mpMmAOOnamaz0CV9rgeKhEWA8j9kMC+f+UGCGrxKaZo=
-github.com/filecoin-project/go-legs v0.4.4/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
+github.com/filecoin-project/go-legs v0.4.5 h1:ZaxURLNu5i9mQyXcDhjxunX2kDp+exaZ98UyIFTvBJ4=
+github.com/filecoin-project/go-legs v0.4.5/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd h1:Ykxbz+LvSCUIl2zFaaPGmF8KHXTJu9T/PymgHr7IHjs=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -188,6 +188,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 		legs.SegmentDepthLimit(int64(cfg.SyncSegmentDepthLimit)),
 		legs.HttpClient(rclient.StandardClient()),
 		legs.BlockHook(ing.generalLegsBlockHook),
+		legs.ResendAnnounce(cfg.ResendDirectAnnounce),
 	)
 
 	if err != nil {


### PR DESCRIPTION
The latest go-legs has the ability to re-publish direct announce messages over pubsub. This PR gives the indexer the ability to be configured to enable/disable this feature.

Fixes issue #582 