### PR TITLE
Add script to get peer ID from identity file

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -13,8 +13,8 @@ patchesStrategicMerge:
 secretGenerator:
 - name: indexer-identity
   files:
-  - indexer-0.key=indexer-0-identity.encrypted
-  - indexer-1.key=indexer-1-identity.encrypted
+  - indexer-0.key=indexer-0-identity.encrypted # 12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd
+  - indexer-1.key=indexer-1-identity.encrypted # 12D3KooWSQpUgBZwbNuMN3ctZjMesnoH9UDhwEXroxParXQCgurN
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -14,8 +14,8 @@ patchesStrategicMerge:
 secretGenerator:
 - name: indexer-identity
   files:
-  - indexer-0.key=indexer-0-identity.encrypted
-  - indexer-1.key=indexer-1-identity.encrypted
+  - indexer-0.key=indexer-0-identity.encrypted # 12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor
+  - indexer-1.key=indexer-1-identity.encrypted # 12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}

--- a/scripts/peer_id_from_priv_key.go
+++ b/scripts/peer_id_from_priv_key.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+// Reads marshalled crypto.PrivKey from os.stdin and prints the peer.ID that corresponds to the key.
+// See: crypto.UnmarshalPrivateKey, peer.IDFromPrivateKey.
+//
+// For example, you can directly get the peer.ID from a sops-encrypted identity file as long as
+// your terminal session is authenticated to the storetheindex AWS account and has access
+// to the relevant KMS keys like this:
+//
+//	sops -d indexer-0-identity.encrypted | go run <path>/<to>/peer_id_from_priv_key.go
+func main() {
+	all, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	key, err := crypto.UnmarshalPrivateKey(all)
+	if err != nil {
+		panic(err)
+	}
+	pid, err := peer.IDFromPrivateKey(key)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(pid.String())
+}


### PR DESCRIPTION
Add an script that accepts marshalled private key as stdin and prints
the public key associated to that identity.

Comment peer ID of dev and prod instances in code for convenience.

