### PR TITLE
Isolate ingestion on `dev/debug` instance to nft.storage

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/indexer-config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/indexer-config.yaml
@@ -47,8 +47,9 @@ data:
         "FilterIPs": true,
         "LotusGateway": "wss://api.chain.love",
         "Policy": {
-          "Allow": true,
+          "Allow": false,
           "Except": [
+            "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC"
           ],
           "Publish": true,
           "PublishExcept": null


### PR DESCRIPTION
Only whitelist the peer ID of nft.storage on dev debug instance to learn
about ingest contention on a node with 30-bit bucket and 3 IOPS per GiB,
the same number of IOPS used by prod instances that serve `cid.contact`.

