### PR TITLE
Set node affinity for sti `dev` instance to nodes of type `r5b.xlarge`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -5,6 +5,15 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - "r5b.xlarge"
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone


### PR DESCRIPTION
This is to avoid having nodes deployed on node types since `r5b` is
specifically optimised for hig IOPS with `io2` volume kind.

