### PR TITLE
Check addrs for length before use

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -795,7 +795,8 @@ func (r *Registry) loadPersistedProviders(ctx context.Context) (int, error) {
 			}
 		}
 
-		if pinfo.Publisher.Validate() == nil && pinfo.PublisherAddr == nil && pinfo.Publisher == pinfo.AddrInfo.ID {
+		if pinfo.Publisher.Validate() == nil && pinfo.PublisherAddr == nil && pinfo.Publisher == pinfo.AddrInfo.ID &&
+			len(pinfo.AddrInfo.Addrs) != 0 {
 			pinfo.PublisherAddr = pinfo.AddrInfo.Addrs[0]
 		}
 		r.providers[peerID] = pinfo


### PR DESCRIPTION
List of multiaddrs in `peer.addrinfo` may be empty. Check length before
use to avoid panic.
