### PR TITLE
Fix `null` publisher addr causing addr slice with `nil` address

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-indexer-core v0.2.19
-	github.com/filecoin-project/go-legs v0.4.8
+	github.com/filecoin-project/go-legs v0.4.9
 	github.com/frankban/quicktest v1.14.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.19 h1:1qJYpK9iuwDIi2+Heu5OOnpeOaemEPbePfp/2vfval8=
 github.com/filecoin-project/go-indexer-core v0.2.19/go.mod h1:SxmXm55AKeKlZsEIIBDTiM7FGauBsDpGobOetQzkohw=
-github.com/filecoin-project/go-legs v0.4.8 h1:4f1y4WwYIP96QSTr6xbWSRsecja9t30Wpbb5uI6i48A=
-github.com/filecoin-project/go-legs v0.4.8/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
+github.com/filecoin-project/go-legs v0.4.9 h1:9ccbv5zDPqMviEpSpf0TdfKKI64TMYGSiuY2A1EXHFY=
+github.com/filecoin-project/go-legs v0.4.9/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd h1:Ykxbz+LvSCUIl2zFaaPGmF8KHXTJu9T/PymgHr7IHjs=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -785,7 +785,7 @@ func (r *Registry) loadPersistedProviders(ctx context.Context) (int, error) {
 
 		if r.filterIPs {
 			pinfo.AddrInfo.Addrs = mautil.FilterPrivateIPs(pinfo.AddrInfo.Addrs)
-			if pinfo.Publisher.Validate() == nil {
+			if pinfo.Publisher.Validate() == nil && pinfo.PublisherAddr != nil {
 				pubAddrs := mautil.FilterPrivateIPs([]multiaddr.Multiaddr{pinfo.PublisherAddr})
 				if len(pubAddrs) == 0 {
 					pinfo.PublisherAddr = nil

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -641,3 +641,17 @@ func TestFilterIPs(t *testing.T) {
 	require.Equal(t, 1, len(pinfo.AddrInfo.Addrs))
 	require.Equal(t, pubAddr, pinfo.AddrInfo.Addrs[0])
 }
+
+func TestRegistry_loadPersistedProvidersFiltersNilAddrGracefully(t *testing.T) {
+	ctx := context.Background()
+	ds := datastore.NewMapDatastore()
+	pid, err := peer.Decode("12D3KooWK7CTS7cyWi51PeNE3cTjS2F2kDCZaQVU4A5xBmb9J1do")
+	require.NoError(t, err)
+
+	err = ds.Put(ctx, peerIDToDsKey(pid), []byte(`{"PublisherAddr": null,"AddrInfo": {},"LastAdvertisement":null,"LastAdvertisementTime":"0001-01-01T00:00:00Z","Publisher":"`+pid.String()+`"}`))
+	require.NoError(t, err)
+	cfg := config.NewDiscovery()
+	cfg.FilterIPs = true
+	_, err = NewRegistry(ctx, cfg, ds, nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
When IP filtering is enabled and `PublisherAddr` is `null`, a slice is
 constructed with the `PublisherAddr` which is then used for filtering.
We will then end up with an addr slice that has a single
`nil` element. Check `PublisherAddr` is not nil before any IP filtering.

Upgrade go-legs to fix panic during IP filtering on `nil` addrs.

