### PR TITLE
Re-enable cluster auto-scaler in `prod`

### DIFF
--- a/deploy/manifests/prod/us-east-2/cluster/cluster-autoscaler/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/cluster-autoscaler/kustomization.yaml
@@ -6,7 +6,3 @@ resources:
 
 patchesStrategicMerge:
   - patch.yaml
-
-replicas:
-  - name: cluster-autoscaler
-    count: 0


### PR DESCRIPTION
Now that worker nodes are configured to scale per AZ, re-enable the
cluster auto-scaler.

Fixes #440, #494
