### PR TITLE
Concurrently ingest core multihashes and entry chunks

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -501,6 +501,7 @@ func createValueStore(ctx context.Context, cfgIndexer config.Indexer) (indexer.I
 			ctx,
 			dir,
 			vcodec,
+			cfgIndexer.CorePutConcurrency,
 			sth.GCInterval(time.Duration(cfgIndexer.GCInterval)),
 			sth.GCTimeLimit(time.Duration(cfgIndexer.GCTimeLimit)),
 			sth.BurstRate(cfgIndexer.STHBurstRate),

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -12,6 +12,10 @@ type Indexer struct {
 	CacheSize int
 	// ConfigCheckInterval is the time between config file update checks.
 	ConfigCheckInterval Duration
+	// CorePutConcurrency is the number of core goroutines used to write
+	// individual multihashes within a Put. A value of 1 means no concurrency,
+	// and zero uses the default.
+	CorePutConcurrency int
 	// GCInterval configures the garbage collection interval for valuestores
 	// that support it.
 	GCInterval Duration
@@ -55,6 +59,7 @@ func NewIndexer() Indexer {
 	return Indexer{
 		CacheSize:           300000,
 		ConfigCheckInterval: Duration(30 * time.Second),
+		CorePutConcurrency:  64,
 		GCInterval:          Duration(30 * time.Minute),
 		GCTimeLimit:         Duration(5 * time.Minute),
 		ShutdownTimeout:     0,
@@ -76,6 +81,9 @@ func (c *Indexer) populateUnset() {
 	}
 	if c.ConfigCheckInterval == 0 {
 		c.ConfigCheckInterval = def.ConfigCheckInterval
+	}
+	if c.CorePutConcurrency == 0 {
+		c.CorePutConcurrency = def.CorePutConcurrency
 	}
 	if c.GCInterval == 0 {
 		c.GCInterval = def.GCInterval

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -27,6 +27,11 @@ type Ingest struct {
 	// (segments) of size set by SyncSegmentDepthLimit. EntriesDepthLimit sets
 	// the limit on the total number of entries chunks across all segments.
 	EntriesDepthLimit int
+	// EntryPutConcurrency is the number of goroutines used to asynchronously
+	// Put entry chunks. This allows fetching the next entry chunk without
+	// waiting for the current one to finish being written. A value of 1 means
+	// no concurrency, and zero uses the default.
+	EntryPutConcurrency int
 	// HttpSyncRetryMax sets the maximum number of times HTTP sync requests
 	// should be retried.
 	HttpSyncRetryMax int
@@ -77,6 +82,7 @@ func NewIngest() Ingest {
 	return Ingest{
 		AdvertisementDepthLimit: 33554432,
 		EntriesDepthLimit:       65536,
+		EntryPutConcurrency:     16,
 		HttpSyncRetryMax:        4,
 		HttpSyncRetryWaitMax:    Duration(30 * time.Second),
 		HttpSyncRetryWaitMin:    Duration(1 * time.Second),
@@ -99,6 +105,9 @@ func (c *Ingest) populateUnset() {
 	}
 	if c.EntriesDepthLimit == 0 {
 		c.EntriesDepthLimit = def.EntriesDepthLimit
+	}
+	if c.EntryPutConcurrency == 0 {
+		c.EntryPutConcurrency = def.EntryPutConcurrency
 	}
 	if c.HttpSyncRetryMax == 0 {
 		c.HttpSyncRetryMax = def.HttpSyncRetryMax

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901232847-d164cef8e9e3
+	github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901234731-3e0244eb1a96
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.5.4
+	github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901232847-d164cef8e9e3
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
+	github.com/gammazero/workerpool v1.1.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901232847-d164cef8e9e3 h1:+k+5ecckdVtQ/6nl6bj8ZkheEUq0ofpSAOJ6EujlCiU=
-github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901232847-d164cef8e9e3/go.mod h1:T0RKdJlXH6buiZRbRZJsKpLEidKRZ9Ozfnj24yofWr8=
+github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901234731-3e0244eb1a96 h1:D8QpVMPNCC+gc9FduzdbY9P69tSHVeXHCLAkoFz6LF4=
+github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901234731-3e0244eb1a96/go.mod h1:T0RKdJlXH6buiZRbRZJsKpLEidKRZ9Ozfnj24yofWr8=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.5.4 h1:kYM5f/rpM4QXp4xgo3CSF5B4C/KzM312LtXGKwaNEPk=
-github.com/filecoin-project/go-indexer-core v0.5.4/go.mod h1:gAOnNHEvML9hr/BGG+Uh3oI4fv2+atsSrBeM/yndSh8=
+github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901232847-d164cef8e9e3 h1:+k+5ecckdVtQ/6nl6bj8ZkheEUq0ofpSAOJ6EujlCiU=
+github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901232847-d164cef8e9e3/go.mod h1:T0RKdJlXH6buiZRbRZJsKpLEidKRZ9Ozfnj24yofWr8=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -255,6 +255,8 @@ github.com/gammazero/keymutex v0.1.0 h1:9Qz6/dUQ+eEdHa8vq8uCR3o8S9OOFvIWJ8EOBB6P
 github.com/gammazero/keymutex v0.1.0/go.mod h1:qtzWCCLMisQUmVa4dvqHVgwfh4BP2YB7JxNDGXnsKrs=
 github.com/gammazero/radixtree v0.3.0 h1:8CVHGuCXMoY1sAE11fMpkrELaXmX2+jpgBOcplXhDdw=
 github.com/gammazero/radixtree v0.3.0/go.mod h1:qvmbw16a4HlQ53wB7V74gNpjKl1Q9hsT+5YTrFXtvK4=
+github.com/gammazero/workerpool v1.1.3 h1:WixN4xzukFoN0XSeXF6puqEqFTl2mECI9S6W44HWy9Q=
+github.com/gammazero/workerpool v1.1.3/go.mod h1:wPjyBLDbyKnUn2XwwyD3EEwo9dHutia9/fwNmSHWACc=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -294,7 +294,7 @@ func (ing *Ingester) Close() error {
 		log.Info("Pending sync processing stopped")
 
 		if ing.entryWP != nil {
-			ing.entryWP.Stop()
+			ing.entryWP.StopWait()
 			log.Info("Entry workers stopped")
 		}
 

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -293,6 +293,11 @@ func (ing *Ingester) Close() error {
 		ing.waitForPendingSyncs.Wait()
 		log.Info("Pending sync processing stopped")
 
+		if ing.entryWP != nil {
+			ing.entryWP.Stop()
+			log.Info("Entry workers stopped")
+		}
+
 		// Stop the distribution goroutine.
 		close(ing.inEvents)
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -44,6 +44,9 @@ import (
 )
 
 const (
+	testCorePutConcurrency  = 4
+	testEntryPutConcurrency = 4
+
 	testRetryInterval = 2 * time.Second
 	testRetryTimeout  = 15 * time.Second
 
@@ -55,6 +58,7 @@ var (
 	defaultTestIngestConfig = config.Ingest{
 		AdvertisementDepthLimit: 100,
 		EntriesDepthLimit:       100,
+		EntryPutConcurrency:     testEntryPutConcurrency,
 		IngestWorkerCount:       1,
 		PubSubTopic:             "test/ingest",
 		RateLimit: config.RateLimit{
@@ -1183,7 +1187,7 @@ func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *test
 
 // Make new indexer engine
 func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil, sth.IndexBitSize(8))
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil, testCorePutConcurrency, sth.IndexBitSize(8))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -344,8 +344,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 			} else {
 				entryWG.Add(1)
 				ing.entryWP.Submit(func() {
-					err = ing.ingestEntryChunk(ctx, ad, syncedFirstEntryCid, *chunk, log)
-					if err != nil {
+					if err := ing.ingestEntryChunk(ctx, ad, syncedFirstEntryCid, *chunk, log); err != nil {
 						errsMutex.Lock()
 						errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
 						errsMutex.Unlock()
@@ -389,8 +388,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 					chnk := *chunk
 					// Submit chunk to entry worker pool.
 					ing.entryWP.Submit(func() {
-						err = ing.ingestEntryChunk(ctx, ad, c, chnk, log)
-						if err != nil {
+						if err := ing.ingestEntryChunk(ctx, ad, c, chnk, log); err != nil {
 							errsMutex.Lock()
 							errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
 							errsMutex.Unlock()

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -33,7 +33,7 @@ var rng = rand.New(rand.NewSource(1413))
 
 // InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil)
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil, 4)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -33,7 +33,7 @@ var rng = rand.New(rand.NewSource(1413))
 
 // InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil)
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil, 4)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
When configured with `Ingest.EntryPutConcurrency` > 1, concurrently/asynchronously ingest each `Put` and fetch and ingest the next chunk without waiting for the current Put to complete. Default is 16.

When configured with `Indexer.CorePutConcurrency` > 1, within each call to the core's `Put`, write each multihash-to-value mapping concurrently. Default is 64.