### PR TITLE
fix(autoretrieve): fix flux branch

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-cd.yaml
@@ -62,7 +62,7 @@ spec:
   git:
     checkout:
       ref:
-        branch: master
+        branch: main
     commit:
       author:
         name: sti-bot


### PR DESCRIPTION
# Goals

In updating the auto retrieve flux config, I think I messed up the ImageUpdateAutomation task, as the new repo uses main.

see this line in flux logs:
```
2022-07-05T19:18:06.234Z error ImageUpdateAutomation/autoretrieve.autoretrieve - Reconciler error unable to clone 'https://github.com/filecoin-project/autoretrieve-deploy.git': reference 'refs/remotes/origin/master' not found
```

# Implementation

change branch to main
