### PR TITLE
don't return providers after polling has stopped

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -83,7 +83,7 @@ func daemonCommand(cctx *cli.Context) error {
 	}
 
 	// Create a valuestore of the configured type.
-	valueStore, err := createValueStore(cfg.Indexer)
+	valueStore, err := createValueStore(cctx.Context, cfg.Indexer)
 	if err != nil {
 		return err
 	}
@@ -455,7 +455,7 @@ func fileChanged(filePath string, modTime time.Time) (time.Time, bool, error) {
 	return modTime, false, nil
 }
 
-func createValueStore(cfgIndexer config.Indexer) (indexer.Interface, error) {
+func createValueStore(ctx context.Context, cfgIndexer config.Indexer) (indexer.Interface, error) {
 	dir, err := config.Path("", cfgIndexer.ValueStoreDir)
 	if err != nil {
 		return nil, err
@@ -468,7 +468,7 @@ func createValueStore(cfgIndexer config.Indexer) (indexer.Interface, error) {
 
 	switch cfgIndexer.ValueStoreType {
 	case vstoreStorethehash:
-		return storethehash.New(dir, storethehash.GCInterval(time.Duration(cfgIndexer.GCInterval)))
+		return storethehash.New(ctx, dir, storethehash.GCInterval(time.Duration(cfgIndexer.GCInterval)))
 	case vstorePogreb:
 		return pogreb.New(dir)
 	case vstoreMemory:

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.2.17
-	github.com/filecoin-project/go-legs v0.4.5
+	github.com/filecoin-project/go-indexer-core v0.2.18-0.20220720202247-6216bb1a7c71
+	github.com/filecoin-project/go-legs v0.4.6
 	github.com/frankban/quicktest v1.14.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1
@@ -113,7 +113,7 @@ require (
 	github.com/ipfs/go-verifcid v0.0.1 // indirect
 	github.com/ipld/edelweiss v0.1.2 // indirect
 	github.com/ipld/go-codec-dagpb v1.4.0 // indirect
-	github.com/ipld/go-storethehash v0.1.8 // indirect
+	github.com/ipld/go-storethehash v0.1.9 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.2.18-0.20220720202247-6216bb1a7c71
+	github.com/filecoin-project/go-indexer-core v0.2.18
 	github.com/filecoin-project/go-legs v0.4.6
 	github.com/frankban/quicktest v1.14.3
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2-0.20220616083012-ea4de61af1
 github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.2.18-0.20220720202247-6216bb1a7c71 h1:KDYjP5x5yVKxGZbBg8ltK9lyz2taj0hYnfQPaLDqtZ0=
-github.com/filecoin-project/go-indexer-core v0.2.18-0.20220720202247-6216bb1a7c71/go.mod h1:BIsKVvT0X6H5+rma35+gGXVaS1TNN4LFuWfp646OPBA=
+github.com/filecoin-project/go-indexer-core v0.2.18 h1:zSWFh88CjdctKFQm4oLwQ0GoZFJ4cHQbyffq0o+a9NM=
+github.com/filecoin-project/go-indexer-core v0.2.18/go.mod h1:BIsKVvT0X6H5+rma35+gGXVaS1TNN4LFuWfp646OPBA=
 github.com/filecoin-project/go-legs v0.4.6 h1:u7sj4wE5l7An5wI3I3YnXcLikKAKxTbPk2vxd67lS9s=
 github.com/filecoin-project/go-legs v0.4.6/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=

--- a/go.sum
+++ b/go.sum
@@ -257,10 +257,10 @@ github.com/filecoin-project/go-data-transfer v1.15.2-0.20220616083012-ea4de61af1
 github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.2.17 h1:rHApNPY4Vjnewlo66r9/k08OrUjcTkGu+KOh1qnZkDY=
-github.com/filecoin-project/go-indexer-core v0.2.17/go.mod h1:M3jX8aaXgAsZf9IR2Uwvnri3Sw+RXrqUx6oQlUPqJeU=
-github.com/filecoin-project/go-legs v0.4.5 h1:ZaxURLNu5i9mQyXcDhjxunX2kDp+exaZ98UyIFTvBJ4=
-github.com/filecoin-project/go-legs v0.4.5/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
+github.com/filecoin-project/go-indexer-core v0.2.18-0.20220720202247-6216bb1a7c71 h1:KDYjP5x5yVKxGZbBg8ltK9lyz2taj0hYnfQPaLDqtZ0=
+github.com/filecoin-project/go-indexer-core v0.2.18-0.20220720202247-6216bb1a7c71/go.mod h1:BIsKVvT0X6H5+rma35+gGXVaS1TNN4LFuWfp646OPBA=
+github.com/filecoin-project/go-legs v0.4.6 h1:u7sj4wE5l7An5wI3I3YnXcLikKAKxTbPk2vxd67lS9s=
+github.com/filecoin-project/go-legs v0.4.6/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd h1:Ykxbz+LvSCUIl2zFaaPGmF8KHXTJu9T/PymgHr7IHjs=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=
@@ -721,8 +721,8 @@ github.com/ipld/go-ipld-prime v0.16.1-0.20220607093021-c88f0b441e80/go.mod h1:aY
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.1.8 h1:w6BMno3GYG1tY70rGRkAzf/nFC/st1GCoEXZ2LA2QMg=
-github.com/ipld/go-storethehash v0.1.8/go.mod h1:Gh52e3JFIbzULuRAP6oPBbJ5jJCNlOakihQ5DVtCv14=
+github.com/ipld/go-storethehash v0.1.9 h1:+J/8UgvRvXcOgEUTKDO3sGCGLMzRzco5Z9X3DYt5g8M=
+github.com/ipld/go-storethehash v0.1.9/go.mod h1:Gh52e3JFIbzULuRAP6oPBbJ5jJCNlOakihQ5DVtCv14=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1182,7 +1182,7 @@ func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *test
 
 // Make new indexer engine
 func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
-	valueStore, err := storethehash.New(t.TempDir(), storethehash.IndexBitSize(8))
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), storethehash.IndexBitSize(8))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -864,7 +864,7 @@ func requireNotIndexed(t *testing.T, ix indexer.Interface, p peer.ID, mhs []mult
 
 func getAdEntriesCid(t *testing.T, store datastore.Batching, ad cid.Cid) cid.Cid {
 	ctx := context.TODO()
-	val, err := store.Get(ctx, dsKey(ad.String()))
+	val, err := store.Get(ctx, datastore.NewKey(ad.String()))
 	require.NoError(t, err)
 	nad, err := decodeIPLDNode(ad.Prefix().Codec, bytes.NewBuffer(val), schema.AdvertisementPrototype)
 	require.NoError(t, err)
@@ -875,7 +875,7 @@ func getAdEntriesCid(t *testing.T, store datastore.Batching, ad cid.Cid) cid.Cid
 
 func decodeEntriesChunk(t *testing.T, store datastore.Batching, c cid.Cid) ([]multihash.Multihash, cid.Cid) {
 	ctx := context.TODO()
-	val, err := store.Get(ctx, dsKey(c.String()))
+	val, err := store.Get(ctx, datastore.NewKey(c.String()))
 	require.NoError(t, err)
 	nentries, err := decodeIPLDNode(c.Prefix().Codec, bytes.NewBuffer(val), schema.EntryChunkPrototype)
 	require.NoError(t, err)
@@ -1213,7 +1213,7 @@ func mkProvLinkSystem(ds datastore.Batching) ipld.LinkSystem {
 	lsys := cidlink.DefaultLinkSystem()
 	lsys.StorageReadOpener = func(lctx ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
 		c := lnk.(cidlink.Link).Cid
-		val, err := ds.Get(lctx.Ctx, dsKey(c.String()))
+		val, err := ds.Get(lctx.Ctx, datastore.NewKey(c.String()))
 		if err != nil {
 			return nil, err
 		}
@@ -1223,7 +1223,7 @@ func mkProvLinkSystem(ds datastore.Batching) ipld.LinkSystem {
 		buf := bytes.NewBuffer(nil)
 		return buf, func(lnk ipld.Link) error {
 			c := lnk.(cidlink.Link).Cid
-			return ds.Put(lctx.Ctx, dsKey(c.String()), buf.Bytes())
+			return ds.Put(lctx.Ctx, datastore.NewKey(c.String()), buf.Bytes())
 		}, nil
 	}
 	return lsys

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -50,7 +50,6 @@ type Registry struct {
 
 	discoveryTimeout time.Duration
 	rediscoverWait   time.Duration
-	stopAfter        time.Duration
 
 	syncChan chan *ProviderInfo
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -502,13 +502,11 @@ func (r *Registry) AllProviderInfo() []*ProviderInfo {
 	var infos []*ProviderInfo
 	done := make(chan struct{})
 	r.actions <- func() {
-		infos = make([]*ProviderInfo, len(r.providers))
-		var i int
+		infos = make([]*ProviderInfo, 0, len(r.providers))
 		earliest := time.Now().Add(r.stopAfter * -1)
 		for _, info := range r.providers {
 			if info.lastContactTime.After(earliest) {
-				infos[i] = info
-				i++
+				infos = append(infos, info)
 			}
 		}
 		close(done)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -506,6 +506,17 @@ func TestPollProvider(t *testing.T) {
 		t.Fatal("Expected sync channel to be written")
 	}
 
+	// Inactive provider should not be returned.
+	pinfo := r.ProviderInfo(peerID)
+	if pinfo != nil {
+		t.Fatal("expected inactive provider not to be returned")
+	}
+
+	pinfo = r.providerInfoAlways(peerID)
+	if pinfo == nil {
+		t.Fatal("expected inactive provider to still be present")
+	}
+
 	// Set stopAfter to 0 so that stopAfter will have elapsed since last
 	// contact. This will make publisher appear unresponsive and polling will
 	// stop.
@@ -518,7 +529,11 @@ func TestPollProvider(t *testing.T) {
 
 	// Check that provider has been removed from registry after provider
 	// appeared non-responsive.
-	pinfo := r.ProviderInfo(peerID)
+	pinfo = r.ProviderInfo(peerID)
+	if pinfo != nil {
+		t.Fatal("expected provider to be removed from registry")
+	}
+	pinfo = r.providerInfoAlways(peerID)
 	if pinfo != nil {
 		t.Fatal("expected provider to be removed from registry")
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -520,13 +520,14 @@ func TestPollProvider(t *testing.T) {
 		if pinfo.AddrInfo.ID != peerID {
 			t.Fatalf("unexpected provider info on sync channel, expected %q got %q", peerID.String(), pinfo.AddrInfo.ID.String())
 		}
-		if !pinfo.Deleted {
+		if !pinfo.Deleted() {
 			t.Fatal("expected delete request for unresponsive provider")
 		}
 	default:
 		t.Fatal("sync channel should have deleted provider")
 	}
 
+	// This should still be ok to call even after provider is removed.
 	err = r.RemoveProvider(context.Background(), peerID)
 	if err != nil {
 		t.Fatal(err)
@@ -630,7 +631,7 @@ func TestPollProviderOverrides(t *testing.T) {
 		if pinfo.AddrInfo.ID != peerID {
 			t.Fatalf("unexpected provider info on sync channel, expected %q got %q", peerID.String(), pinfo.AddrInfo.ID.String())
 		}
-		if !pinfo.Deleted {
+		if !pinfo.Deleted() {
 			t.Fatal("expected delete request for unresponsive provider")
 		}
 	default:
@@ -640,10 +641,8 @@ func TestPollProviderOverrides(t *testing.T) {
 	// Check that sync channel was not written since polling should have
 	// stopped.
 	select {
-	case pinfo := <-r.SyncChan():
-		if pinfo.AddrInfo.ID == peerID {
-			t.Fatal("sync channel should not have beem written to for override peer")
-		}
+	case <-r.SyncChan():
+		t.Fatal("sync channel should not have beem written to for override peer")
 	default:
 	}
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -473,6 +473,9 @@ func TestPollProvider(t *testing.T) {
 		if pinfo.Publisher != pubID {
 			t.Fatal("Wrong publisher ID")
 		}
+		if pinfo.Inactive() {
+			t.Error("Expected provider not to be marked inactive")
+		}
 	case <-timeout:
 		t.Fatal("Expected sync channel to be written")
 	}
@@ -492,7 +495,13 @@ func TestPollProvider(t *testing.T) {
 		t.Fatal("actions channel blocked")
 	}
 	select {
-	case <-r.SyncChan():
+	case pinfo := <-r.SyncChan():
+		if pinfo.AddrInfo.ID != peerID {
+			t.Fatalf("unexpected provider info on sync channel, expected %q got %q", peerID.String(), pinfo.AddrInfo.ID.String())
+		}
+		if !pinfo.Inactive() {
+			t.Error("Expected provider to be marked inactive")
+		}
 	case <-timeout:
 		t.Fatal("Expected sync channel to be written")
 	}

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -9,10 +9,13 @@ import (
 	v0 "github.com/filecoin-project/storetheindex/api/v0"
 	"github.com/filecoin-project/storetheindex/api/v0/finder/model"
 	"github.com/filecoin-project/storetheindex/internal/registry"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 )
+
+var log = logging.Logger("indexer/finder")
 
 // avg_mh_size is a slight overcount over the expected size of a multihash as a
 // way of estimating the number of entries in the primary value store.
@@ -57,6 +60,17 @@ func (h *FinderHandler) Find(mhashes []multihash.Multihash) (*model.FindResponse
 			if !ok {
 				pinfo := h.registry.ProviderInfo(provID)
 				if pinfo == nil {
+					// If provider not in registry, then provider was deleted.
+					// Tell the indexed core to delete the contextID for the
+					// deleted provider. Delete the contextID from the core,
+					// because there is no way to delete all records for the
+					// provider without a scan of the entire core valuestore.
+					go func(value indexer.Value) {
+						err := h.indexer.RemoveProviderContext(value.ProviderID, value.ContextID)
+						if err != nil {
+							log.Errorw("Error removing provider context", "err", err)
+						}
+					}(values[j])
 					// If provider not in registry, do not return in result.
 					continue
 				}

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -74,6 +74,10 @@ func (h *FinderHandler) Find(mhashes []multihash.Multihash) (*model.FindResponse
 					// If provider not in registry, do not return in result.
 					continue
 				}
+				// Omit provider info if it is marked as inactive.
+				if pinfo.Inactive() {
+					continue
+				}
 				addrs = pinfo.AddrInfo.Addrs
 				provAddrs[provID] = addrs
 			}

--- a/server/finder/libp2p/protocol_test.go
+++ b/server/finder/libp2p/protocol_test.go
@@ -100,3 +100,27 @@ func TestGetStats(t *testing.T) {
 	}
 	test.GetStatsTest(ctx, t, c)
 }
+
+func TestRemoveProvider(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Initialize everything
+	ind := test.InitIndex(t, true)
+	reg := test.InitRegistry(t)
+	s, sh := setupServer(ctx, ind, reg, t)
+	c := setupClient(s.ID(), t)
+	err := c.ConnectAddrs(ctx, sh.Addrs()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	test.RemoveProviderTest(ctx, t, c, ind, reg)
+
+	if err = reg.Close(); err != nil {
+		t.Errorf("Error closing registry: %s", err)
+	}
+	if err = ind.Close(); err != nil {
+		t.Errorf("Error closing indexer core: %s", err)
+	}
+}

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -32,7 +32,7 @@ var rng = rand.New(rand.NewSource(1413))
 
 //InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
-	valueStore, err := storethehash.New(t.TempDir())
+	valueStore, err := storethehash.New(context.Background(), t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -53,7 +53,7 @@ func (m *mockIndexer) Put(value indexer.Value, mhs ...multihash.Multihash) error
 }
 
 func (m *mockIndexer) Remove(indexer.Value, ...multihash.Multihash) error { return nil }
-func (m *mockIndexer) RemoveProvider(peer.ID) error                       { return nil }
+func (m *mockIndexer) RemoveProvider(context.Context, peer.ID) error      { return nil }
 func (m *mockIndexer) RemoveProviderContext(peer.ID, []byte) error        { return nil }
 func (m *mockIndexer) Size() (int64, error)                               { return 0, nil }
 func (m *mockIndexer) Flush() error                                       { return nil }

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -33,7 +33,7 @@ var rng = rand.New(rand.NewSource(1413))
 
 //InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
-	valueStore, err := storethehash.New(t.TempDir())
+	valueStore, err := storethehash.New(context.Background(), t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Context
Providers are currently listed at `/providers` even when not live

## Proposed Changes
After polling has started and still unresponsive after at least one poll attempt, exclude provider from find responses and from `/providers` in both list and get responses (#594)
 
When polling has stopped with no responses remove the provider data from the indexer. (#595)
- Remove provider from registry's list of providers, in memory and datastore.
- Remove latest sync data (for provider's publisher) from ingester datastore.
- Remove handler from legs subscriber.
- Remove provider content from indexer core. Delete by contextID when removed provider seen in query result.

Fixes #594 
Fixes #595