### PR TITLE
Create two new workers in `dev` with larger mermory per AZ

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -46,6 +46,34 @@ module "eks" {
         }
       }
     }
+    dev-ue2b-r5b-2xl = {
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 1
+      instance_types = ["r5b.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2b.id]
+      taints = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5b"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+    dev-ue2c-r5b-2xl = {
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 1
+      instance_types = ["r5b.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2c.id]
+      taints = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5b"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
   }
 
   tags = local.tags
@@ -53,4 +81,30 @@ module "eks" {
 
 data "aws_eks_cluster_auth" "this" {
   name = module.eks.cluster_id
+}
+
+data "aws_subnet" "ue2b" {
+  vpc_id = module.vpc.vpc_id
+
+  filter {
+    name   = "availability-zone"
+    values = ["us-east-2b"]
+  }
+  filter {
+    name   = "subnet-id"
+    values = module.vpc.private_subnets
+  }
+}
+
+data "aws_subnet" "ue2c" {
+  vpc_id = module.vpc.vpc_id
+
+  filter {
+    name   = "availability-zone"
+    values = ["us-east-2c"]
+  }
+  filter {
+    name   = "subnet-id"
+    values = module.vpc.private_subnets
+  }
 }

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -19,6 +19,16 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2-r5b-xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2b-r5b-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2c-r5b-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih


### PR DESCRIPTION
Create two new worker nodes in `dev` with ASG per AZ so that we can
avoid having idle instances and control scaling per AZ. The instance
type used is `r5b.2xl`which is a memory optimised instance type that
offers higher IOPS with `io2` volumes used by the network indexer.
