### PR TITLE
Destroy `r5b.xl` worker group on `prod`

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -38,19 +38,6 @@ module "eks" {
     # See:
     #  - https://aws.amazon.com/ec2/instance-types/#Memory_Optimized
     #  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#solid-state-drives
-    prod-ue2-r5b-xl = {
-      min_size       = 3
-      max_size       = 7
-      desired_size   = 3
-      instance_types = ["r5b.xlarge"]
-      taints         = {
-        dedicated = {
-          key    = "dedicated"
-          value  = "r5b"
-          effect = "NO_SCHEDULE"
-        }
-      }
-    }
     prod-ue2a-r5b-4xl = {
       min_size       = 1
       max_size       = 3


### PR DESCRIPTION
Now that both production nodes are running on `r5b.4xl` instances,
destroy the older unused worker group.
