### PR TITLE
Increase worker count in prod from 10 to 20

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
@@ -72,7 +72,7 @@ data:
         "HttpSyncRetryWaitMax": "30s",
         "HttpSyncRetryWaitMin": "1s",
         "HttpSyncTimeout": "10s",
-        "IngestWorkerCount": 10,
+        "IngestWorkerCount": 20,
         "PubSubTopic": "/indexer/ingest/mainnet",
         "RateLimit": {
           "Apply": false,


### PR DESCRIPTION
Increase worker count in `prod` to investigate slow ingestion time for
ads.

