### PR TITLE
Deploy individually configurable sti nodes in `dev`

### DIFF
--- a/deploy/manifests/base/storetheindex-single/config.json
+++ b/deploy/manifests/base/storetheindex-single/config.json
@@ -1,0 +1,95 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": true,
+      "Except": null,
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5h0m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s"
+  },
+  "Indexer": {
+    "CacheSize": 300000,
+    "ConfigCheckInterval": "30s",
+    "GCInterval": "30m0s",
+    "ShutdownTimeout": "15s",
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "sth"
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount": 10,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 100,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 4096,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": null
+  }
+}

--- a/deploy/manifests/base/storetheindex-single/deployment.yaml
+++ b/deploy/manifests/base/storetheindex-single/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  # Do not run more than one replica; this overlay is designed to run a single instance only.
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: indexer
+  template:
+    metadata:
+      labels:
+        app: indexer
+    spec:
+      terminationGracePeriodSeconds: 300
+      securityContext:
+        runAsUser: 10001
+        fsGroup: 532
+      containers:
+        - name: indexer
+          image: storetheindex
+          envFrom:
+            - configMapRef:
+                name: env-vars
+          env:
+            - name: STORETHEINDEX_PRIV_KEY_PATH
+              value: /identity/identity.key
+            - name: STORETHEINDEX_PATH
+              value: /config
+          ports:
+            - containerPort: 3000
+              name: finder
+            - containerPort: 3001
+              name: ingest
+            - containerPort: 3002
+              name: admin
+          volumeMounts:
+            - name: identity
+              mountPath: /identity
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /config
+          readinessProbe:
+            httpGet:
+              port: finder
+              path: /health
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: identity
+          secret:
+            secretName: identity
+        - name: data
+          persistentVolumeClaim:
+            claimName: data
+        - name: config
+          configMap:
+            name: config

--- a/deploy/manifests/base/storetheindex-single/identity.key
+++ b/deploy/manifests/base/storetheindex-single/identity.key
@@ -1,0 +1,1 @@
+<place-holder for libp2p private key>

--- a/deploy/manifests/base/storetheindex-single/kustomization.yaml
+++ b/deploy/manifests/base/storetheindex-single/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml
+
+transformers:
+  - labels.yaml
+
+commonLabels:
+  app: indexer-single
+
+secretGenerator:
+  - name: identity
+    files:
+      - identity.key
+
+configMapGenerator:
+  - name: env-vars
+    behavior: create
+    literals:
+      - GOLOG_LOG_LEVEL=INFO
+      - GOLOG_LOG_FMT=json
+      - STORETHEINDEX_WATCH_CONFIG=true
+  - name: config
+    behavior: create
+    files:
+      - config=config.json

--- a/deploy/manifests/base/storetheindex-single/labels.yaml
+++ b/deploy/manifests/base/storetheindex-single/labels.yaml
@@ -1,0 +1,10 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/part-of: storetheindex
+  app.kubernetes.io/managed-by: kustomization
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/deploy/manifests/base/storetheindex-single/pvc.yaml
+++ b/deploy/manifests/base/storetheindex-single/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Ti

--- a/deploy/manifests/base/storetheindex-single/service.yaml
+++ b/deploy/manifests/base/storetheindex-single/service.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: indexer
+spec:
+  ports:
+    - name: finder
+      port: 3000
+      targetPort: finder
+    - name: ingest
+      port: 3001
+      targetPort: ingest
+  selector:
+    app: indexer-single
+  type: ClusterIP
+  clusterIP: None

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/io2-storage-class.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/io2-storage-class.yaml
@@ -1,3 +1,16 @@
+# Notes on `iopsPerGB` in io2 Volumes
+# ===================================
+# 
+# `iopsPerGB` is I/O operations per second per GiB, which is multiplied by the size of the 
+# requested volume. The maximum supported also depends on the instance type i.e. K8S worker node 
+# type, and a global limit on the region.
+# 
+# Avoid hitting the upper IOPS limit by calculating the total IOPS relative to the disk size. For
+# example, `iopsPerGB` of 1 for a volume of size 5TiB will result in 5,120 IOPS.
+# 
+# See: 
+#  - https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters
+#  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#EBSVolumeTypes_piops
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -7,19 +20,17 @@ volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
   type: io2
-  # `iopsPerGB` is I/O operations per second per GiB, which is multiplied by the size of the 
-  # requested volume. The maximum supported also depends on the instance type i.e. K8S worker node 
-  # type.
-  # 
-  # To avoid hitting the upper IOPS limit, here we configure a low value, 1, and let the CSI increase it
-  # automatically to the minimum required. This means volumes of size 5TiB, currently provisioned 
-  # for storetheindex will demand 5,000 IOPS.
-  #
-  # For specific use-cases where IOPS is carefully calculated based on the PVC sizes, consider 
-  # defining explicit storage class.
-  # 
-  # See: 
-  #  - https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters
-  #  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#EBSVolumeTypes_piops
   iopsPerGB: "1"
+  allowAutoIOPSPerGBIncrease: "true"
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: io2-iops3
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: io2
+  iopsPerGB: "3"
   allowAutoIOPSPerGBIncrease: "true"

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/config.json
@@ -1,0 +1,98 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web.cid.contact/dev/",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": true,
+      "Except": [
+      ],
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5h0m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s"
+  },
+  "Indexer": {
+    "CacheSize": 300000,
+    "ConfigCheckInterval": "30s",
+    "GCInterval": "30m0s",
+    "ShutdownTimeout": "15s",
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "sth",
+    "STHBits": 30
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount": 20,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 100,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": null
+  }
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      containers:
+        - name: indexer
+          resources:
+            limits:
+              cpu: "10"
+              memory: 120Gi
+            requests:
+              cpu: "10"
+              memory: 120Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5b.4xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2b
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b-4xl
+          effect: NoSchedule

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:rJx4I6W5cCf8h+x9XB7idOzLXhxutzQQYPKMlPyINUb6khSDnUdAYTKvb0K1YrsWr940WJmBPe5/bMkBzc5ldBXdMTE=,iv:TVPhDfK7jSJE8q4V8lUZckZ0jzDccwd2lnZDie0ZJcE=,tag:GNS53zF6cYSh6ehGUKS5sw==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2022-08-16T10:03:02Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAHnoOYOBREXPxnfmVNuE07JAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMMgQbHWWoB6aFzyR8AgEQgDuUbbbfwHawa8Oh/3na0B6k8HDMdAqG05iHrsTOLX1464X+MW0fMSva2ywEdVlLE23NySruP+ehieR11Q==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-08-16T10:03:03Z",
+		"mac": "ENC[AES256_GCM,data:XYrtjGfCL8FpaOKyhP0M5x1fD98Wmto+j3CzNP83wXCN8I+ut5k10FayuX6KumvP/gpVk+6eczn3iyGaidzziaOfYGqbjCByAw37rPwvg+ryK6BQsTfBDTcCGXUNGMiTx6Vbm85zLlxlcxa4KbDX6U/IiBEJQodXVQpTU1LZbGc=,iv:5YzT7I1Q0l2BG6YtyZewH/WInh4mgXnB7OoTJOtIcYU=,tag:azAXIOUIMXcYuUcFhYeW0g==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - arvo.dev.cid.contact
+      secretName: arvo-indexer-ingress-tls
+  rules:
+    - host: arvo.dev.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+
+namePrefix: arvo-
+
+commonLabels:
+  name: arvo
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWQAvGBkEMh8bSFroNNaDMv2AKZfEbzsXADNV497kyfAKZ
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - pvc.yaml
+  - deployment.yaml
+
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20220812173641-93e48840e1c6a87bf9de3ad1a3f9bcb0cd633663

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  resources:
+    requests:
+      storage: 10Ti
+  storageClassName: io2-iops3

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - pdb.yaml
+  - arvo
+  - mya

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
@@ -1,0 +1,98 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web.cid.contact/dev/",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": true,
+      "Except": [
+      ],
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5h0m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s"
+  },
+  "Indexer": {
+    "CacheSize": 300000,
+    "ConfigCheckInterval": "30s",
+    "GCInterval": "30m0s",
+    "ShutdownTimeout": "15s",
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "sth",
+    "STHBits": 30
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount": 20,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 100,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": null
+  }
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      containers:
+        - name: indexer
+          resources:
+            limits:
+              cpu: "10"
+              memory: 120Gi
+            requests:
+              cpu: "10"
+              memory: 120Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5b.4xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2c
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b-4xl
+          effect: NoSchedule

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:+hx8/u/uXtVzrtqmpMZ9yIhBV3ddYBM2nAhvhOXTkMJ8mWy/Cr7VF3OupzzJKIxpYvWCywJYW+Pkog4SotUd5oCgnBA=,iv:IegYj09/pSC1HATqjoAs2mFtntsUwKQdXlHM3YGfSEw=,tag:8Tm2srBx9JmqMJ3Dqcfmug==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2022-08-15T16:12:42Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAEWM+4tUkdb0O+HzjSYTJYtAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMqOcBqVy4ZmVcjr3+AgEQgDv6A5Fg1GDONgq1NpEk3GPXEGpvQHw95GWE03Miirbnkt23srwHwBh7YpRN/DuXHCwiZtT5T4ZweyTiVw==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-08-15T16:12:43Z",
+		"mac": "ENC[AES256_GCM,data:kFtSK+GEE365FSz5SjCBVJ0Lkfwg9K0P6ijPqry8lSW+qwpLPGxyQGrmlvJTmAic3+RYfzO+m2h8KVSLaxnkS0MHjJwjBVD9czfeAkSI1z8C2w9PmYvGZMdOhpvYA+Lh4fu9b0Fn7Wt/RrjZ2UlyqtpR8/f/wLhCVQ3QWtnjSr4=,iv:MuBx4dChUlCEGZYbpEJWNo42YYtNBm/j23pGjpP79sw=,tag:QLVLRceFv/wzAdsg95UJXw==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - mya.dev.cid.contact
+      secretName: mya-indexer-ingress-tls
+  rules:
+    - host: mya.dev.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+
+namePrefix: mya-
+
+commonLabels:
+  name: mya
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWHGHu3jVjya9sDSAYRmAVtUnQGTwnWeqan1smfJdjzscB
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - pvc.yaml
+  - deployment.yaml
+
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20220812173641-93e48840e1c6a87bf9de3ad1a3f9bcb0cd633663

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  resources:
+    requests:
+      storage: 10Ti
+  storageClassName: io2-iops3

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/pdb.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: indexer-single
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: indexer-single

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ingress.yaml
 - pod-monitor.yaml
 - github-auth.yaml
+- instances
 patchesStrategicMerge:
 - patch-indexer.yaml
 - indexer-config.yaml


### PR DESCRIPTION
The current deployment of storetheindex uses a statefulset with replica
count of 2. This makes up a simpler deployment mechanics but does not
allow the config or version of the container run by each node to be
different from one another. This makes debugging or trial of a specific
solution require an "all or nothing" change to the environment.

A new kustomization overlay is defined, which is explicitly designed to
run a single instance of storetheindex. The overlay also separates the
PVC definitions which makes expansion of volumes easier, and removes the
need for manual statefulset re-creation to work around volume claims
immutability.

Two new instances based on the new singel-node overlay are added to the
dev environment under the human readable names of `arvo` and `mya`. The
rationale for naming is to make it easier to reference each of the
nodes in conversations. The nodes are configured to run on explicit AZs,
`us-east-2b` and `us-east-2c`, respectively, on `r5b.4xl` nodes. The new
nodes also use `30` bit bucket size in their storethehash datastore.
They are individually addressable via two separate ingress definitions.

A pod disruption budget is created which selects pods across both
deployments. This is to allow zero-downtime rollout of deployments
across both nodes, despite the fact that they are created by two
separate `Deployment` objects.

A new storage class of type `io2` with IOPS per GiB of 3 is created in
order to match the IOPS provided to production nodes in `dev`
environment. The new storage class is used by both of the new nodes.

Fixes: https://github.com/filecoin-project/storetheindex/issues/657

