### PR TITLE
Increase termination grace period to 10 minutes in `tara`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/config.json
@@ -57,7 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
-    "ShutdownTimeout": "15s",
+    "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
     "STHBits": 30

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
@@ -57,7 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
-    "ShutdownTimeout": "15s",
+    "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
     "STHBits": 30

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
@@ -57,7 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
-    "ShutdownTimeout": "15s",
+    "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
     "STHBits": 30

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
@@ -57,7 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
-    "ShutdownTimeout": "15s",
+    "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
     "STHBits": 30

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      terminationGracePeriodSeconds: 600
       containers:
         - name: indexer
           resources:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
@@ -58,7 +58,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
-    "ShutdownTimeout": "15s",
+    "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
     "STHBits": 30,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/config.json
@@ -57,7 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
-    "ShutdownTimeout": "15s",
+    "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
     "STHBits": 30,


### PR DESCRIPTION
The previous value of 5 minutes seems to be too low as the container
did not shut down gracefully within the configured time limit. Double
it to see if that suffices for a graceful shutdown.

