### PR TITLE
Double the storage batch size to fit 6K multihash count

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-config.yaml
@@ -83,7 +83,7 @@ data:
           "BurstSize": 500
         },
         "ResendDirectAnnounce": false,
-        "StoreBatchSize": 4096,
+        "StoreBatchSize": 8192,
         "SyncSegmentDepthLimit": 2000,
         "SyncTimeout": "2h0m0s"
       },

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
@@ -81,7 +81,7 @@ data:
           "BurstSize": 500
         },
         "ResendDirectAnnounce": false,
-        "StoreBatchSize": 4096,
+        "StoreBatchSize": 8192,
         "SyncSegmentDepthLimit": 2000,
         "SyncTimeout": "2h0m0s"
       },


### PR DESCRIPTION
Almost all the ads sent by nft.storage, one of the high-volume
providers, have just over 6K multihashes. Increase the batch size to
reduce IO operations when advertisements are ingested.

