### PR TITLE
Deploy min mh length change to dev and half of prod single nodes

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/kustomization.yaml
@@ -19,4 +19,4 @@ replicas:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220811123311-90cf8099a482611211ae9288e884e1f59239b008
+    newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/patch-indexer.yaml
@@ -18,6 +18,7 @@ spec:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: ScheduleAnyway
+      terminationGracePeriodSeconds: 600
       containers:
         - name: indexer
           env:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
@@ -4,5 +4,5 @@ List of individually configurable instances:
 
 | Instance | sth bit-size | IOPS per GiB | Value Codec  | Whitelist           | Running |
 |----------|--------------|--------------|--------------|---------------------|---------|
-| `arvo`   | 30           | 3            | `json`       | all                 | [93e48840e1c6a87bf9de3ad1a3f9bcb0cd633663](https://github.com/filecoin-project/storetheindex/commit/93e48840e1c6a87bf9de3ad1a3f9bcb0cd633663)        |
-| `mya`    | 30           | 3            | `json`       | all                 | [d150b7b088863a9e4f7ed02dd5ce55b64029383e](https://github.com/filecoin-project/storetheindex/commit/d150b7b088863a9e4f7ed02dd5ce55b64029383e)        |
+| `arvo`   | 30           | 3            | `json`       | all                 | [5e35bebb187be3db8096347d635fdef13bd85a96](https://github.com/filecoin-project/storetheindex/commit/5e35bebb187be3db8096347d635fdef13bd85a96)        |
+| `mya`    | 30           | 3            | `json`       | all                 | [5e35bebb187be3db8096347d635fdef13bd85a96](https://github.com/filecoin-project/storetheindex/commit/5e35bebb187be3db8096347d635fdef13bd85a96)        |

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      terminationGracePeriodSeconds: 600
       containers:
         - name: indexer
           resources:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220812173641-93e48840e1c6a87bf9de3ad1a3f9bcb0cd633663
+    newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      terminationGracePeriodSeconds: 600
       containers:
         - name: indexer
           resources:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220825110625-d150b7b088863a9e4f7ed02dd5ce55b64029383e
+    newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -18,4 +18,4 @@ secretGenerator:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 20220825110625-d150b7b088863a9e4f7ed02dd5ce55b64029383e # {"$imagepolicy": "storetheindex:storetheindex:tag"}
+  newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96 # {"$imagepolicy": "storetheindex:storetheindex:tag"}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
@@ -4,7 +4,7 @@ List of individually configurable instances:
 
 | Instance | sth bit-size | IOPS per GiB  | Value Codec  | Whitelist           | Running |
 |----------|--------------|---------------|--------------|---------------------|---------|
-| `romi`   | 30           | 5             | `json`       | all                 | [d150b7b088863a9e4f7ed02dd5ce55b64029383e](https://github.com/filecoin-project/storetheindex/commit/d150b7b088863a9e4f7ed02dd5ce55b64029383e)        |
-| `tara`   | 30           | 5             | `json`       | all                 | [d150b7b088863a9e4f7ed02dd5ce55b64029383e](https://github.com/filecoin-project/storetheindex/commit/d150b7b088863a9e4f7ed02dd5ce55b64029383e)        |
+| `romi`   | 30           | 5             | `json`       | all                 | [5e35bebb187be3db8096347d635fdef13bd85a96](https://github.com/filecoin-project/storetheindex/commit/5e35bebb187be3db8096347d635fdef13bd85a96)        |
+| `tara`   | 30           | 5             | `json`       | all                 | [5e35bebb187be3db8096347d635fdef13bd85a96](https://github.com/filecoin-project/storetheindex/commit/5e35bebb187be3db8096347d635fdef13bd85a96)        |
 | `xabi`   | 30           | 5             | `binary`     | all                 | [d150b7b088863a9e4f7ed02dd5ce55b64029383e](https://github.com/filecoin-project/storetheindex/commit/d150b7b088863a9e4f7ed02dd5ce55b64029383e)        |
 | `vega`   | 30           | 5             | `binary`     | `nft.storage` only  | [ca7859d9bb905663908fbdc4aacbd31f14efdc19](https://github.com/filecoin-project/storetheindex/commit/ca7859d9bb905663908fbdc4aacbd31f14efdc19)    |

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220825110625-d150b7b088863a9e4f7ed02dd5ce55b64029383e
+    newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220825110625-d150b7b088863a9e4f7ed02dd5ce55b64029383e
+    newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96


### PR DESCRIPTION
Deploy the latest changes to check for minimum mh len to dev and half
of prod single nodes.
