### PR TITLE
Deploy head of `main` to `dev` and two other `prod` instances

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-config.yaml
@@ -64,7 +64,7 @@ data:
         "CacheSize": 300000,
         "ConfigCheckInterval": "30s",
         "GCInterval": "30m0s",
-        "ShutdownTimeout": "15s",
+        "ShutdownTimeout": "15m",
         "ValueStoreDir": "/data/valuestore",
         "ValueStoreType": "sth"
       },

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -18,4 +18,4 @@ secretGenerator:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 20220816144316-5785bc278b9f4322d3001e424b65db3ef9316be4 # {"$imagepolicy": "storetheindex:storetheindex:tag"}
+  newTag: 20220825110625-d150b7b088863a9e4f7ed02dd5ce55b64029383e # {"$imagepolicy": "storetheindex:storetheindex:tag"}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 2
   template:
     spec:
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 600
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
@@ -4,7 +4,7 @@ List of individually configurable instances:
 
 | Instance | sth bit-size | IOPS per GiB  | Value Codec  | Whitelist           | Running |
 |----------|--------------|---------------|--------------|---------------------|---------|
-| `romi`   | 30           | 5             | `json`       | all                 | [5785bc278b9f4322d3001e424b65db3ef9316be4](https://github.com/filecoin-project/storetheindex/commit/5785bc278b9f4322d3001e424b65db3ef9316be4)        |
+| `romi`   | 30           | 5             | `json`       | all                 | [d150b7b088863a9e4f7ed02dd5ce55b64029383e](https://github.com/filecoin-project/storetheindex/commit/d150b7b088863a9e4f7ed02dd5ce55b64029383e)        |
 | `tara`   | 30           | 5             | `json`       | all                 | [d150b7b088863a9e4f7ed02dd5ce55b64029383e](https://github.com/filecoin-project/storetheindex/commit/d150b7b088863a9e4f7ed02dd5ce55b64029383e)        |
-| `xabi`   | 30           | 5             | `binary`     | all                 | [ca7859d9bb905663908fbdc4aacbd31f14efdc19](https://github.com/filecoin-project/storetheindex/commit/ca7859d9bb905663908fbdc4aacbd31f14efdc19)        |
+| `xabi`   | 30           | 5             | `binary`     | all                 | [d150b7b088863a9e4f7ed02dd5ce55b64029383e](https://github.com/filecoin-project/storetheindex/commit/d150b7b088863a9e4f7ed02dd5ce55b64029383e)        |
 | `vega`   | 30           | 5             | `binary`     | `nft.storage` only  | [ca7859d9bb905663908fbdc4aacbd31f14efdc19](https://github.com/filecoin-project/storetheindex/commit/ca7859d9bb905663908fbdc4aacbd31f14efdc19)    |

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      terminationGracePeriodSeconds: 600
       containers:
         - name: indexer
           resources:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220816144316-5785bc278b9f4322d3001e424b65db3ef9316be4
+    newTag: 20220825110625-d150b7b088863a9e4f7ed02dd5ce55b64029383e

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      terminationGracePeriodSeconds: 600
       containers:
         - name: indexer
           resources:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/kustomization.yaml
@@ -31,5 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    # Commit: https://github.com/filecoin-project/storetheindex/commit/ca7859d9bb905663908fbdc4aacbd31f14efdc19
-    newTag: 20220818175126-ca7859d9bb905663908fbdc4aacbd31f14efdc19
+    newTag: 20220825110625-d150b7b088863a9e4f7ed02dd5ce55b64029383e


### PR DESCRIPTION
Deploy the head of main to `dev` `indexer-0` and `indexer-1`, plus
`prod` `romi` and `xabi`. It is already successfully deployed to `dev`
`mya` and prod `tara`.
