### PR TITLE
Fix kustomize build issue in sti debug

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/indexer-config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/indexer-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: indexer-config
-  namespace: storetheindex-debug
+  namespace: storetheindex
 data:
   config: |
     {


### PR DESCRIPTION
kustmoize fails to match config since namespace does not match. The
namespace is later on overridden to the right one by kustomization.

