### PR TITLE
Check `AddrInfo` has addresses before use

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -415,7 +415,9 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 		}
 
 		if publisher.ID.Validate() == nil {
-			if publisher.ID != info.Publisher {
+			if len(publisher.Addrs) == 0 {
+				log.Warnw("Publisher has no addresses", "publisher", publisher.ID, "provider", providerID)
+			} else if publisher.ID != info.Publisher {
 				// Publisher ID changed.
 				info.Publisher = publisher.ID
 				info.PublisherAddr = publisher.Addrs[0]


### PR DESCRIPTION
A panic is caused in registry when the publisher is changed for a known
provider with empty addrs.  An `AddrInfo` can have empty addresses. This
can happen when getting `AddrInfo` from the peerstore of a host that
does not know about a given peer ID.  Therefore, check that addresses
are not empty before attempting full registration.

Add logging to identify the provider and publisher for which this
scenario occurs. This is to help further investigate if there is
anything we might be missing in the context of legs peerstore update
(both the HTTP peerstore and libp2p peerstore).

