### PR TITLE
Roll out indexstar as the front-proxy in `prod`

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/cert_manager.tf
+++ b/deploy/infrastructure/prod/us-east-2/cert_manager.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "cert_manager" {
     resources = ["arn:aws:route53:::change/*"]
   }
   statement {
-    effect  = "Allow"
+    effect = "Allow"
     actions = [
       "route53:ChangeResourceRecordSets",
       "route53:ListResourceRecordSets"

--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -44,7 +44,7 @@ module "eks" {
       desired_size   = 1
       instance_types = ["r5b.4xlarge"]
       subnet_ids     = [data.aws_subnet.ue2a.id]
-      taints         = {
+      taints = {
         dedicated = {
           key    = "dedicated"
           value  = "r5b-4xl"
@@ -58,7 +58,7 @@ module "eks" {
       desired_size   = 1
       instance_types = ["r5b.4xlarge"]
       subnet_ids     = [data.aws_subnet.ue2b.id]
-      taints         = {
+      taints = {
         dedicated = {
           key    = "dedicated"
           value  = "r5b-4xl"

--- a/deploy/infrastructure/prod/us-east-2/monitoring.tf
+++ b/deploy/infrastructure/prod/us-east-2/monitoring.tf
@@ -30,7 +30,7 @@ module "monitoring_role" {
   create_role = true
 
   role_name    = "monitoring"
-  role_path = local.iam_path
+  role_path    = local.iam_path
   provider_url = module.eks.oidc_provider
 
   role_policy_arns = [

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -8,12 +8,10 @@ spec:
       containers:
         - name: indexstar
           args:
-            - '--backends=https://cid.contact/'
-            - '--backends=https://romi.prod.cid.contact/'
-            - '--backends=https://tara.prod.cid.contact/'
-            - '--backends=https://xabi.prod.cid.contact/'
-            - '--backends=https://vega.prod.cid.contact/'
-            - '--backends=https://mya.dev.cid.contact/'
-            - '--backends=https://arvo.dev.cid.contact/'
-            - '--backends=https://cdn.dev.cid.contact/'
-            - '--backends=https://debug.dev.cid.contact/'
+            # Use service names local to the namespace over HTTP to avoid
+            # TLS handshake overhead.
+            - '--backends=http://indexer:3000/'
+            - '--backends=http://romi-indexer:3000/'
+            - '--backends=http://tara-indexer:3000/'
+            - '--backends=http://xabi-indexer:3000/'
+            - '--backends=http://vega-indexer:3000/'

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
 spec:
   tls:
     - hosts:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -12,10 +12,9 @@ patchesStrategicMerge:
 
 replicas:
   - name: indexstar
-    count: 1
+    count: 10
 
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    # https://github.com/filecoin-shipyard/indexstar/commit/115164b2dc28c18a2e8b76795ca2738d93bf8d27
-    newTag: 20220822134009-115164b2dc28c18a2e8b76795ca2738d93bf8d27
+    newTag: 20220823121245-fcd7b5d6a729488bf4910c1eb7fa5a82b1c6d5f0


### PR DESCRIPTION
Roll out the indexstar service as the front-proxy in production, to
scatter-gather requests across multiple indexer instances for the
following endpoints:
- `/reframe`
- `/multihash/*`
- `/cid/*`
- `/providers`

Scale up indexstar to 10 instances for high-availability and
load-handling. Deploy the latest version which includes a number of bug
fixes and improvements.

Enable CORS on indexstar ingress to keep web UI happy.

