### PR TITLE
Add `dido` to indexstart and point to individual indexer instances

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -10,8 +10,10 @@ spec:
           args:
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
-            - '--backends=http://indexer:3000/'
+            - '--backends=http://indexer-0.indexer:3000/'
+            - '--backends=http://indexer-1.indexer:3000/'
             - '--backends=http://romi-indexer:3000/'
             - '--backends=http://tara-indexer:3000/'
             - '--backends=http://xabi-indexer:3000/'
             - '--backends=http://vega-indexer:3000/'
+            - '--backends=http://dido-indexer:3000/'


### PR DESCRIPTION
To route find requests to `dido` add it to the list of nodes in
indexstar.

While at it point indexstar to individual idnexer-0 and indexer-1 nodes
to get better repeatability over aggregated result, since otherwise the
requests from indexstar might land on only one of the two at random.

