### PR TITLE
Increase PVC size in `prod` statefulset to 20Ti

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -57,4 +57,4 @@ spec:
         storageClassName: io2
         resources:
           requests:
-            storage: 10Ti
+            storage: 20Ti


### PR DESCRIPTION
Increase the PVC size as we are near 90% utilisation at the moment. Note
that the statefulset needs to be manually re-created when size is
modified. We won't need to do this once the single instances catch up.
Since they use manifest that define a separate PVC resource. For now we
do the manual dance of orphaning the pods and recreating the statefulset
to apply the size increase.
