### PR TITLE
Do not delist blocked providers

### DIFF
--- a/internal/registry/policy/policy.go
+++ b/internal/registry/policy/policy.go
@@ -40,14 +40,19 @@ func (p *Policy) Allowed(peerID peer.ID) bool {
 }
 
 // PublishAllowed returns true if policy allows the publisher to publish
-// advertisements for the identified provider.  This assumes that both are
-// already allowed by policy.
+// advertisements for the identified provider, and the provider is allowed.
 func (p *Policy) PublishAllowed(publisherID, providerID peer.ID) bool {
 	p.rwmutex.RLock()
 	defer p.rwmutex.RUnlock()
 
+	// Publisher is always allowed to publish to self.
 	if publisherID == providerID {
 		return true
+	}
+	// Publisher may not publish advertisements for a provider that is not
+	// allowed to register.
+	if !p.allow.Eval(providerID) {
+		return false
 	}
 	return p.publish.Eval(publisherID)
 }

--- a/internal/registry/policy/policy_test.go
+++ b/internal/registry/policy/policy_test.go
@@ -99,10 +99,10 @@ func TestPolicyAccess(t *testing.T) {
 		t.Error("peer ID should not be allowed to publish")
 	}
 	if !p.PublishAllowed(otherID, otherID) {
-		t.Error("peer ID should be allowed to publish to self")
+		t.Error("should be allowed to publish to self")
 	}
-	if !p.PublishAllowed(exceptID, otherID) {
-		t.Error("peer ID should be allowed to publish")
+	if p.PublishAllowed(exceptID, otherID) {
+		t.Error("should not be allowed to publish to blocked peer")
 	}
 
 	p.Allow(otherID)
@@ -131,8 +131,8 @@ func TestPolicyAccess(t *testing.T) {
 		t.Error("peer ID should not be allowed")
 	}
 
-	if !p.PublishAllowed(otherID, exceptID) {
-		t.Error("peer ID should be allowed to publish")
+	if p.PublishAllowed(otherID, exceptID) {
+		t.Error("should not be allowed to publish to blocked peer")
 	}
 	if p.PublishAllowed(exceptID, otherID) {
 		t.Error("peer ID should not be allowed to publish")

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -120,8 +120,11 @@ func TestRegisterProvider(t *testing.T) {
 		t.Fatal("expected response to be", http.StatusOK)
 	}
 
-	pinfo := reg.ProviderInfo(peerID)
+	pinfo, allowed := reg.ProviderInfo(peerID)
 	if pinfo == nil {
 		t.Fatal("provider was not registered")
+	}
+	if !allowed {
+		t.Fatal("provider not allowed")
 	}
 }

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -165,9 +165,12 @@ func IndexContentNewAddr(t *testing.T, cl client.Ingest, providerID peer.ID, pri
 		t.Fatal(err)
 	}
 
-	info := reg.ProviderInfo(providerID)
+	info, allowed := reg.ProviderInfo(providerID)
 	if info == nil {
 		t.Fatal("did not get infor for provider:", providerID)
+	}
+	if !allowed {
+		t.Fatal("provider not allowed")
 	}
 
 	maddr, err := multiaddr.NewMultiaddr(newAddr)


### PR DESCRIPTION
When a provider is not allowed by policy, the indexer will not poll that provider and will remove it and delete its contents. This PR changes the behavior to retain blocked providers without removing them or their contents. The blocked providers will still not appear in `find` or  `provider` responses.  This makes it safe to manipulate allow/block lists without the concern of deleting content.