### PR TITLE
Roll out GC free files option to dev and prod single instances

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
@@ -2,7 +2,7 @@
 
 List of individually configurable instances:
 
-| Instance | sth bit-size | IOPS per GiB | Value Codec  | Whitelist           | Running |
-|----------|--------------|--------------|--------------|---------------------|---------|
-| `arvo`   | 30           | 3            | `json`       | all                 | [5e35bebb187be3db8096347d635fdef13bd85a96](https://github.com/filecoin-project/storetheindex/commit/5e35bebb187be3db8096347d635fdef13bd85a96)        |
-| `mya`    | 30           | 3            | `json`       | all                 | [5e35bebb187be3db8096347d635fdef13bd85a96](https://github.com/filecoin-project/storetheindex/commit/5e35bebb187be3db8096347d635fdef13bd85a96)        |
+| Instance | sth bit-size | IOPS per GiB | Value Codec  | Whitelist           | `GCScanFree` | Running |
+|----------|--------------|--------------|--------------|---------------------|--------------|---------|
+| `arvo`   | 30           | 3            | `json`       | all                 | `false`      | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)        |
+| `mya`    | 30           | 3            | `json`       | all                 | `true`       | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)        |

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/config.json
@@ -57,6 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
+    "GCScanFree": false,
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96
+    newTag: 20220827185242-945940507682064093e846ecc8578a58a5f16535

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
@@ -57,6 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
+    "GCScanFree": true,
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96
+    newTag: 20220827185242-945940507682064093e846ecc8578a58a5f16535

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -18,4 +18,4 @@ secretGenerator:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96 # {"$imagepolicy": "storetheindex:storetheindex:tag"}
+  newTag: 20220827185242-945940507682064093e846ecc8578a58a5f16535 # {"$imagepolicy": "storetheindex:storetheindex:tag"}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
@@ -2,9 +2,9 @@
 
 List of individually configurable instances:
 
-| Instance | sth bit-size | IOPS per GiB  | Value Codec  | Whitelist           | Running |
-|----------|--------------|---------------|--------------|---------------------|---------|
-| `romi`   | 30           | 5             | `json`       | all                 | [5e35bebb187be3db8096347d635fdef13bd85a96](https://github.com/filecoin-project/storetheindex/commit/5e35bebb187be3db8096347d635fdef13bd85a96)        |
-| `tara`   | 30           | 5             | `json`       | all                 | [5e35bebb187be3db8096347d635fdef13bd85a96](https://github.com/filecoin-project/storetheindex/commit/5e35bebb187be3db8096347d635fdef13bd85a96)        |
-| `xabi`   | 30           | 5             | `binary`     | all                 | [d150b7b088863a9e4f7ed02dd5ce55b64029383e](https://github.com/filecoin-project/storetheindex/commit/d150b7b088863a9e4f7ed02dd5ce55b64029383e)        |
-| `vega`   | 30           | 5             | `binary`     | `nft.storage` only  | [ca7859d9bb905663908fbdc4aacbd31f14efdc19](https://github.com/filecoin-project/storetheindex/commit/ca7859d9bb905663908fbdc4aacbd31f14efdc19)    |
+| Instance | sth bit-size | IOPS per GiB  | Value Codec  | Whitelist           | `GCScanFree` | Running |
+|----------|--------------|---------------|--------------|---------------------|--------------|---------|
+| `romi`   | 30           | 5             | `json`       | all                 | `false`      | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)        |
+| `tara`   | 30           | 5             | `json`       | all                 | `true`       | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)        |
+| `xabi`   | 30           | 5             | `binary`     | all                 | `true`       | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)        |
+| `vega`   | 30           | 5             | `binary`     | `nft.storage` only  | `false`      | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)    |

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
@@ -57,6 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
+    "GCScanFree": false,
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96
+    newTag: 20220827185242-945940507682064093e846ecc8578a58a5f16535

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
@@ -57,6 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
+    "GCScanFree": true,
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220826192838-5e35bebb187be3db8096347d635fdef13bd85a96
+    newTag: 20220827185242-945940507682064093e846ecc8578a58a5f16535

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
@@ -58,6 +58,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
+    "GCScanFree": false,
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/kustomization.yaml
@@ -31,5 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    # Commit: https://github.com/filecoin-project/storetheindex/commit/ca7859d9bb905663908fbdc4aacbd31f14efdc19
-    newTag: 20220818175126-ca7859d9bb905663908fbdc4aacbd31f14efdc19
+    newTag: 20220827185242-945940507682064093e846ecc8578a58a5f16535

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/config.json
@@ -57,6 +57,7 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
+    "GCScanFree": true,
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220825110625-d150b7b088863a9e4f7ed02dd5ce55b64029383e
+    newTag: 20220827185242-945940507682064093e846ecc8578a58a5f16535


### PR DESCRIPTION
Roll out change to GC mechanism optionally freeing files in `dev` all
nodes, and `prod` single-deployment nodes. Preliminary testing showed
that changes to the locking mechanism significantly reduces spike in
latency when the GC runs. To further study the long-term impact of the
changes, the rollout here sets the option to `true` in some nodes and
`false` in others.
