### PR TITLE
Fix go template buffer issue for landing page

### DIFF
--- a/server/finder/http/handler_test.go
+++ b/server/finder/http/handler_test.go
@@ -138,3 +138,25 @@ func TestServer_CORSWithExpectedContentType(t *testing.T) {
 		})
 	}
 }
+
+func TestServer_Landing(t *testing.T) {
+	ind := test.InitIndex(t, false)
+	reg := test.InitRegistry(t)
+	s, err := New("127.0.0.1:0", ind, reg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, ind.Close())
+		require.NoError(t, reg.Close())
+	})
+
+	rr := httptest.NewRecorder()
+
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	s.server.Handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	gotBody := rr.Body.String()
+	require.NotEmpty(t, gotBody)
+	require.True(t, strings.Contains(gotBody, "https://web.cid.contact/"))
+}

--- a/server/finder/http/server.go
+++ b/server/finder/http/server.go
@@ -52,12 +52,12 @@ func New(listen string, indexer indexer.Interface, registry *registry.Registry, 
 	h := newHandler(indexer, registry)
 
 	// Compile index template.
-	var webUIRendered []byte
 	t, err := template.ParseFS(webUI, "index.html")
 	if err != nil {
 		return nil, err
 	}
-	if err = t.Execute(bytes.NewBuffer(webUIRendered), struct {
+	var buf bytes.Buffer
+	if err = t.Execute(&buf, struct {
 		URL string
 	}{
 		URL: cfg.homepageURL,
@@ -69,7 +69,7 @@ func New(listen string, indexer indexer.Interface, registry *registry.Registry, 
 	r := mux.NewRouter().StrictSlash(true)
 	compileTime := time.Now()
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.ServeContent(w, r, "index.html", compileTime, bytes.NewReader(webUIRendered))
+		http.ServeContent(w, r, "index.html", compileTime, bytes.NewReader(buf.Bytes()))
 	}).Methods(http.MethodGet)
 	r.HandleFunc("/cid/{cid}", h.findCid).Methods(http.MethodGet)
 	r.HandleFunc("/multihash/{multihash}", h.find).Methods(http.MethodGet)


### PR DESCRIPTION
Add test that asserts it returns rendered content.
