### PR TITLE
Interpret shutdown timeout of zero as no limit

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -401,8 +401,11 @@ func daemonCommand(cctx *cli.Context) error {
 
 	log.Infow("Shutting down daemon")
 
-	ctx, cancel = context.WithTimeout(context.Background(), time.Duration(cfg.Indexer.ShutdownTimeout))
-	defer cancel()
+	ctx = context.Background()
+	if cfg.Indexer.ShutdownTimeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(cfg.Indexer.ShutdownTimeout))
+		defer cancel()
+	}
 
 	go func() {
 		// Wait for context to be canceled.  If timeout, then exit with error.

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -22,6 +22,8 @@ type Indexer struct {
 	GCScanFree bool
 	// ShutdownTimeout is the duration that a graceful shutdown has to complete
 	// before the daemon process is terminated.
+	// A timeout of zero disables the shutdown timeout completely.
+	// if unset, defaults to no shutdown timeout.
 	ShutdownTimeout Duration
 	// ValueStoreDir is the directory where value store is kept. If this is not an absolute path
 	// then the location is relative to the indexer repo directory.
@@ -53,7 +55,7 @@ func NewIndexer() Indexer {
 		GCInterval:          Duration(30 * time.Minute),
 		GCTimeLimit:         Duration(5 * time.Minute),
 		GCScanFree:          false,
-		ShutdownTimeout:     Duration(10 * time.Second),
+		ShutdownTimeout:     0,
 		ValueStoreDir:       "valuestore",
 		ValueStoreType:      "sth",
 		STHBits:             24,
@@ -76,9 +78,6 @@ func (c *Indexer) populateUnset() {
 	}
 	if c.GCTimeLimit == 0 {
 		c.GCTimeLimit = def.GCTimeLimit
-	}
-	if c.ShutdownTimeout == 0 {
-		c.ShutdownTimeout = def.ShutdownTimeout
 	}
 	if c.ValueStoreDir == "" {
 		c.ValueStoreDir = def.ValueStoreDir

--- a/server/finder/http/protocol_test.go
+++ b/server/finder/http/protocol_test.go
@@ -54,7 +54,7 @@ func TestFindIndexData(t *testing.T) {
 
 	test.FindIndexTest(ctx, t, c, ind, reg)
 
-	err := s.Shutdown(ctx)
+	err := s.Close()
 	if err != nil {
 		t.Error("shutdown error:", err)
 	}
@@ -101,7 +101,7 @@ func TestReframeFindIndexData(t *testing.T) {
 
 	test.ReframeFindIndexTest(ctx, t, c, reframeClient, ind, reg)
 
-	err = s.Shutdown(ctx)
+	err = s.Close()
 	if err != nil {
 		t.Error("shutdown error:", err)
 	}
@@ -144,7 +144,7 @@ func TestProviderInfo(t *testing.T) {
 
 	test.ListProvidersTest(t, httpClient, peerID)
 
-	err := s.Shutdown(ctx)
+	err := s.Close()
 	if err != nil {
 		t.Error("shutdown error:", err)
 	}
@@ -185,7 +185,7 @@ func TestGetStats(t *testing.T) {
 
 	test.GetStatsTest(ctx, t, httpClient)
 
-	err := s.Shutdown(ctx)
+	err := s.Close()
 	if err != nil {
 		t.Error("shutdown error:", err)
 	}
@@ -218,7 +218,7 @@ func TestRemoveProvider(t *testing.T) {
 
 	test.RemoveProviderTest(ctx, t, c, ind, reg)
 
-	err := s.Shutdown(ctx)
+	err := s.Close()
 	if err != nil {
 		t.Error("shutdown error:", err)
 	}

--- a/server/finder/http/server.go
+++ b/server/finder/http/server.go
@@ -98,6 +98,7 @@ func (s *Server) Start() error {
 	return s.server.Serve(s.l)
 }
 
-func (s *Server) Shutdown(ctx context.Context) error {
-	return s.server.Shutdown(ctx)
+func (s *Server) Close() error {
+	log.Info("finder http server shutdown")
+	return s.server.Shutdown(context.Background())
 }

--- a/server/ingest/http/server.go
+++ b/server/ingest/http/server.go
@@ -63,7 +63,7 @@ func (s *Server) Start() error {
 	return s.server.Serve(s.l)
 }
 
-func (s *Server) Shutdown(ctx context.Context) error {
+func (s *Server) Close() error {
 	log.Info("ingest http server shutdown")
-	return s.server.Shutdown(ctx)
+	return s.server.Shutdown(context.Background())
 }


### PR DESCRIPTION
Storetheindex at runtime can have 2 shutdown timeouts: one from K8S,
i.e. the termination grace period, and one at application level. The two
can conflict each other. So on deployment to K8S one has to make sure
the value of latter is always higher than the value of former.

To avoid having to make sure the value is higher, simply interpret zero
as no timeout. That way, the user can disable shutdown timeout fully and
avoid conflicting config depending on runtime environment.

Change the default shutdown timeout to no-timeout.

