### PR TITLE
Upgrade to latest indexstar with upgraded reframe dependency

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -17,4 +17,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20220823134106-d1eb66391dbcb2e034df6bdb799ad0c1d4a1ff51
+    newTag: 20220823221905-d85ffdd885033c656e0116426468d7217af2286e


### PR DESCRIPTION
To avoid potential DAG-JSON decoding issues when multiple find provider
results are returned from a server run the latest indexstar with
upgraded reframe dependency.
