### PR TITLE
Deploy two individually configurable sti nodes in `prod`

### DIFF
--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/io2-storage-class.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/io2-storage-class.yaml
@@ -1,3 +1,16 @@
+# Notes on `iopsPerGB` in io2 Volumes
+# ===================================
+# 
+# `iopsPerGB` is I/O operations per second per GiB, which is multiplied by the size of the 
+# requested volume. The maximum supported also depends on the instance type i.e. K8S worker node 
+# type, and a global limit on the region.
+# 
+# Avoid hitting the upper IOPS limit by calculating the total IOPS relative to the disk size. For
+# example, `iopsPerGB` of 1 for a volume of size 5TiB will result in 5,120 IOPS.
+# 
+# See: 
+#  - https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters
+#  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#EBSVolumeTypes_piops
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -7,19 +20,17 @@ volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
   type: io2
-  # `iopsPerGB` is I/O operations per second per GiB, which is multiplied by the size of the 
-  # requested volume. The maximum supported also depends on the instance type i.e. K8S worker node 
-  # type.
-  # 
-  # To avoid hitting the upper IOPS limit, here we configure a low value, 3, and let the CSI increase it
-  # automatically to the minimum required. This means volumes of size 5TiB, currently provisioned 
-  # for storetheindex will demand 15,000 IOPS.
-  #
-  # For specific use-cases where IOPS is carefully calculated based on the PVC sizes, consider 
-  # defining explicit storage class.
-  # 
-  # See: 
-  #  - https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters
-  #  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#EBSVolumeTypes_piops
   iopsPerGB: "3"
+  allowAutoIOPSPerGBIncrease: "true"
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: io2-iops5
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: io2
+  iopsPerGB: "5"
   allowAutoIOPSPerGBIncrease: "true"

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - pdb.yaml
+  - pod-monitor.yaml
+  - romi
+  - tara

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/pdb.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: indexer-single
+  labels:
+    app: indexer-single
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: indexer-single

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: indexer-single
+  labels:
+    app: indexer-single
+spec:
+  selector:
+    matchLabels:
+      app: indexer-single
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: admin

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
@@ -1,0 +1,98 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web.cid.contact/",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": true,
+      "Except": [
+      ],
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5h0m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s"
+  },
+  "Indexer": {
+    "CacheSize": 300000,
+    "ConfigCheckInterval": "30s",
+    "GCInterval": "30m0s",
+    "ShutdownTimeout": "15s",
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "sth",
+    "STHBits": 30
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount": 20,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 100,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": null
+  }
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      containers:
+        - name: indexer
+          resources:
+            limits:
+              cpu: "10"
+              memory: 120Gi
+            requests:
+              cpu: "10"
+              memory: 120Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5b.4xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2a
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b-4xl
+          effect: NoSchedule

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/identity.key.encrypted
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:7i19FjOCsHlaTjn0Z01KM8mMGnnwYgeu1pe9GQJvGNz1sMm5IXvakzmEaKJVK2Jv5svHcnYCmOmp+/4WVOFD5WT8xp4=,iv:3lIkbLjxd7EdmHXe1e27Nw2ekjYNvX2ooVbOabXkFkM=,tag:km1WlCG+hGMLZMVKwWSzww==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/prod/us-east-2/sti",
+				"created_at": "2022-08-16T13:54:20Z",
+				"enc": "AQICAHjmLCaDZ4fRYyty7669VvFjJmy9C7/Y4dwd6seUJHRobwFGjN+aBaOFH76HJedC+MhsAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMVcS7P2eWPHyGHXDSAgEQgDtT0P75o/Kpc7htP/XCpdEg3B2k1oGbvqNv3S4zSX0BlkRp09YDhPf70pMUN2Ix+ERqo7u7Wn8Wsd1tZA==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-08-16T13:54:21Z",
+		"mac": "ENC[AES256_GCM,data:sGlM2bn7wrhreFFqwFK3DRYjtHQAz+EnYpYoTO9OX6vXIlhlx3v8YS3NmOeAVVBj8gIhuHzT981aSq5AUMB5a0utxVB1oHwanuUdPZeqGm8lR8ws9kfhGPekz037tMkBwRqqXqw9NYim3uNj2w3PbMhCMT8O6isPLIq5XBJZZUY=,iv:3r0hDWVxp1RTnfm8Ad3l+cQ28RYs8DS9IrEoVhB0Pe0=,tag:Vb8q6zqCkwzsC2glPcn+cQ==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - romi.prod.cid.contact
+      secretName: romi-indexer-ingress-tls
+  rules:
+    - host: romi.prod.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+
+namePrefix: romi-
+
+commonLabels:
+  name: romi
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWRsjQqLi3Ajm5MHyg6EriKBn45wWpweCN5GpJWtSuTR31
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - pvc.yaml
+  - deployment.yaml
+
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20220816144316-5785bc278b9f4322d3001e424b65db3ef9316be4

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  resources:
+    requests:
+      storage: 10Ti
+  storageClassName: io2-iops5

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
@@ -1,0 +1,98 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web.cid.contact/",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": true,
+      "Except": [
+      ],
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5h0m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s"
+  },
+  "Indexer": {
+    "CacheSize": 300000,
+    "ConfigCheckInterval": "30s",
+    "GCInterval": "30m0s",
+    "ShutdownTimeout": "15s",
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "sth",
+    "STHBits": 30
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount": 20,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 100,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": null
+  }
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      containers:
+        - name: indexer
+          resources:
+            limits:
+              cpu: "10"
+              memory: 120Gi
+            requests:
+              cpu: "10"
+              memory: 120Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5b.4xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2b
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b-4xl
+          effect: NoSchedule

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/identity.key.encrypted
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:pEH1ZNoosF/DR4mMrVkn94QLNBEaUJ2hfUe+ds0KSev1i9/nQn+ny7/2eAWHmGEzxD46iAHP6L/SnqG9Mstmzdz6+ic=,iv:0nMLwjpU47kCgRZ+Vrfffvby/wKIBSUIbwT90nPKdxc=,tag:3WBALiU7DeP+hKcpP6n6fQ==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/prod/us-east-2/sti",
+				"created_at": "2022-08-16T13:54:28Z",
+				"enc": "AQICAHjmLCaDZ4fRYyty7669VvFjJmy9C7/Y4dwd6seUJHRobwG0+j0A9bYSy0yVeiFVghNJAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMBkOWlE6W1PZHUmoDAgEQgDuwssB2de5Cu0ijKVw/Kj4zNL2y+EsLWGXL7Di9rwd3ZbkUipndgfVUaVMKoJ7hljYRU3HUHaiSgcxDGw==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-08-16T13:54:29Z",
+		"mac": "ENC[AES256_GCM,data:RbyEbQKh99X0iH+CEb6Opozhs6QTJlH94o1/l1feVpQV0taxxWQrKFgcmS2DgcWBk8eyjVEtYDc/Pvlbb6zTJPFFwR8aojixGAUCM8z0EJyxKFgY33aF/4gNDy1dNrO708ou8x+vU8yaPliFBiAIBFsroj7yOldRKCtIU6RJHbc=,iv:2sMWuSXs8lTitZrAEpDK50vAGq44F3PPBUjulZTsUiI=,tag:NVARGq89IUjFAAE/l+T4wA==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - tara.prod.cid.contact
+      secretName: tara-indexer-ingress-tls
+  rules:
+    - host: tara.prod.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+
+namePrefix: tara-
+
+commonLabels:
+  name: tara
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWCpB1suDK2Pdto57hNjTEtJbg6yaYEZ4tUs7QztqpKbKe
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - pvc.yaml
+  - deployment.yaml
+
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20220816144316-5785bc278b9f4322d3001e424b65db3ef9316be4

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  resources:
+    requests:
+      storage: 10Ti
+  storageClassName: io2-iops5

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ingress.yaml
 - pod-monitor.yaml
 - github-auth.yaml
+- instances
 patchesStrategicMerge:
 - patch-indexer.yaml
 - indexer-config.yaml
@@ -14,9 +15,6 @@ secretGenerator:
   files:
   - indexer-0.key=indexer-0-identity.encrypted
   - indexer-1.key=indexer-1-identity.encrypted
-replicas:
-- name: indexer
-  count: 2
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   name: indexer
 spec:
+  replicas: 2
   template:
     spec:
       affinity:


### PR DESCRIPTION
Deploy two new individually configurable and publicly addressable
instances of storetheindex in `prod` with 30-bit sth bucket size running
on `r5b.4xl` workers.

Define a new storage class of type `io2` with 5 IOPS per GiB and use it
as the strorage class for the new nodes.

Both of the nodes are configured to run the head of `main` branch. Note
that CD pipeline is not enabled for the nodes, and change of version
running requires explicit PR to update the image tag in each relevant
node kustomization.
