### PR TITLE
Configure debug instance to run on larger machines

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -46,30 +46,30 @@ module "eks" {
         }
       }
     }
-    dev-ue2b-r5b-2xl = {
+    dev-ue2b-r5b-4xl = {
       min_size       = 1
       max_size       = 3
       desired_size   = 1
-      instance_types = ["r5b.2xlarge"]
+      instance_types = ["r5b.4xlarge"]
       subnet_ids     = [data.aws_subnet.ue2b.id]
       taints = {
         dedicated = {
           key    = "dedicated"
-          value  = "r5b-2xl"
+          value  = "r5b-4xl"
           effect = "NO_SCHEDULE"
         }
       }
     }
-    dev-ue2c-r5b-2xl = {
+    dev-ue2c-r5b-4xl = {
       min_size       = 1
       max_size       = 3
       desired_size   = 1
-      instance_types = ["r5b.2xlarge"]
+      instance_types = ["r5b.4xlarge"]
       subnet_ids     = [data.aws_subnet.ue2c.id]
       taints = {
         dedicated = {
           key    = "dedicated"
-          value  = "r5b-2xl"
+          value  = "r5b-4xl"
           effect = "NO_SCHEDULE"
         }
       }

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -22,12 +22,12 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/dev-ue2b-r5b-2xl-eks-node-group
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2b-r5b-4xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
     - groups:
       - system:bootstrappers
       - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/dev-ue2c-r5b-2xl-eks-node-group
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2c-r5b-4xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/indexer-config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/indexer-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: indexer-config
-  namespace: storetheindex
+  namespace: storetheindex-debug
 data:
   config: |
     {
@@ -67,7 +67,7 @@ data:
         "ShutdownTimeout": "15s",
         "ValueStoreDir": "/data/valuestore",
         "ValueStoreType": "sth",
-        "STHBits": 32
+        "STHBits": 30
       },
       "Ingest": {
         "AdvertisementDepthLimit": 33554432,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt"
-  namespace: storetheindex
+  namespace: storetheindex-debug
 spec:
   tls:
     - hosts:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/patch-indexer.yaml
@@ -13,7 +13,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - "r5b.2xlarge"
+                      - "r5b.4xlarge"
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
@@ -32,16 +32,16 @@ spec:
               mountPath: /identity
           resources:
             limits:
-              cpu: "5"
-              memory: 60Gi
+              cpu: "10"
+              memory: 120Gi
             requests:
-              cpu: "5"
-              memory: 60Gi
+              cpu: "10"
+              memory: 120Gi
       # Require r5b instance types to run index provider pods.
       tolerations:
         - key: dedicated
           operator: Equal
-          value: r5b-2xl
+          value: r5b-4xl
           effect: NoSchedule
       volumes:
         - name: identity


### PR DESCRIPTION
The sth bit size is changed to 30 which should comfortably fit into the
120Gi memory available to the instances. Since there is plenty of spare
CPU available on `r5b.4xl` machines, the CPU available to the instances
is also increased to 10.

Various missed out namespace updated are alos fixed.
