### PR TITLE
Increase STH sync interval on `vega` to 3 seconds

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
@@ -2,9 +2,9 @@
 
 List of individually configurable instances:
 
-| Instance | sth bit-size | IOPS per GiB  | Value Codec  | Whitelist           | `GCScanFree` | Running |
-|----------|--------------|---------------|--------------|---------------------|--------------|---------|
-| `romi`   | 30           | 5             | `json`       | all                 | `false`      | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)        |
-| `tara`   | 30           | 5             | `json`       | all                 | `true`       | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)        |
-| `xabi`   | 30           | 5             | `binary`     | all                 | `true`       | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)        |
-| `vega`   | 30           | 5             | `binary`     | `nft.storage` only  | `false`      | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535)    |
+| Instance | sth bit-size | IOPS per GiB  | Value Codec  | Whitelist           | `GCScanFree` | `STHSyncInterval` | Running                                                                                                                                       |
+|----------|--------------|---------------|--------------|---------------------|--------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `romi`   | 30           | 5             | `json`       | all                 | `false`      | `1s`              | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535) |
+| `tara`   | 30           | 5             | `json`       | all                 | `true`       | `1s`              | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535) |
+| `xabi`   | 30           | 5             | `binary`     | all                 | `true`       | `1s`              | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535) |
+| `vega`   | 30           | 5             | `binary`     | `nft.storage` only  | `false`      | `3s`              | [945940507682064093e846ecc8578a58a5f16535](https://github.com/filecoin-project/storetheindex/commit/945940507682064093e846ecc8578a58a5f16535) |

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
@@ -63,7 +63,8 @@
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
     "STHBits": 30,
-    "ValueStoreCodec": "binary"
+    "ValueStoreCodec": "binary",
+    "STHSyncInterval": "3s"
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,


### PR DESCRIPTION
Investigate the impact of increasing sync interval on `vega` by
increasing it from the default of 1 second to 3 seconds.
