### PR TITLE
Stand up `r5b.4xl` worker nodes in `prod` cluster

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -51,5 +51,60 @@ module "eks" {
         }
       }
     }
+    prod-ue2a-r5b-4xl = {
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 1
+      instance_types = ["r5b.4xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2a.id]
+      taints         = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5b-4xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+    prod-ue2b-r5b-4xl = {
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 1
+      instance_types = ["r5b.4xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2b.id]
+      taints         = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5b-4xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
   }
 }
+
+data "aws_subnet" "ue2a" {
+  vpc_id = module.vpc.vpc_id
+
+  filter {
+    name   = "availability-zone"
+    values = ["us-east-2a"]
+  }
+  filter {
+    name   = "subnet-id"
+    values = module.vpc.private_subnets
+  }
+}
+
+data "aws_subnet" "ue2b" {
+  vpc_id = module.vpc.vpc_id
+
+  filter {
+    name   = "availability-zone"
+    values = ["us-east-2b"]
+  }
+  filter {
+    name   = "subnet-id"
+    values = module.vpc.private_subnets
+  }
+}
+

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -15,6 +15,16 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2-m4-xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2a-r5b-4xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2b-r5b-4xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih


### PR DESCRIPTION
Instantiate `r5b.4xl` worker nodes in prod with per AZ ASG to provide
the ability to control scaling better since we run only 2 indexer nodes.

