### PR TITLE
Limit entry chunks queued for async processing

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -345,6 +345,9 @@ func daemonCommand(cctx *cli.Context) error {
 		case <-reloadSig:
 			reloadErrsChan <- nil
 		case errChan := <-reloadErrsChan:
+			// A reload has been triggered by putting either an error channel
+			// or nil on reloadErrsChan. If the reload signaler wants to know
+			// if an error occurred, the the error channel is not nil.
 			prevCfgChk := cfg.Indexer.ConfigCheckInterval
 			if prevCfgChk != cfg.Indexer.ConfigCheckInterval {
 				ticker.Reset(time.Duration(cfg.Indexer.ConfigCheckInterval))
@@ -581,7 +584,7 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 		return nil, fmt.Errorf("failed to configure logging: %w", err)
 	}
 
-	fmt.Println("Reloaded policy, rate limit, and logging configuration")
+	log.Info("Reloaded reloadable values from configuration")
 	return cfg, nil
 }
 

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -27,11 +27,6 @@ type Ingest struct {
 	// (segments) of size set by SyncSegmentDepthLimit. EntriesDepthLimit sets
 	// the limit on the total number of entries chunks across all segments.
 	EntriesDepthLimit int
-	// SyncWriteEntries tells the indexer to process entry chunks
-	// synchronously, waiting for each to complete before fetching the next.
-	// When this is false, the indexer processes entry chunks asynchronously.
-	// This value is reloadable.
-	SyncWriteEntries bool
 	// HttpSyncRetryMax sets the maximum number of times HTTP sync requests
 	// should be retried.
 	HttpSyncRetryMax int
@@ -75,6 +70,11 @@ type Ingest struct {
 	// or a chain of advertisement entries. The value is an integer string
 	// ending in "s", "m", "h" for seconds. minutes, hours.
 	SyncTimeout Duration
+	// SyncWriteEntries, when true, tells the indexer to process entry chunks
+	// synchronously, waiting for each to complete before fetching the next.
+	// Otherwise, the indexer processes entry chunks asynchronously. This value
+	// is updated when the configuration is reloaded.
+	SyncWriteEntries bool
 }
 
 // NewIngest returns Ingest with values set to their defaults.

--- a/doc/config.md
+++ b/doc/config.md
@@ -93,7 +93,8 @@ config file at runtime.
     "ResendDirectAnnounce": true,
     "StoreBatchSize": 4096,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s"
+    "SyncTimeout": "2h0m0s",
+    "SyncWriteEntries": false
   },
   "Logging": {
     "Level": "info",
@@ -231,7 +232,8 @@ Default:
   "ResendDirectAnnounce": false,
   "StoreBatchSize": 4096,
   "SyncSegmentDepthLimit": 2000,
-  "SyncTimeout": "2h0m0s"
+  "SyncTimeout": "2h0m0s",
+  "SyncWriteEntries": false
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
-	github.com/gammazero/workerpool v1.1.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
@@ -70,6 +69,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/gammazero/keymutex v0.1.0 // indirect
 	github.com/gammazero/radixtree v0.3.0 // indirect
+	github.com/gammazero/workerpool v1.1.3 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -136,11 +136,10 @@ type Ingester struct {
 
 	// Multihash minimum length
 	minKeyLen int
-	// syncWriteEntries is accessed through Ingester.SetSyncWriteEntries() and
-	// Ingester.syncWriteEntries(). It tells the Ingester to handle write entry
-	// chunks synchronously, waiting for each to complete before fetching the
-	// next.
-	_syncWriteEntries uint32
+	// syncWriteEnts is accessed through SetSyncWriteEntries() and
+	// syncWriteEntries(). It tells the Ingester to handle writing entry chunks
+	// synchronously, waiting for each to complete before fetching the next.
+	syncWriteEnts uint32
 }
 
 // NewIngester creates a new Ingester that uses a go-legs Subscriber to handle
@@ -271,11 +270,11 @@ func (ing *Ingester) SetSyncWriteEntries(val bool) {
 	if val {
 		b32 = 1
 	}
-	atomic.StoreUint32(&ing._syncWriteEntries, b32)
+	atomic.StoreUint32(&ing.syncWriteEnts, b32)
 }
 
 func (ing *Ingester) syncWriteEntries() bool {
-	return atomic.LoadUint32(&ing._syncWriteEntries) != 0
+	return atomic.LoadUint32(&ing.syncWriteEnts) != 0
 }
 
 func (ing *Ingester) Close() error {


### PR DESCRIPTION
The number of entry chunks queued for async processing is limited to 1. This prevents queuing large chains of entry chunks awaiting processing and exhausting memory.

Other changes:
- Daemon logs config reload
- Documentation updates
