### PR TITLE
Configure prometheus monitoring for single-node indexers

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -5,5 +5,6 @@ namespace: storetheindex
 
 resources:
   - pdb.yaml
+  - pod-monitor.yaml
   - arvo
   - mya

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/pdb.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/pdb.yaml
@@ -2,6 +2,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: indexer-single
+  labels:
+    app: indexer-single
 spec:
   maxUnavailable: 1
   selector:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: indexer-single
+  labels:
+    app: indexer-single
+spec:
+  selector:
+    matchLabels:
+      app: indexer-single
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: admin


### PR DESCRIPTION
Set up pod monitor to select pods with label `indexer-single`, used by
the single-node indexers.

