### PR TITLE
Run prod instances explicitly on `r5b.4xl` node and increase resources

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -5,6 +5,15 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - "r5b.4xlarge"
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
@@ -23,16 +32,16 @@ spec:
               mountPath: /identity
           resources:
             limits:
-              cpu: "3.5"
-              memory: 25Gi
+              cpu: "10"
+              memory: 120Gi
             requests:
-              cpu: "3.5"
-              memory: 25Gi
+              cpu: "10"
+              memory: 120Gi
       # Require r5b instance types to run index provider pods.
       tolerations:
         - key: dedicated
           operator: Equal
-          value: r5b
+          value: r5b-4xl
           effect: NoSchedule
       volumes:
         - name: identity


### PR DESCRIPTION
Now that there are `r5b.4xl` worker nodes in the cluster, set affinity
for `prod` nodes to them and increase the memory and CPU resources to
utilise what the worker nodes offer.

