### PR TITLE
Keep entries chunk worker goroutines running

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -617,9 +617,9 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 		if err != nil {
 			return nil, fmt.Errorf("failed to set rate limit config: %w", err)
 		}
-		ingester.SetEntriesChunkConcurrency(cfg.Ingest.EntriesChunkConcurrency)
 		ingester.SetBatchSize(cfg.Ingest.StoreBatchSize)
 		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
+		ingester.SetEntriesChunkConcurrency(cfg.Ingest.EntriesChunkConcurrency)
 	}
 
 	err = setLoggingConfig(cfg.Logging)

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -17,7 +17,7 @@ type Ingest struct {
 	// size set by SyncSegmentDepthLimit. AdvertisementDepthLimit sets the
 	// limit on the total number of advertisements across all segments.
 	AdvertisementDepthLimit int
-	// EntriesChunkConcurrency, tells the indexer to process chunks of
+	// EntriesChunkConcurrency tells the indexer to process chunks of
 	// multihash entries asynchronously using this number of goroutines, where
 	// this number is at least as large the worker pool size. If n is -1,
 	// asynchronous processing is disabled. If n < IngestWorkerCount, then n is

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -17,11 +17,11 @@ type Ingest struct {
 	// size set by SyncSegmentDepthLimit. AdvertisementDepthLimit sets the
 	// limit on the total number of advertisements across all segments.
 	AdvertisementDepthLimit int
-	// EntriesChunkConcurrency is the number of additional goroutines for each
-	// publisher/worker to asynchronously process entry chunks. This allows
-	// fetching the next entry chunk without waiting for the current one to
-	// finish being written. A value of 1 means no concurrency, and zero uses
-	// the default. This value is reloadable.
+	// EntriesChunkConcurrency, tells the indexer to process chunks of
+	// multihash entries asynchronously using this number of goroutines, where
+	// this number is at least as large the worker pool size. If n is -1,
+	// asynchronous processing is disabled. If n < IngestWorkerCount, then n is
+	// set to IngestWorkerCount.
 	EntriesChunkConcurrency int
 	// EntriesDepthLimit is the total maximum recursion depth limit when
 	// syncing advertisement entries. The value -1 means no limit and zero
@@ -82,7 +82,6 @@ type Ingest struct {
 func NewIngest() Ingest {
 	return Ingest{
 		AdvertisementDepthLimit: 33554432,
-		EntriesChunkConcurrency: 8,
 		EntriesDepthLimit:       65536,
 		HttpSyncRetryMax:        4,
 		HttpSyncRetryWaitMax:    Duration(30 * time.Second),
@@ -103,9 +102,6 @@ func (c *Ingest) populateUnset() {
 
 	if c.AdvertisementDepthLimit == 0 {
 		c.AdvertisementDepthLimit = def.AdvertisementDepthLimit
-	}
-	if c.EntriesChunkConcurrency == 0 {
-		c.EntriesChunkConcurrency = def.EntriesChunkConcurrency
 	}
 	if c.EntriesDepthLimit == 0 {
 		c.EntriesDepthLimit = def.EntriesDepthLimit

--- a/doc/config.md
+++ b/doc/config.md
@@ -77,6 +77,7 @@ config file at runtime.
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
+    "EntriesChunkConcurrency"; 0,
     "EntriesDepthLimit": 65536,
     "HttpSyncRetryMax": 4,
     "HttpSyncRetryWaitMax": "30s",
@@ -93,8 +94,7 @@ config file at runtime.
     "ResendDirectAnnounce": true,
     "StoreBatchSize": 4096,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "SyncWriteEntries": false
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",
@@ -221,6 +221,7 @@ Default:
 ```json
 "Ingest": {
   "AdvertisementDepthLimit": 33554432,
+  "EntriesChunkConcurrency"; 0,
   "EntriesDepthLimit": 65536,
   "HttpSyncRetryMax": 4,
   "HttpSyncRetryWaitMax": "30s",
@@ -232,8 +233,7 @@ Default:
   "ResendDirectAnnounce": false,
   "StoreBatchSize": 4096,
   "SyncSegmentDepthLimit": 2000,
-  "SyncTimeout": "2h0m0s",
-  "SyncWriteEntries": false
+  "SyncTimeout": "2h0m0s"
 }
 ```
 
@@ -283,6 +283,7 @@ The storetheindex daemon can reload some portions of its config without restarti
 - [`Discovery.Policy`](#discoverypolicy)
 - [`Indexer.ConfigCheckInterval`](#indexer)
 - [`Indexer.ShutdownTimeout`](#indexer)
+- [`Ingest.EntriesChunkConcurrency`](#ingest)
 - [`Ingest.IngestWorkerCount`](#ingest)
 - [`Ingest.RateLimit`](#ingestratelimit)
 - [`Ingest.StoreBatchSize`](#ingest)

--- a/doc/config.md
+++ b/doc/config.md
@@ -77,7 +77,7 @@ config file at runtime.
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
-    "EntriesChunkConcurrency"; 0,
+    "EntriesChunkConcurrency": 0,
     "EntriesDepthLimit": 65536,
     "HttpSyncRetryMax": 4,
     "HttpSyncRetryWaitMax": "30s",
@@ -221,7 +221,7 @@ Default:
 ```json
 "Ingest": {
   "AdvertisementDepthLimit": 33554432,
-  "EntriesChunkConcurrency"; 0,
+  "EntriesChunkConcurrency": 0,
   "EntriesDepthLimit": 65536,
   "HttpSyncRetryMax": 4,
   "HttpSyncRetryWaitMax": "30s",


### PR DESCRIPTION
Do not start and stop entries chunk worker goroutines with each ad processed. Instead, if enabled, use a global pool that is at least as big as the worker pool size. The worker goroutines compete fairly to use the entries chunk workers, so one will not starve others.

The config setting `Ingest.EntriesChunkConcurrency` controls the number of entries chunk workers and is runtime reloadable. A value of 0 (the default) sets this to the same as the ingest worker pool size. A value of -1 disables it and makes entries chunk processing synchronous.
