### PR TITLE
Filter non-routable IP addresses

### DIFF
--- a/config/discovery.go
+++ b/config/discovery.go
@@ -8,6 +8,9 @@ import (
 // advertisements, which peers to allow and block, and time related settings
 // for provider discovery
 type Discovery struct {
+	// FilterIPs, when true, removes any private, loopback, or unspecified IP
+	// addresses from provider and publisher addresses.
+	FilterIPs bool
 	// LotusGateway is the host or host:port for a lotus gateway used to
 	// verify providers on the blockchain.
 	LotusGateway string

--- a/deploy/manifests/base/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/base/storetheindex/indexer-config.yaml
@@ -44,6 +44,7 @@ data:
         "Dir": "/data/datastore"
       },
       "Discovery": {
+        "FilterIPs": true,
         "LotusGateway": "wss://api.chain.love",
         "Policy": {
           "Allow": true,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-config.yaml
@@ -44,6 +44,7 @@ data:
         "Dir": "/data/datastore"
       },
       "Discovery": {
+        "FilterIPs": true,
         "LotusGateway": "wss://api.chain.love",
         "Policy": {
           "Allow": true,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
@@ -43,6 +43,7 @@ data:
         "Dir": "/data/datastore"
       },
       "Discovery": {
+        "FilterIPs": true,
         "LotusGateway": "wss://api.chain.love",
         "Policy": {
           "Allow": true,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.19
-	github.com/filecoin-project/go-legs v0.4.6
+	github.com/filecoin-project/go-legs v0.4.8-0.20220810152545-a3f095e74989
 	github.com/frankban/quicktest v1.14.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.19
-	github.com/filecoin-project/go-legs v0.4.8-0.20220810152545-a3f095e74989
+	github.com/filecoin-project/go-legs v0.4.8
 	github.com/frankban/quicktest v1.14.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/filecoin-project/go-indexer-core v0.2.19 h1:1qJYpK9iuwDIi2+Heu5OOnpeO
 github.com/filecoin-project/go-indexer-core v0.2.19/go.mod h1:SxmXm55AKeKlZsEIIBDTiM7FGauBsDpGobOetQzkohw=
 github.com/filecoin-project/go-legs v0.4.6 h1:u7sj4wE5l7An5wI3I3YnXcLikKAKxTbPk2vxd67lS9s=
 github.com/filecoin-project/go-legs v0.4.6/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
+github.com/filecoin-project/go-legs v0.4.8-0.20220810152545-a3f095e74989 h1:MfRturcx8vgtQGHEQRSZH7H4TCkfRSPHVLMBZtq79A8=
+github.com/filecoin-project/go-legs v0.4.8-0.20220810152545-a3f095e74989/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd h1:Ykxbz+LvSCUIl2zFaaPGmF8KHXTJu9T/PymgHr7IHjs=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=

--- a/go.sum
+++ b/go.sum
@@ -259,10 +259,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.19 h1:1qJYpK9iuwDIi2+Heu5OOnpeOaemEPbePfp/2vfval8=
 github.com/filecoin-project/go-indexer-core v0.2.19/go.mod h1:SxmXm55AKeKlZsEIIBDTiM7FGauBsDpGobOetQzkohw=
-github.com/filecoin-project/go-legs v0.4.6 h1:u7sj4wE5l7An5wI3I3YnXcLikKAKxTbPk2vxd67lS9s=
-github.com/filecoin-project/go-legs v0.4.6/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
-github.com/filecoin-project/go-legs v0.4.8-0.20220810152545-a3f095e74989 h1:MfRturcx8vgtQGHEQRSZH7H4TCkfRSPHVLMBZtq79A8=
-github.com/filecoin-project/go-legs v0.4.8-0.20220810152545-a3f095e74989/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
+github.com/filecoin-project/go-legs v0.4.8 h1:4f1y4WwYIP96QSTr6xbWSRsecja9t30Wpbb5uI6i48A=
+github.com/filecoin-project/go-legs v0.4.8/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd h1:Ykxbz+LvSCUIl2zFaaPGmF8KHXTJu9T/PymgHr7IHjs=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -182,6 +182,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 	// to index data as it is received.
 	sub, err := legs.NewSubscriber(h, ds, ing.lsys, cfg.PubSubTopic, Selectors.AdSequence,
 		legs.AllowPeer(reg.Allowed),
+		legs.FilterIPs(reg.FilterIPsEnabled()),
 		legs.SyncRecursionLimit(recursionLimit(cfg.AdvertisementDepthLimit)),
 		legs.UseLatestSyncHandler(&syncHandler{ing}),
 		legs.RateLimiter(ing.getRateLimiter),

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -400,29 +400,37 @@ func (r *Registry) BlockPeer(peerID peer.ID) bool {
 	return r.policy.Block(peerID)
 }
 
+// FilterIPsEnabled returns true if IP address filtering is enabled.
+func (r *Registry) FilterIPsEnabled() bool {
+	return r.filterIPs
+}
+
 // RegisterOrUpdate attempts to register an unregistered provider, or updates
 // the addresses and latest advertisement of an already registered provider.
 // If publisher has a valid ID, then the data in publisher replaces the
 // provider's previous publisher information.
-func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, addrs []string, adID cid.Cid, publisher peer.AddrInfo) error {
+func (r *Registry) RegisterOrUpdate(ctx context.Context, provider peer.AddrInfo, adID cid.Cid, publisher peer.AddrInfo) error {
 	if r.filterIPs {
+		provider.Addrs = mautil.FilterPrivateIPs(provider.Addrs)
 		publisher.Addrs = mautil.FilterPrivateIPs(publisher.Addrs)
 	}
 
 	var fullRegister bool
 	// Check that the provider has been discovered and validated
-	info := r.ProviderInfo(providerID)
+	info := r.ProviderInfo(provider.ID)
 	if info != nil {
 		info = &ProviderInfo{
-			AddrInfo: peer.AddrInfo{
-				ID:    providerID,
-				Addrs: info.AddrInfo.Addrs,
-			},
+			AddrInfo:              info.AddrInfo,
 			DiscoveryAddr:         info.DiscoveryAddr,
 			LastAdvertisement:     info.LastAdvertisement,
 			LastAdvertisementTime: info.LastAdvertisementTime,
 			Publisher:             info.Publisher,
 			PublisherAddr:         info.PublisherAddr,
+		}
+
+		// If new addrs provided, update to use these.
+		if len(provider.Addrs) != 0 {
+			info.AddrInfo.Addrs = provider.Addrs
 		}
 
 		if publisher.ID.Validate() == nil {
@@ -432,7 +440,7 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 				fullRegister = true
 				// There is a new publisher, but no new publisher addresses.
 				if len(publisher.Addrs) != 0 {
-					log.Warnw("Publisher has no addresses", "publisher", publisher.ID, "provider", providerID)
+					log.Warnw("Publisher has no addresses", "publisher", publisher.ID, "provider", provider.ID)
 					// Use provider addr if publisher and provider are same.
 					info.PublisherAddr = nil
 				}
@@ -444,27 +452,13 @@ func (r *Registry) RegisterOrUpdate(ctx context.Context, providerID peer.ID, add
 	} else {
 		fullRegister = true
 		info = &ProviderInfo{
-			AddrInfo: peer.AddrInfo{
-				ID: providerID,
-			},
+			AddrInfo: provider,
 		}
 		if publisher.ID.Validate() == nil {
 			info.Publisher = publisher.ID
 		}
 		if len(publisher.Addrs) != 0 {
 			info.PublisherAddr = publisher.Addrs[0]
-		}
-	}
-
-	if len(addrs) != 0 {
-		maddrs, err := stringsToMultiaddrs(addrs)
-		if err != nil {
-			log.Errorw("Invalid provider address", "err", err)
-		} else if len(maddrs) != 0 {
-			if r.filterIPs {
-				maddrs = mautil.FilterPrivateIPs(maddrs)
-			}
-			info.AddrInfo.Addrs = maddrs
 		}
 	}
 
@@ -914,21 +908,4 @@ func (r *Registry) syncRemoveProvider(ctx context.Context, providerID peer.ID) e
 		return err
 	}
 	return nil
-}
-
-// stringsToMultiaddrs converts a slice of string into a slice of Multiaddr
-func stringsToMultiaddrs(addrs []string) ([]multiaddr.Multiaddr, error) {
-	if len(addrs) == 0 {
-		return nil, nil
-	}
-
-	maddrs := make([]multiaddr.Multiaddr, len(addrs))
-	for i, m := range addrs {
-		var err error
-		maddrs[i], err = multiaddr.NewMultiaddr(m)
-		if err != nil {
-			return nil, fmt.Errorf("bad address: %s", err)
-		}
-	}
-	return maddrs, nil
 }

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
 )
 
 // IngestHandler provides request handling functionality for the ingest server
@@ -91,8 +92,13 @@ func (h *IngestHandler) IndexContent(ctx context.Context, data []byte) error {
 		return err
 	}
 
+	provider := peer.AddrInfo{
+		ID:    ingReq.ProviderID,
+		Addrs: stringsToMultiaddrs(ingReq.Addrs),
+	}
+
 	// Register provider if not registered, or update addreses if already registered
-	err = h.registry.RegisterOrUpdate(ctx, ingReq.ProviderID, ingReq.Addrs, cid.Undef, peer.AddrInfo{})
+	err = h.registry.RegisterOrUpdate(ctx, provider, cid.Undef, peer.AddrInfo{})
 	if err != nil {
 		return err
 	}
@@ -154,4 +160,19 @@ func (h *IngestHandler) Announce(r io.Reader) error {
 	// Use background context because this will be an async process. We don't
 	// want to attach the context to the request context that started this.
 	return h.ingester.Announce(context.Background(), an.Cid, addrInfo)
+}
+
+func stringsToMultiaddrs(addrs []string) []multiaddr.Multiaddr {
+	if len(addrs) == 0 {
+		return nil
+	}
+	maddrs := make([]multiaddr.Multiaddr, 0, len(addrs))
+	for _, addr := range addrs {
+		maddr, err := multiaddr.NewMultiaddr(addr)
+		if err != nil {
+			continue
+		}
+		maddrs = append(maddrs, maddr)
+	}
+	return maddrs
 }


### PR DESCRIPTION
Remove any private, loopback, and unspecified IP addresses from provider and publisher addresses when they are written to the registry.