### PR TITLE
Define base manifests for `indexstar` and deploy to `prod`

### DIFF
--- a/deploy/manifests/base/indexstar/deployment.yaml
+++ b/deploy/manifests/base/indexstar/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexstar
+spec:
+  selector:
+    matchLabels:
+      app: indexstar
+  template:
+    metadata:
+      labels:
+        app: indexstar
+    spec:
+      securityContext:
+        runAsUser: 10001
+        fsGroup: 532
+      containers:
+        - name: indexstar
+          image: indexstar
+          env:
+            - name: GOLOG_LOG_LEVEL
+              value: INFO
+            - name: GOLOG_LOG_FMT
+              value: json
+          ports:
+            - containerPort: 8080
+              name: http

--- a/deploy/manifests/base/indexstar/kustomization.yaml
+++ b/deploy/manifests/base/indexstar/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+
+commonLabels:
+  app: indexstar

--- a/deploy/manifests/base/indexstar/pdb.yaml
+++ b/deploy/manifests/base/indexstar/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: indexstar
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: indexstar

--- a/deploy/manifests/base/indexstar/service.yaml
+++ b/deploy/manifests/base/indexstar/service.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: indexstar
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app: indexstar
+  type: ClusterIP
+  clusterIP: None

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexstar
+spec:
+  template:
+    spec:
+      containers:
+        - name: indexstar
+          args:
+            - '--backends=https://cid.contact/'
+            - '--backends=https://romi.prod.cid.contact/'
+            - '--backends=https://tara.prod.cid.contact/'
+            - '--backends=https://xabi.prod.cid.contact/'
+            - '--backends=https://vega.prod.cid.contact/'
+            - '--backends=https://mya.dev.cid.contact/'
+            - '--backends=https://arvo.dev.cid.contact/'
+            - '--backends=https://cdn.dev.cid.contact/'
+            - '--backends=https://debug.dev.cid.contact/'

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexstar
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - indexstar.prod.cid.contact
+      secretName: indexstar-ingress-tls
+  rules:
+    - host: indexstar.prod.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexstar
+                port:
+                  number: 8080

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/indexstar
+  - ingress.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+replicas:
+  - name: indexstar
+    count: 1
+
+images:
+  - name: indexstar
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
+    # https://github.com/filecoin-shipyard/indexstar/commit/ed1134d579d437b9c612550c279e533f1be15a7c
+    newTag: 20220819112004-ed1134d579d437b9c612550c279e533f1be15a7c

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - pod-monitor.yaml
 - github-auth.yaml
 - instances
+- indexstar
 patchesStrategicMerge:
 - patch-indexer.yaml
 - indexer-config.yaml


### PR DESCRIPTION
Define the base K8S manifests for `indexstar` as a stateless deployment
and run an instance of it on `prod` cluster proxying from every running
instance of storetheindex across both dev and prod environments.

Run the `indexstar` in the same namespace as `storetheindex` since it is
 to eventually become an umbrella service which serves finds on
 cid.contact.

