### PR TITLE
Do not label metrics by replica and drop high-cardinality metrics

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/prometheus-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/prometheus-patch.yaml
@@ -4,7 +4,17 @@ metadata:
   name: k8s
   namespace: monitoring
 spec:
+  # Do not include prometheus_replica label in metrics. Because, running more than one replicas
+  # results in duplicate metrics.
+  replicaExternalLabelName: ""
   remoteWrite:
     - url: https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-324f25cd-3624-4250-9b66-96d36addd73f/api/v1/remote_write
       sigv4:
         region: us-east-2
+      writeRelabelConfigs:
+        # Remove unused K8S metrics with high cardinality.
+        # See: https://grafana.com/docs/grafana-cloud/billing-and-usage/control-prometheus-metrics-usage/usage-analysis-explore/
+        - sourceLabels:
+            - "__name__"
+          action: drop
+          regex: "apiserver_request_duration_seconds_bucket|etcd_request_duration_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_duration_seconds_bucket|apiserver_watch_events_sizes_bucket|storage_operation_duration_seconds_bucket|rest_client_rate_limiter_duration_seconds_bucket|kubelet_runtime_operations_duration_seconds_bucket|apiserver_request_total|cluster_quantile:apiserver_request_duration_seconds:histogram_quantile|apiserver_request_duration_seconds_count|apiserver_request_duration_seconds_sum|apiserver_flowcontrol_priority_level_request_count_watermarks_bucket|apiserver_admission_controller_admission_duration_seconds_bucket"

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/prometheus-patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/prometheus-patch.yaml
@@ -4,7 +4,17 @@ metadata:
   name: k8s
   namespace: monitoring
 spec:
+  # Do not include prometheus_replica label in metrics. Because, running more than one replicas
+  # results in duplicate metrics.
+  replicaExternalLabelName: ""
   remoteWrite:
     - url: https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-02af630f-e4e0-444f-a59b-e5632f79b46f/api/v1/remote_write
       sigv4:
         region: us-east-2
+      writeRelabelConfigs:
+        # Remove unused K8S metrics with high cardinality.
+        # See: https://grafana.com/docs/grafana-cloud/billing-and-usage/control-prometheus-metrics-usage/usage-analysis-explore/
+        - sourceLabels:
+            - "__name__"
+          action: drop
+          regex: "apiserver_request_duration_seconds_bucket|etcd_request_duration_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_duration_seconds_bucket|apiserver_watch_events_sizes_bucket|storage_operation_duration_seconds_bucket|rest_client_rate_limiter_duration_seconds_bucket|kubelet_runtime_operations_duration_seconds_bucket|apiserver_request_total|cluster_quantile:apiserver_request_duration_seconds:histogram_quantile|apiserver_request_duration_seconds_count|apiserver_request_duration_seconds_sum|apiserver_flowcontrol_priority_level_request_count_watermarks_bucket|apiserver_admission_controller_admission_duration_seconds_bucket"


### PR DESCRIPTION
Clusters run two replicas of prometheus remote writers for
high-availability. By default all metrics are labeled by the collector
instance, with label name `prometheus_replica`. This results in doubling
the metric cardinality, which comes across as duplicate metrics in
grafana. Set replica external label name to empty string to drop this
labeling altogether and avoid duplicate metrics.

While at it, remove not-so-useful K8S-specific metrics with high
cardinality to reduce load and PL Grafana cost.

Fixes https://github.com/filecoin-project/storetheindex/issues/522