### PR TITLE
Fix error writing existing value; add more STH config

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -503,7 +503,8 @@ func createValueStore(ctx context.Context, cfgIndexer config.Indexer) (indexer.I
 			vcodec,
 			sth.GCInterval(time.Duration(cfgIndexer.GCInterval)),
 			sth.GCTimeLimit(time.Duration(cfgIndexer.GCTimeLimit)),
-			sth.GCScanFree(cfgIndexer.GCScanFree),
+			sth.BurstRate(cfgIndexer.STHBurstRate),
+			sth.SyncInterval(time.Duration(cfgIndexer.STHSyncInterval)),
 			sth.IndexBitSize(cfgIndexer.STHBits),
 		)
 		minKeyLen = sthMinKeyLen

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.5.3
+	github.com/filecoin-project/go-indexer-core v0.5.4-0.20220830055939-d0348f7b490c
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -22,7 +22,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.4
+	github.com/ipld/go-storethehash v0.2.6-0.20220830055254-5359217edae7
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0
@@ -67,7 +67,7 @@ require (
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
-	github.com/gammazero/keymutex v0.0.2 // indirect
+	github.com/gammazero/keymutex v0.1.0 // indirect
 	github.com/gammazero/radixtree v0.3.0 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.5.3 h1:TSi2m9UCoUKzhlSwLyK/Apjs8wgUxrkNFpCPZUCXlH8=
-github.com/filecoin-project/go-indexer-core v0.5.3/go.mod h1:jsU6gEMwQyPyCPWS6jffCAOM8Px5EtnNnLGkjfN2W5Y=
+github.com/filecoin-project/go-indexer-core v0.5.4-0.20220830055939-d0348f7b490c h1:qsmrE3C/BCS5746OQ0AtJUCbvOUSarekNUnf00zi/3Q=
+github.com/filecoin-project/go-indexer-core v0.5.4-0.20220830055939-d0348f7b490c/go.mod h1:fjsjZdHkl4Z+hHFih4K6p+tIo1bUX4dUa3Z3ehZPQOc=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -251,8 +251,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/gammazero/deque v0.2.0 h1:SkieyNB4bg2/uZZLxvya0Pq6diUlwx7m2TeT7GAIWaA=
 github.com/gammazero/deque v0.2.0/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
-github.com/gammazero/keymutex v0.0.2 h1:cmpLBJHdEwn+WlR5Z/o9/BN92znSZTp5AKPQDpu1QcI=
-github.com/gammazero/keymutex v0.0.2/go.mod h1:qtzWCCLMisQUmVa4dvqHVgwfh4BP2YB7JxNDGXnsKrs=
+github.com/gammazero/keymutex v0.1.0 h1:9Qz6/dUQ+eEdHa8vq8uCR3o8S9OOFvIWJ8EOBB6PycQ=
+github.com/gammazero/keymutex v0.1.0/go.mod h1:qtzWCCLMisQUmVa4dvqHVgwfh4BP2YB7JxNDGXnsKrs=
 github.com/gammazero/radixtree v0.3.0 h1:8CVHGuCXMoY1sAE11fMpkrELaXmX2+jpgBOcplXhDdw=
 github.com/gammazero/radixtree v0.3.0/go.mod h1:qvmbw16a4HlQ53wB7V74gNpjKl1Q9hsT+5YTrFXtvK4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -625,8 +625,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.4 h1:c5jYkJrX1idE3IH4PjtC6AunkfaWKi+2x+MhM6KvK3E=
-github.com/ipld/go-storethehash v0.2.4/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.6-0.20220830055254-5359217edae7 h1:2VwXKPtsUFKCWXcXUzpMDNLrnEfXp5WQJQifkceojpY=
+github.com/ipld/go-storethehash v0.2.6-0.20220830055254-5359217edae7/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=


### PR DESCRIPTION
## Update STH Config options
- Add `Config.Indexer.STHBurstRate`
- Add `Config.Indexer.STHSyncInterval`
- Remove `Config.Indexer.GCScanFree`

The `GCScanFree` option is no longer needed since whether or not it is used is now automatically determined by a simple heuristic.

- Update to STH with scan free heuristic

## Update to core with write lock enhancement
When writing to the indexer-core, an exclusive lock was serializing much of the call to Put.  The locking has been changed to make it much more granular and should allow for better write concurrency.

## Fix error when writing existing key/value to sth
When querying by a multihash that was deleted when its provider was delete, the indexer tries to opportunistically delete the multihash when it determines the provider is gone. Updating the value key list to remove the value-key for a provider's value can result in writing the same value that was already updated in the valued store being written again and cause an error that looks like:
```
{"level":"error","ts":"2022-08-30T06:13:37.592Z","logger":"indexer/http","caller":"httpserver/util.go:29","msg":"Cannot handle request","regType":"get","err":"failed to query \"122029cdd79402c8b60dd2e479921a9d6877f9c71a14d7083f24710928f822f895c3\": cannot get values for multihash: cannot update value keys for multihash: key exists","status":500}
```
This PR depends on a version of STH that has a fix for this.


