### PR TITLE
Disable indexer-core cache on `dido` by setting it to -1

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -54,7 +54,7 @@
     "Timeout": "2m0s"
   },
   "Indexer": {
-    "CacheSize": 0,
+    "CacheSize": -1,
     "ConfigCheckInterval": "30s",
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",


### PR DESCRIPTION
Change cachesize to `-1` to actually disable it. `0`  will result in
revert to default value.

