### PR TITLE
Onboard `index-provider` as a tenant of `dev` cluster

### DIFF
--- a/deploy/infrastructure/common/ecr.tf
+++ b/deploy/infrastructure/common/ecr.tf
@@ -5,6 +5,7 @@ module "ecr_ue2" {
     "storetheindex/storetheindex",
     "index-observer/index-observer",
     "autoretrieve/autoretrieve",
+    "index-provider/index-provider",
   ]
   tags = local.tags
 }

--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -49,6 +49,7 @@ module "github_actions_role" {
 
   oidc_subjects_with_wildcards = [
     "repo:filecoin-project/storetheindex:*",
+    "repo:filecoin-project/index-provider:*",
     "repo:filecoin-shipyard/index-observer:*",
     "repo:application-research/autoretrieve:*"
   ]

--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -38,7 +38,7 @@ module "eks" {
       max_size       = 3
       desired_size   = 3
       instance_types = ["r5b.xlarge"]
-      taints         = {
+      taints = {
         dedicated = {
           key    = "dedicated"
           value  = "r5b"

--- a/deploy/infrastructure/dev/us-east-2/index-provider.tf
+++ b/deploy/infrastructure/dev/us-east-2/index-provider.tf
@@ -1,0 +1,71 @@
+resource "aws_kms_alias" "kms_index_provider" {
+  target_key_id = aws_kms_key.kms_index_provider.key_id
+  name          = "alias${local.iam_path}index_provider"
+}
+
+resource "aws_kms_key" "kms_index_provider" {
+  description = "Key used to encrypt index_provider tenant secrets"
+  policy      = data.aws_iam_policy_document.kms_index_provider.json
+  is_enabled  = true
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "kms_index_provider" {
+  statement {
+    sid = "Enable IAM User Permissions"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::407967248065:root"]
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow access for Devs via sops"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::407967248065:user/masih",
+        "arn:aws:iam::407967248065:user/marco",
+        "arn:aws:iam::407967248065:user/gammazero",
+        "arn:aws:iam::407967248065:user/will.scott",
+        "arn:aws:iam::407967248065:user/kylehuntsman",
+        "arn:aws:iam::407967248065:user/steveFraser",
+        "arn:aws:iam::407967248065:user/cmharden",
+      ]
+    }
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+  }
+
+
+  statement {
+    sid = "Allow Flux to decrypt"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        module.kustomize_controller_role.iam_role_arn
+      ]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+  }
+}

--- a/deploy/infrastructure/dev/us-east-2/kms.tf
+++ b/deploy/infrastructure/dev/us-east-2/kms.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "kust_ctrlr" {
       "kms:DescribeKey",
     ]
 
-    resources = [aws_kms_key.kms_sti.arn, aws_kms_key.kms_cluster.arn, aws_kms_key.kms_autoretrieve.arn]
+    resources = [aws_kms_key.kms_sti.arn, aws_kms_key.kms_cluster.arn, aws_kms_key.kms_autoretrieve.arn, aws_kms_key.kms_index_provider.arn]
   }
 }
 

--- a/deploy/infrastructure/dev/us-east-2/outputs.tf
+++ b/deploy/infrastructure/dev/us-east-2/outputs.tf
@@ -10,6 +10,10 @@ output "kms_autoretrieve_alias_arn" {
   value = aws_kms_alias.kms_autoretrieve.arn
 }
 
+output "kms_index_provider_alias_arn" {
+  value = aws_kms_alias.kms_index_provider.arn
+}
+
 output "kustomize_controller_role_arn" {
   value = module.kustomize_controller_role.iam_role_arn
 }

--- a/deploy/manifests/dev/us-east-2/cluster/index-provider/.sops.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-provider/.sops.yaml
@@ -1,0 +1,6 @@
+creation_rules:
+  - path_regex: '.+\.env'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/cluster'
+  - path_regex: '.+\.y(a)?ml'
+    encrypted_regex: '^(data|stringData)$'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/cluster'

--- a/deploy/manifests/dev/us-east-2/cluster/index-provider/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-provider/flux-cd.yaml
@@ -1,0 +1,91 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: index-provider
+spec:
+  interval: 5m
+  url: https://github.com/filecoin-project/index-provider.git
+  ref:
+    branch: main
+  secretRef:
+    name: github-auth
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: index-provider
+spec:
+  serviceAccountName: flux
+  decryption:
+    provider: sops
+  interval: 5m
+  path: "./deploy/manifests/dev/us-east-2"
+  sourceRef:
+    kind: GitRepository
+    name: index-provider
+  prune: true
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: index-provider
+spec:
+  interval: 5m
+  image: 407967248065.dkr.ecr.us-east-2.amazonaws.com/index-provider/index-provider
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1alpha1
+kind: ImagePolicy
+metadata:
+  name: index-provider
+spec:
+  filterTags:
+    pattern: '^(?P<timestamp>\d+)-.+$'
+    extract: '$timestamp'
+  policy:
+    numerical:
+      order: asc
+  imageRepositoryRef:
+    name: index-provider
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: index-provider
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: index-provider
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        name: sti-bot
+        email: sti-bot@protocol.ai
+      messageTemplate: |
+        Update {{ .AutomationObject.Namespace }}/{{ .AutomationObject.Name }} in `dev` environment
+        
+        Files:
+        {{ range $filename, $_ := .Updated.Files -}}
+        - {{ $filename }}
+        {{ end -}}
+        
+        Objects:
+        {{ range $resource, $_ := .Updated.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+        
+        Images:
+        {{ range .Updated.Images -}}
+        - {{.}}
+        {{ end -}}
+    push:
+      branch: 'cd/dev'
+  update:
+    strategy: Setters
+    path: "./deploy/manifests/dev/us-east-2"

--- a/deploy/manifests/dev/us-east-2/cluster/index-provider/flux-rbac.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-provider/flux-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flux
+rules:
+  - apiGroups: [ '*' ]
+    resources: [ '*' ]
+    verbs: [ '*' ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flux
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: index-provider

--- a/deploy/manifests/dev/us-east-2/cluster/index-provider/github-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-provider/github-auth.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: github-auth
+    namespace: index-provider
+type: Opaque
+stringData:
+    username: ENC[AES256_GCM,data:ksmDR6jmsw==,iv:OmjzLpU++L1vsuraWh84wzj0pIKgHS9LsgHOF6ijwtQ=,tag:/mFjfeygxlgN/82APndG9Q==,type:str]
+    password: ENC[AES256_GCM,data:Tobrq901GrlW2nMsgA3XpofF48+SYV4IBg1lyqCn6+bv7F6npyg/xA==,iv:ikKjumEXc5xkK6E6DAfO2pi1LcAwnNZAT27mou6Ysh4=,tag:QKh2xKqwLeB0daHV+EK88w==,type:str]
+sops:
+    kms:
+        - arn: arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/cluster
+          created_at: "2022-06-24T15:36:27Z"
+          enc: AQICAHjPLKH8p/5QB+TsPnURNgsbMMOlVWn14S9WvEpahS2p4wEy4eYH3r9Xm26EGTu/Q95uAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMH6pJH61KX4EC35ECAgEQgDutf0FfoDdajEl46V/VyF7y2q14sdgTJQdjmzKl8oNxKv1uA/zMG4xf1hoB816uAFSj1EuIlNYeCuEh6Q==
+          aws_profile: ""
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-06-24T15:36:28Z"
+    mac: ENC[AES256_GCM,data:5y14En7OrfMhEc08dwzJYBv/5AFoGFgdmQFtTUgxscbcFvoRr2k3w0h26UKXDPZzZEqkX194B4KJIyrtTf4hDllTWHMwR6yc9+DBnucngX2xiU4dxhcQIV/FZu+Vk78INGIXbpEr9RkSEoSMAgtgeVWpSS/qRLzjpOWYxGzs4mc=,iv:A5NOhbr1GLyT2K9FnKV4xXwGn1XRXsMf1kelJ2VjXq0=,tag:mNiuN6u2Ux6+YETiI0MYTA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.2

--- a/deploy/manifests/dev/us-east-2/cluster/index-provider/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-provider/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: index-provider
+
+commonLabels:
+  toolkit.fluxcd.io/tenant: index-provider
+
+resources:
+  - namespace.yaml
+  - flux-cd.yaml
+  - flux-rbac.yaml
+  - github-auth.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/index-provider/namespace.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/index-provider/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: index-provider

--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - promtail
   - index-observer
   - autoretrieve
+  - index-provider


### PR DESCRIPTION
* Create a KMS key to encrypt index-provider application secrets.
* Create an ECR repository to which containers will be published.
* Authorize GitHub actions to accept ECR publication from index-provider
  repo.
* Create a namespace and set up Flux CD pipeline for the index-provider.

Relates to:
 - https://github.com/filecoin-project/index-provider/issues/246
