### PR TITLE
Disable indexer-core cache on `dido`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -54,7 +54,7 @@
     "Timeout": "2m0s"
   },
   "Indexer": {
-    "CacheSize": 300000,
+    "CacheSize": 0,
     "ConfigCheckInterval": "30s",
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",


### PR DESCRIPTION
Disable indexer-core cache on `dido` until the following issue is
resolved:
 - https://github.com/filecoin-project/go-indexer-core/issues/80

