### PR TITLE
Introduce binary format valustore serialization

### DIFF
--- a/config/indexer.go
+++ b/config/indexer.go
@@ -7,7 +7,7 @@ import (
 // Indexer holds configuration for the indexer core. Setting any of these items
 // to their zero-value configures the default value.
 type Indexer struct {
-	// Maximum number of CIDs that cache can hold. Setting to -1 disables the
+	// CacheSize is the maximum number of CIDs that cache can hold. Setting to -1 disables the
 	// cache.
 	CacheSize int
 	// ConfigCheckInterval is the time between config file update checks.
@@ -21,14 +21,26 @@ type Indexer struct {
 	// ShutdownTimeout is the duration that a graceful shutdown has to complete
 	// before the daemon process is terminated.
 	ShutdownTimeout Duration
-	// Directory where value store is kept. If this is not an absolute path
+	// ValueStoreDir is the directory where value store is kept. If this is not an absolute path
 	// then the location is relative to the indexer repo directory.
 	ValueStoreDir string
-	// Type of valuestore to use, such as "sth" or "pogreb".
+	// ValueStoreType specifies type of valuestore to use, such as "sth" or "pogreb".
 	ValueStoreType string
-	// bits for bucket size in store the hash. Note: this should not be changed
-	// from it's value at initialization or the datastore will be corrupted.
+	// STHBits is bits for bucket size in store the hash. Note: this should not be changed
+	// from its value at initialization or the datastore will be corrupted.
 	STHBits uint8
+	// ValueStoreCodec configures the marshalling format of values stored by the valuestore.
+	// It can be one of "json" or "binary". If unspecified, json format is used by default.
+	//
+	// Note that the format must not be changed after a valuestore is initialized. Changing
+	// the format for a pre-existing valuestore will result in failure and potentially data
+	// corruption.
+	ValueStoreCodec string
+
+	//TODO: If left unspecified, could the functionality instead be to use whatever the existing
+	//      value store uses? If there is no existing value store, then use binary by default.
+	//      For this we need probing mechanisms in go-indexer-core.
+	//      While at it, do the same for STHBits.
 }
 
 // NewIndexer returns Indexer with values set to their defaults.
@@ -42,6 +54,7 @@ func NewIndexer() Indexer {
 		ValueStoreDir:       "valuestore",
 		ValueStoreType:      "sth",
 		STHBits:             24,
+		ValueStoreCodec:     "json",
 	}
 }
 
@@ -72,5 +85,8 @@ func (c *Indexer) populateUnset() {
 	}
 	if c.STHBits == 0 {
 		c.STHBits = def.STHBits
+	}
+	if c.ValueStoreCodec == "" {
+		c.ValueStoreCodec = def.ValueStoreCodec
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.3.0
+	github.com/filecoin-project/go-indexer-core v0.5.0
 	github.com/filecoin-project/go-legs v0.4.9
 	github.com/frankban/quicktest v1.14.3
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2-0.20220616083012-ea4de61af1
 github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.3.0 h1:h9nMX1Ta/pr2E30L8Yr5piF+nl6VvTf6uqXj1RPdc/o=
-github.com/filecoin-project/go-indexer-core v0.3.0/go.mod h1:kRsyZvLlN2XWcURn6See+AUf1mWXhLOlfuNcTrLJU1Q=
+github.com/filecoin-project/go-indexer-core v0.5.0 h1:7oA4eSLZid44tAcG8ukmTFfWRoK9lUfiv839RHRiMGc=
+github.com/filecoin-project/go-indexer-core v0.5.0/go.mod h1:DZSnB2xM26aqGWcKLPc8MtXtQGi7rhnLjEGd1BwZT64=
 github.com/filecoin-project/go-legs v0.4.9 h1:9ccbv5zDPqMviEpSpf0TdfKKI64TMYGSiuY2A1EXHFY=
 github.com/filecoin-project/go-legs v0.4.9/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1183,7 +1183,7 @@ func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *test
 
 // Make new indexer engine
 func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), sth.IndexBitSize(8))
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil, sth.IndexBitSize(8))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -33,7 +33,7 @@ var rng = rand.New(rand.NewSource(1413))
 
 //InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir())
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -33,7 +33,7 @@ var rng = rand.New(rand.NewSource(1413))
 
 //InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir())
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Upgrade to the latest `go-indexer-core` which introduces binary
serialization format for values that offers much better performance in
comparison with JSON.

Add configuration values in storetheindex so that the valuestore
serialization format can be configured, with default of JSON for
backward-compatibility.
