### PR TITLE
Configurable entries chunk concurrency

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -574,7 +574,7 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 		if err != nil {
 			return nil, fmt.Errorf("failed to set rate limit config: %w", err)
 		}
-		ingester.SetSyncWriteEntries(cfg.Ingest.SyncWriteEntries)
+		ingester.SetEntriesChunkConcurrency(cfg.Ingest.EntriesChunkConcurrency)
 		ingester.SetBatchSize(cfg.Ingest.StoreBatchSize)
 		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
 	}

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -44,7 +44,8 @@ import (
 )
 
 const (
-	testCorePutConcurrency = 4
+	testCorePutConcurrency      = 4
+	testEntriesChunkConcurrency = 2
 
 	testRetryInterval = 2 * time.Second
 	testRetryTimeout  = 15 * time.Second
@@ -56,8 +57,8 @@ const (
 var (
 	defaultTestIngestConfig = config.Ingest{
 		AdvertisementDepthLimit: 100,
+		EntriesChunkConcurrency: testEntriesChunkConcurrency,
 		EntriesDepthLimit:       100,
-		SyncWriteEntries:        false,
 		IngestWorkerCount:       1,
 		PubSubTopic:             "test/ingest",
 		RateLimit: config.RateLimit{


### PR DESCRIPTION
Configure the number of additional threads per publisher/worker to asynchronously process each incoming entry chunk. This is configured with the run-time reloadable configuration setting `Ingest.EntriesChunkConcurrency`.

The ingest workers do not compete with each other for a global pool of goroutines, since they each get this number of additional goroutines, so one provider will not starve others.