### PR TITLE
Configure replica count in `dev` via patch for finer control

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -15,9 +15,6 @@ secretGenerator:
   files:
   - indexer-0.key=indexer-0-identity.encrypted
   - indexer-1.key=indexer-1-identity.encrypted
-replicas:
-- name: indexer
-  count: 2
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   name: indexer
 spec:
+  replicas: 2
   template:
     spec:
       affinity:


### PR DESCRIPTION
The `images` kustomization transform does not support image
transformation filtering by `kind`. Since the image name across both
single-instances are the same, the replica is changed to 2 across the
deployments and statefulsets.

Set the replica via patch for finer control over the resource it is
applied to.

