### PR TITLE
Asynchronously handle entry chunks by default

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -417,7 +417,6 @@ func daemonCommand(cctx *cli.Context) error {
 			log.Errorw("Error stopping peering service", "err", err)
 		}
 	}
-	fmt.Println("---> Stopped peering service")
 
 	if cancelP2pServers != nil {
 		cancelP2pServers()
@@ -441,7 +440,6 @@ func daemonCommand(cctx *cli.Context) error {
 			finalErr = ErrDaemonStop
 		}
 	}
-	fmt.Println("---> Closed servers")
 
 	// If ingester set, close ingester
 	if ingester != nil {
@@ -450,13 +448,11 @@ func daemonCommand(cctx *cli.Context) error {
 			finalErr = ErrDaemonStop
 		}
 	}
-	fmt.Println("---> Closed ingestor")
 
 	if err = valueStore.Close(); err != nil {
 		log.Errorw("Error closing value store", "err", err)
 		finalErr = ErrDaemonStop
 	}
-	fmt.Println("---> Closed valuestore")
 
 	log.Info("Indexer stopped")
 	return finalErr

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -417,6 +417,7 @@ func daemonCommand(cctx *cli.Context) error {
 			log.Errorw("Error stopping peering service", "err", err)
 		}
 	}
+	fmt.Println("---> Stopped peering service")
 
 	if cancelP2pServers != nil {
 		cancelP2pServers()
@@ -440,6 +441,7 @@ func daemonCommand(cctx *cli.Context) error {
 			finalErr = ErrDaemonStop
 		}
 	}
+	fmt.Println("---> Closed servers")
 
 	// If ingester set, close ingester
 	if ingester != nil {
@@ -448,11 +450,13 @@ func daemonCommand(cctx *cli.Context) error {
 			finalErr = ErrDaemonStop
 		}
 	}
+	fmt.Println("---> Closed ingestor")
 
 	if err = valueStore.Close(); err != nil {
 		log.Errorw("Error closing value store", "err", err)
 		finalErr = ErrDaemonStop
 	}
+	fmt.Println("---> Closed valuestore")
 
 	log.Info("Indexer stopped")
 	return finalErr
@@ -571,6 +575,7 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 		if err != nil {
 			return nil, fmt.Errorf("failed to set rate limit config: %w", err)
 		}
+		ingester.SetSyncWriteEntries(cfg.Ingest.SyncWriteEntries)
 		ingester.SetBatchSize(cfg.Ingest.StoreBatchSize)
 		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
 	}

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -27,11 +27,11 @@ type Ingest struct {
 	// (segments) of size set by SyncSegmentDepthLimit. EntriesDepthLimit sets
 	// the limit on the total number of entries chunks across all segments.
 	EntriesDepthLimit int
-	// EntryPutConcurrency is the number of goroutines used to asynchronously
-	// Put entry chunks. This allows fetching the next entry chunk without
-	// waiting for the current one to finish being written. A value of 1 means
-	// no concurrency, and zero uses the default.
-	EntryPutConcurrency int
+	// SyncWriteEntries tells the indexer to process entry chunks
+	// synchronously, waiting for each to complete before fetching the next.
+	// When this is false, the indexer processes entry chunks asynchronously.
+	// This value is reloadable.
+	SyncWriteEntries bool
 	// HttpSyncRetryMax sets the maximum number of times HTTP sync requests
 	// should be retried.
 	HttpSyncRetryMax int
@@ -82,7 +82,6 @@ func NewIngest() Ingest {
 	return Ingest{
 		AdvertisementDepthLimit: 33554432,
 		EntriesDepthLimit:       65536,
-		EntryPutConcurrency:     16,
 		HttpSyncRetryMax:        4,
 		HttpSyncRetryWaitMax:    Duration(30 * time.Second),
 		HttpSyncRetryWaitMin:    Duration(1 * time.Second),
@@ -105,9 +104,6 @@ func (c *Ingest) populateUnset() {
 	}
 	if c.EntriesDepthLimit == 0 {
 		c.EntriesDepthLimit = def.EntriesDepthLimit
-	}
-	if c.EntryPutConcurrency == 0 {
-		c.EntryPutConcurrency = def.EntryPutConcurrency
 	}
 	if c.HttpSyncRetryMax == 0 {
 		c.HttpSyncRetryMax = def.HttpSyncRetryMax

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901234731-3e0244eb1a96
+	github.com/filecoin-project/go-indexer-core v0.5.5
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901234731-3e0244eb1a96 h1:D8QpVMPNCC+gc9FduzdbY9P69tSHVeXHCLAkoFz6LF4=
-github.com/filecoin-project/go-indexer-core v0.5.5-0.20220901234731-3e0244eb1a96/go.mod h1:T0RKdJlXH6buiZRbRZJsKpLEidKRZ9Ozfnj24yofWr8=
+github.com/filecoin-project/go-indexer-core v0.5.5 h1:TSCzYiVdApkDWWGdQJTSjrDngVOsMbxqkY2vb+mC+UI=
+github.com/filecoin-project/go-indexer-core v0.5.5/go.mod h1:T0RKdJlXH6buiZRbRZJsKpLEidKRZ9Ozfnj24yofWr8=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -17,7 +17,6 @@ import (
 	"github.com/filecoin-project/storetheindex/internal/metrics"
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	"github.com/filecoin-project/storetheindex/peerutil"
-	"github.com/gammazero/workerpool"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -137,9 +136,9 @@ type Ingester struct {
 
 	// Multihash minimum length
 	minKeyLen int
-
-	// entryWP is a worker pool for asynchronous calls to indexer.Put.
-	entryWP *workerpool.WorkerPool
+	// syncWriteEntries tells the Ingester to handle write entry chunks
+	// synchronously, waiting for each to complete before fetching the next.
+	syncWriteEntries atomic.Bool
 }
 
 // NewIngester creates a new Ingester that uses a go-legs Subscriber to handle
@@ -167,6 +166,8 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 
 		minKeyLen: cfg.MinimumKeyLength,
 	}
+
+	ing.SetSyncWriteEntries(cfg.SyncWriteEntries)
 
 	var err error
 	ing.rateApply, ing.rateBurst, ing.rateLimit, err = configRateLimit(cfg.RateLimit)
@@ -210,10 +211,6 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 
 	if cfg.IngestWorkerCount == 0 {
 		return nil, errors.New("ingester worker count must be > 0")
-	}
-
-	if cfg.EntryPutConcurrency > 1 {
-		ing.entryWP = workerpool.New(cfg.EntryPutConcurrency)
 	}
 
 	ing.workersCtx, ing.cancelWorkers = context.WithCancel(context.Background())
@@ -265,6 +262,10 @@ func (ing *Ingester) getRateLimiter(publisher peer.ID) *rate.Limiter {
 	return rate.NewLimiter(ing.rateLimit, ing.rateBurst)
 }
 
+func (ing *Ingester) SetSyncWriteEntries(syncWriteEntries bool) {
+	ing.syncWriteEntries.Store(syncWriteEntries)
+}
+
 func (ing *Ingester) Close() error {
 	// Tell workers to stop ingestion in progress.
 	ing.cancelWorkers()
@@ -292,11 +293,6 @@ func (ing *Ingester) Close() error {
 		close(ing.closePendingSyncs)
 		ing.waitForPendingSyncs.Wait()
 		log.Info("Pending sync processing stopped")
-
-		if ing.entryWP != nil {
-			ing.entryWP.StopWait()
-			log.Info("Entry workers stopped")
-		}
 
 		// Stop the distribution goroutine.
 		close(ing.inEvents)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -136,9 +136,11 @@ type Ingester struct {
 
 	// Multihash minimum length
 	minKeyLen int
-	// syncWriteEntries tells the Ingester to handle write entry chunks
-	// synchronously, waiting for each to complete before fetching the next.
-	syncWriteEntries atomic.Bool
+	// syncWriteEntries is accessed through Ingester.SetSyncWriteEntries() and
+	// Ingester.syncWriteEntries(). It tells the Ingester to handle write entry
+	// chunks synchronously, waiting for each to complete before fetching the
+	// next.
+	_syncWriteEntries uint32
 }
 
 // NewIngester creates a new Ingester that uses a go-legs Subscriber to handle
@@ -262,8 +264,18 @@ func (ing *Ingester) getRateLimiter(publisher peer.ID) *rate.Limiter {
 	return rate.NewLimiter(ing.rateLimit, ing.rateBurst)
 }
 
-func (ing *Ingester) SetSyncWriteEntries(syncWriteEntries bool) {
-	ing.syncWriteEntries.Store(syncWriteEntries)
+// SetSyncWriteEntries, when set to true, tells the indexer to process chunks
+// of multihash entries synchronously.
+func (ing *Ingester) SetSyncWriteEntries(val bool) {
+	var b32 uint32
+	if val {
+		b32 = 1
+	}
+	atomic.StoreUint32(&ing._syncWriteEntries, b32)
+}
+
+func (ing *Ingester) syncWriteEntries() bool {
+	return atomic.LoadUint32(&ing._syncWriteEntries) != 0
 }
 
 func (ing *Ingester) Close() error {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -44,8 +44,7 @@ import (
 )
 
 const (
-	testCorePutConcurrency  = 4
-	testEntryPutConcurrency = 4
+	testCorePutConcurrency = 4
 
 	testRetryInterval = 2 * time.Second
 	testRetryTimeout  = 15 * time.Second
@@ -58,7 +57,7 @@ var (
 	defaultTestIngestConfig = config.Ingest{
 		AdvertisementDepthLimit: 100,
 		EntriesDepthLimit:       100,
-		EntryPutConcurrency:     testEntryPutConcurrency,
+		SyncWriteEntries:        false,
 		IngestWorkerCount:       1,
 		PubSubTopic:             "test/ingest",
 		RateLimit: config.RateLimit{

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -331,7 +331,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		var errsMutex sync.Mutex
 		var entryWP *workerpool.WorkerPool
 
-		syncWriteEntries := ing.syncWriteEntries.Load()
+		syncWriteEntries := ing.syncWriteEntries()
 
 		// Create a WorkerPool with one worker. This allows all the Put calls
 		// to be queued, and processed while they are being queued.

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/filecoin-project/storetheindex/internal/metrics"
 	"github.com/filecoin-project/storetheindex/internal/registry"
+	"github.com/gammazero/workerpool"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	hamt "github.com/ipld/go-ipld-adl-hamt"
@@ -327,8 +328,16 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 	} else {
 		log = log.With("entriesKind", "EntryChunk")
 
-		var entryWG sync.WaitGroup
 		var errsMutex sync.Mutex
+		var entryWP *workerpool.WorkerPool
+
+		syncWriteEntries := ing.syncWriteEntries.Load()
+
+		// Create a WorkerPool with one worker. This allows all the Put calls
+		// to be queued, and processed while they are being queued.
+		if !syncWriteEntries {
+			entryWP = workerpool.New(1)
+		}
 
 		// We have already peeked at the first EntryChunk as part of probing the entries type.
 		// So process that first
@@ -336,27 +345,25 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		if err != nil {
 			errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
 		} else {
-			if ing.entryWP == nil {
+			if syncWriteEntries {
 				err = ing.ingestEntryChunk(ctx, ad, syncedFirstEntryCid, *chunk, log)
 				if err != nil {
 					errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
 				}
 			} else {
-				entryWG.Add(1)
-				ing.entryWP.Submit(func() {
+				entryWP.Submit(func() {
 					if err := ing.ingestEntryChunk(ctx, ad, syncedFirstEntryCid, *chunk, log); err != nil {
 						errsMutex.Lock()
 						errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
 						errsMutex.Unlock()
 					}
-					entryWG.Done()
 				})
 			}
 		}
 
 		if chunk != nil && chunk.Next != nil {
 			var errCh chan error
-			if ing.entryWP != nil {
+			if !syncWriteEntries {
 				errCh = make(chan error, 1)
 			}
 			nextChunkCid := chunk.Next.(cidlink.Link).Cid
@@ -369,7 +376,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 					errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
 					return
 				}
-				if ing.entryWP == nil {
+				if syncWriteEntries {
 					err = ing.ingestEntryChunk(ctx, ad, c, *chunk, log)
 					if err != nil {
 						actions.FailSync(err)
@@ -384,10 +391,9 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 						actions.FailSync(err)
 						return
 					}
-					entryWG.Add(1)
 					chnk := *chunk
 					// Submit chunk to entry worker pool.
-					ing.entryWP.Submit(func() {
+					entryWP.Submit(func() {
 						if err := ing.ingestEntryChunk(ctx, ad, c, chnk, log); err != nil {
 							errsMutex.Lock()
 							errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
@@ -398,7 +404,6 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 							default:
 							}
 						}
-						entryWG.Done()
 					})
 				}
 
@@ -408,8 +413,8 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 					actions.SetNextSyncCid(cid.Undef)
 				}
 			}))
-			if ing.entryWP != nil {
-				entryWG.Wait()
+			if !syncWriteEntries {
+				entryWP.StopWait()
 			}
 
 			if err != nil {

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -413,16 +413,18 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 					actions.SetNextSyncCid(cid.Undef)
 				}
 			}))
-			if !syncWriteEntries {
-				entryWP.StopWait()
-			}
-
 			if err != nil {
+				if !syncWriteEntries {
+					entryWP.StopWait()
+				}
 				if strings.Contains(err.Error(), "datatransfer failed: content not found") {
 					return adIngestError{adIngestContentNotFound, fmt.Errorf("failed to sync entries: %w", err)}
 				}
 				return adIngestError{adIngestSyncEntriesErr, fmt.Errorf("failed to sync entries: %w", err)}
 			}
+		}
+		if !syncWriteEntries {
+			entryWP.StopWait()
 		}
 	}
 	elapsed := time.Since(startTime)


### PR DESCRIPTION
Handle entry chunks asynchronously, unless `Config.Ingest.SyncWriteEntries` is true. The asynchronous behavior allows the indexer to fetch the next entry chunk without having to wait for the current one to complete processing. An asynchronous goroutine (one per worker) processes the entry chunks while they are being queued.

Previously, the `EntryPutConcurrency` setting configured a pool of goroutines, shared by all workers, to handle processing entry chunks. A problem with this was that one provider/worker could submit many entry chunks to his pool and keep all the goroutines busy for itself, starving the other provider/workers of the ability to process entry chunks.

With this PR, each provider/worker has its own async goroutine and can asynchronously process entry chunks without starving any other provider/worker. The asynchronous behavior can be enabled or disabled using the `Ingest.SyncWriteEntries` setting (false=async, true=sync). This configuration value is run-time reloadable.