### PR TITLE
Registration of new publisher with no addresses

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -448,9 +448,10 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 	if len(addrs) != 0 {
 		maddrs, err := stringsToMultiaddrs(addrs)
 		if err != nil {
-			panic(err)
+			log.Errorw("Invalid provider address", "err", err)
+		} else if len(maddrs) != 0 {
+			info.AddrInfo.Addrs = maddrs
 		}
-		info.AddrInfo.Addrs = maddrs
 	}
 
 	// If there is no publisher addr and the publisher is the same as the

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -769,7 +769,10 @@ func (r *Registry) loadPersistedProviders(ctx context.Context) (int, error) {
 		pinfo := new(ProviderInfo)
 		err = json.Unmarshal(ent.Value, pinfo)
 		if err != nil {
-			return 0, err
+			log.Errorw("Cannot load provider info", "err", err, "provider", peerID)
+			pinfo.AddrInfo.ID = peerID
+			// Add the provider to the set of registered providers so that it
+			// does not get delisted. The next update should fix the addresses.
 		}
 
 		if pinfo.Publisher.Validate() == nil && pinfo.PublisherAddr == nil && pinfo.Publisher == pinfo.AddrInfo.ID {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -415,15 +415,18 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 		}
 
 		if publisher.ID.Validate() == nil {
-			if len(publisher.Addrs) == 0 {
-				log.Warnw("Publisher has no addresses", "publisher", publisher.ID, "provider", providerID)
-			} else if publisher.ID != info.Publisher {
+			if publisher.ID != info.Publisher {
 				// Publisher ID changed.
 				info.Publisher = publisher.ID
-				info.PublisherAddr = publisher.Addrs[0]
 				fullRegister = true
+				// There is a new publisher, but no new publisher addresses.
+				if len(publisher.Addrs) != 0 {
+					log.Warnw("Publisher has no addresses", "publisher", publisher.ID, "provider", providerID)
+					// Use provider addr if publisher and provider are same.
+					info.PublisherAddr = nil
+				}
 			} else if len(publisher.Addrs) != 0 {
-				// Use provided publisher addrs.
+				// Use new publisher addrs if any given.
 				info.PublisherAddr = publisher.Addrs[0]
 			}
 		}
@@ -442,6 +445,16 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 		}
 	}
 
+	if len(addrs) != 0 {
+		maddrs, err := stringsToMultiaddrs(addrs)
+		if err != nil {
+			panic(err)
+		}
+		info.AddrInfo.Addrs = maddrs
+	}
+
+	// If there is no publisher addr and the publisher is the same as the
+	// provider, then use the provider address if there is one.
 	if info.Publisher.Validate() == nil && info.PublisherAddr == nil && info.Publisher == info.AddrInfo.ID {
 		if len(info.AddrInfo.Addrs) == 0 {
 			log.Warnw("Register provider with no provider or publisher addresses",
@@ -449,14 +462,6 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 		} else {
 			info.PublisherAddr = info.AddrInfo.Addrs[0]
 		}
-	}
-
-	if len(addrs) != 0 {
-		maddrs, err := stringsToMultiaddrs(addrs)
-		if err != nil {
-			panic(err)
-		}
-		info.AddrInfo.Addrs = maddrs
 	}
 
 	now := time.Now()
@@ -473,7 +478,7 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 		return r.Register(ctx, info)
 	}
 
-	// If laready registered and no new IDs, register without verification.
+	// If aready registered and no new IDs, register without verification.
 	errCh := make(chan error, 1)
 	r.actions <- func() {
 		errCh <- r.syncRegister(ctx, info)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -226,8 +226,8 @@ func TestDiscoveryBlocked(t *testing.T) {
 		t.Fatal("expected error:", ErrNotAllowed, "got:", err)
 	}
 
-	into := r.ProviderInfo(peerID)
-	if into != nil {
+	info := r.ProviderInfo(peerID)
+	if info != nil {
 		t.Error("should not have found provider info for miner")
 	}
 }
@@ -704,4 +704,16 @@ func TestRegistry_RegisterOrUpdateToleratesEmptyPublisherAddrs(t *testing.T) {
 	c := cid.NewCidV1(cid.Raw, mh)
 	err = subject.RegisterOrUpdate(ctx, provId, []string{publisherAddr}, c, peer.AddrInfo{ID: publisherID})
 	require.NoError(t, err)
+
+	info := subject.ProviderInfo(provId)
+	require.NotNil(t, info)
+	require.Nil(t, info.PublisherAddr)
+
+	// Register a publisher that has no addresses, but publisherID is same as
+	// provider. Registry should use provider's address as publisher.
+	err = subject.RegisterOrUpdate(ctx, provId, []string{publisherAddr}, c, peer.AddrInfo{ID: provId})
+	info = subject.ProviderInfo(provId)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.Equal(t, info.AddrInfo.Addrs[0], info.PublisherAddr)
 }


### PR DESCRIPTION
Handle registering a new publisher for a provider, when no new provider addresses are given. Handle the case where the publisher is different from the publisher, and where the provider is the same as the publisher.

This also fixes another issue where the new provider addresses, if given, need to be applied before setting an empty publisher address to that of the provider with the same ID.