### PR TITLE
Deploy prod instance with `binary` encoding dedicated to nft.storage

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
@@ -1,0 +1,8 @@
+# Instances
+
+List of individually configurable instances:
+
+| Instance | sth bit-size | IOPS per GiB | Value Codec  | Whitelist           | Running |
+|----------|--------------|--------------|--------------|---------------------|---------|
+| `arvo`   | 30           | 3            | `json`       | all                 | [93e48840e1c6a87bf9de3ad1a3f9bcb0cd633663](https://github.com/filecoin-project/storetheindex/commit/93e48840e1c6a87bf9de3ad1a3f9bcb0cd633663)        |
+| `mya`    | 30           | 3            | `json`       | all                 | [93e48840e1c6a87bf9de3ad1a3f9bcb0cd633663](https://github.com/filecoin-project/storetheindex/commit/93e48840e1c6a87bf9de3ad1a3f9bcb0cd633663)        |

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
@@ -1,0 +1,10 @@
+# Instances
+
+List of individually configurable instances:
+
+| Instance | sth bit-size | IOPS per GiB  | Value Codec  | Whitelist           | Running |
+|----------|--------------|---------------|--------------|---------------------|---------|
+| `romi`   | 30           | 5             | `json`       | all                 | [5785bc278b9f4322d3001e424b65db3ef9316be4](https://github.com/filecoin-project/storetheindex/commit/5785bc278b9f4322d3001e424b65db3ef9316be4)        |
+| `tara`   | 30           | 5             | `json`       | all                 | [5785bc278b9f4322d3001e424b65db3ef9316be4](https://github.com/filecoin-project/storetheindex/commit/5785bc278b9f4322d3001e424b65db3ef9316be4)        |
+| `xabi`   | 30           | 5             | `binary`     | all                 | [ca7859d9bb905663908fbdc4aacbd31f14efdc19](https://github.com/filecoin-project/storetheindex/commit/ca7859d9bb905663908fbdc4aacbd31f14efdc19)        |
+| `vega`   | 30           | 5             | `binary`     | `nft.storage` only  | [ca7859d9bb905663908fbdc4aacbd31f14efdc19](https://github.com/filecoin-project/storetheindex/commit/ca7859d9bb905663908fbdc4aacbd31f14efdc19)    |

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - romi # 30-bit bucket size, JSON value codec, 5 IOPS per GiB
   - tara # 30-bit bucket size, JSON value codec, 5 IOPS per GiB
   - xabi # 30-bit bucket size, binary value codec, 5 IOPS per GiB 
+  - vega # 30-bit bucket size, binary value codec, 5 IOPS per GiB, nft.storage only

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
@@ -1,0 +1,100 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web.cid.contact/",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": false,
+      "Except": [
+        "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC"
+      ],
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5h0m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s"
+  },
+  "Indexer": {
+    "CacheSize": 300000,
+    "ConfigCheckInterval": "30s",
+    "GCInterval": "30m0s",
+    "ShutdownTimeout": "15s",
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "sth",
+    "STHBits": 30,
+    "ValueStoreCodec": "binary"
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount": 20,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 100,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": null
+  }
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      containers:
+        - name: indexer
+          resources:
+            limits:
+              cpu: "10"
+              memory: 120Gi
+            requests:
+              cpu: "10"
+              memory: 120Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5b.4xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2b
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b-4xl
+          effect: NoSchedule

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/identity.key.encrypted
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:9Qu6pS0hH74yGaQ7GZn5UW5yLot1DKSZttEFPN9/sXdQTfgDCfmj3BKgkBI4GF3OtlLCUlOWc7M9LXHBPcBQ5lCGWlc=,iv:MfBzVs68s1cI3xOF3rwHKNK6UWjXcWwDdladwtuD3rY=,tag:XAsXmRjP7NPGBiMg5lCqVg==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/prod/us-east-2/sti",
+				"created_at": "2022-08-19T10:00:26Z",
+				"enc": "AQICAHjmLCaDZ4fRYyty7669VvFjJmy9C7/Y4dwd6seUJHRobwE9kF+9UY5Oxp5PVdmwJUJGAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMck15kTe0zE9RGCDYAgEQgDsdezVnZu27rJBDFNuoMpMDdhPDKhS5zKXZropemu2Z6JuxI7jMa9nXStOspMqLtszvPkgftLh5cBjlXw==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-08-19T10:00:27Z",
+		"mac": "ENC[AES256_GCM,data:5CsEGNcTaOArvmeaLAfnFC/FDZlTeLLtjfRGwLnRGDkcfgtyNFG0V3ql9ywZLLfWFUPPfjw3AmP4w530BLAvZ0yxtbYrulzI9LR7SczPzVddHth3F+lpfglNNjucnX8EVRDOHG37cPXc5A/Fs7toQh8KZy0AQD2xoh/J1wp0wwo=,iv:Hz83sO77fmXl0Gg/Ykzkag1HAiaUS4++tYF0KaGGQr0=,tag:rBCUJn54Auf9oi/FPS73yg==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - vega.prod.cid.contact
+      secretName: vega-indexer-ingress-tls
+  rules:
+    - host: vega.prod.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+
+namePrefix: vega-
+
+commonLabels:
+  name: vega
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWQiwuQGFg1huMiU1H4qSGp6LPjQCwNnULyQnuznnL2bJy
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - pvc.yaml
+  - deployment.yaml
+
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    # Commit: https://github.com/filecoin-project/storetheindex/commit/ca7859d9bb905663908fbdc4aacbd31f14efdc19
+    newTag: 20220818175126-ca7859d9bb905663908fbdc4aacbd31f14efdc19

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  resources:
+    requests:
+      storage: 10Ti
+  storageClassName: io2-iops5


### PR DESCRIPTION
Deploy a fresh instance, named `vega`, in `prod` with identical config
as `xabi` except only has nft.storage whitelisted. This is to gain a new
data point on binary encoding plus zero concurrent ingest contention.

Add README with tables to make it easier to see config across instances.

