### PR TITLE
Fix response headers and CORS OPTIONS support via middleware

### DIFF
--- a/internal/httpserver/util.go
+++ b/internal/httpserver/util.go
@@ -15,9 +15,6 @@ var log = logging.Logger("indexer/http")
 func WriteJsonResponse(w http.ResponseWriter, status int, body []byte) {
 	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
 	if _, err := w.Write(body); err != nil {
 		log.Errorw("cannot write response", "err", err)
 		http.Error(w, "", http.StatusInternalServerError)


### PR DESCRIPTION
The finder server responses did not include the headers despite them
being set as part of request handling. Instead of setting headers in
handlers, which may not get applied depending on gorilla mux router
configuration, use a "middleware" provided by the gorilla mux framework
to set allowed methods extracted from the router as well as allow
origin all.

For CORS to function correctly, the endpoints also need to handle
`OPTIONS` method gracefully. This is also added, where the handling is
terminated after the headers are written.

Relates to:
 - https://github.com/filecoin-project/storetheindex/issues/612


