### PR TITLE
Write entries chunks synchronously or asynchronously

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -619,7 +619,7 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 		}
 		ingester.SetBatchSize(cfg.Ingest.StoreBatchSize)
 		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
-		ingester.SetEntriesChunkConcurrency(cfg.Ingest.EntriesChunkConcurrency)
+		ingester.SetSyncWriteEntries(cfg.Ingest.SyncWriteEntries)
 	}
 
 	err = setLoggingConfig(cfg.Logging)

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -619,7 +619,7 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 		}
 		ingester.SetBatchSize(cfg.Ingest.StoreBatchSize)
 		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
-		ingester.SetSyncWriteEntries(cfg.Ingest.SyncWriteEntries)
+		ingester.SetWriteEntriesSynchronously(cfg.Ingest.WriteEntriesSynchronously)
 	}
 
 	err = setLoggingConfig(cfg.Logging)

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -17,12 +17,6 @@ type Ingest struct {
 	// size set by SyncSegmentDepthLimit. AdvertisementDepthLimit sets the
 	// limit on the total number of advertisements across all segments.
 	AdvertisementDepthLimit int
-	// EntriesChunkConcurrency tells the indexer to process chunks of
-	// multihash entries asynchronously using this number of goroutines, where
-	// this number is at least as large the worker pool size. If n is -1,
-	// asynchronous processing is disabled. If n < IngestWorkerCount, then n is
-	// set to IngestWorkerCount.
-	EntriesChunkConcurrency int
 	// EntriesDepthLimit is the total maximum recursion depth limit when
 	// syncing advertisement entries. The value -1 means no limit and zero
 	// means use the default value. The purpose is to prevent overload from
@@ -76,6 +70,11 @@ type Ingest struct {
 	// or a chain of advertisement entries. The value is an integer string
 	// ending in "s", "m", "h" for seconds. minutes, hours.
 	SyncTimeout Duration
+	// SyncWriteEntries, when true, tells the indexer to process entry chunks
+	// synchronously, waiting for each to complete before fetching the next.
+	// Otherwise, the indexer processes entry chunks asynchronously. This value
+	// is updated when the configuration is reloaded.
+	SyncWriteEntries bool
 }
 
 // NewIngest returns Ingest with values set to their defaults.

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -70,11 +70,11 @@ type Ingest struct {
 	// or a chain of advertisement entries. The value is an integer string
 	// ending in "s", "m", "h" for seconds. minutes, hours.
 	SyncTimeout Duration
-	// SyncWriteEntries, when true, tells the indexer to process entry chunks
+	// Synchronously, when true, tells the indexer to process entry chunks
 	// synchronously, waiting for each to complete before fetching the next.
 	// Otherwise, the indexer processes entry chunks asynchronously. This value
 	// is updated when the configuration is reloaded.
-	SyncWriteEntries bool
+	WriteEntriesSynchronously bool
 }
 
 // NewIngest returns Ingest with values set to their defaults.

--- a/doc/config.md
+++ b/doc/config.md
@@ -77,7 +77,6 @@ config file at runtime.
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
-    "EntriesChunkConcurrency": 0,
     "EntriesDepthLimit": 65536,
     "HttpSyncRetryMax": 4,
     "HttpSyncRetryWaitMax": "30s",
@@ -94,7 +93,8 @@ config file at runtime.
     "ResendDirectAnnounce": true,
     "StoreBatchSize": 4096,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s"
+    "SyncTimeout": "2h0m0s",
+    "SyncWriteEntries": false
   },
   "Logging": {
     "Level": "info",
@@ -221,7 +221,6 @@ Default:
 ```json
 "Ingest": {
   "AdvertisementDepthLimit": 33554432,
-  "EntriesChunkConcurrency": 0,
   "EntriesDepthLimit": 65536,
   "HttpSyncRetryMax": 4,
   "HttpSyncRetryWaitMax": "30s",
@@ -233,7 +232,8 @@ Default:
   "ResendDirectAnnounce": false,
   "StoreBatchSize": 4096,
   "SyncSegmentDepthLimit": 2000,
-  "SyncTimeout": "2h0m0s"
+  "SyncTimeout": "2h0m0s",
+  "SyncWriteEntries": false
 }
 ```
 
@@ -283,9 +283,9 @@ The storetheindex daemon can reload some portions of its config without restarti
 - [`Discovery.Policy`](#discoverypolicy)
 - [`Indexer.ConfigCheckInterval`](#indexer)
 - [`Indexer.ShutdownTimeout`](#indexer)
-- [`Ingest.EntriesChunkConcurrency`](#ingest)
 - [`Ingest.IngestWorkerCount`](#ingest)
 - [`Ingest.RateLimit`](#ingestratelimit)
 - [`Ingest.StoreBatchSize`](#ingest)
+- [`Ingest.SyncWriteEntries`](#ingest)
 - [`Logging`](#logging)
 - [`Peering`](#peering)

--- a/doc/config.md
+++ b/doc/config.md
@@ -94,7 +94,7 @@ config file at runtime.
     "StoreBatchSize": 4096,
     "SyncSegmentDepthLimit": 2000,
     "SyncTimeout": "2h0m0s",
-    "SyncWriteEntries": false
+    "WriteEntriesSynchronously": false
   },
   "Logging": {
     "Level": "info",
@@ -233,7 +233,7 @@ Default:
   "StoreBatchSize": 4096,
   "SyncSegmentDepthLimit": 2000,
   "SyncTimeout": "2h0m0s",
-  "SyncWriteEntries": false
+  "WriteEntriesSynchronously": false
 }
 ```
 
@@ -286,6 +286,6 @@ The storetheindex daemon can reload some portions of its config without restarti
 - [`Ingest.IngestWorkerCount`](#ingest)
 - [`Ingest.RateLimit`](#ingestratelimit)
 - [`Ingest.StoreBatchSize`](#ingest)
-- [`Ingest.SyncWriteEntries`](#ingest)
+- [`Ingest.WriteEntriesSynchronously`](#ingest)
 - [`Logging`](#logging)
 - [`Peering`](#peering)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907071215-cd8f0d1c1959
+	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907075326-ba437b4e7353
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.7-0.20220907071047-3e80d40cbb6b
+	github.com/ipld/go-storethehash v0.2.7-0.20220907074626-45aa8601a7f4
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907075326-ba437b4e7353
+	github.com/filecoin-project/go-indexer-core v0.6.1
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.7-0.20220907074626-45aa8601a7f4
+	github.com/ipld/go-storethehash v0.2.7
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907012008-8f21f523fd6f
+	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907013935-fa15bb7a6901
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.7-0.20220907011855-273d1de85662
+	github.com/ipld/go-storethehash v0.2.7-0.20220907013838-23bbe8d26468
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.0
+	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906204935-8314bbd14f48
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906230301-b29e1698ea5e
+	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907012008-8f21f523fd6f
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.7-0.20220906225950-397d22b3520a
+	github.com/ipld/go-storethehash v0.2.7-0.20220907011855-273d1de85662
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906204935-8314bbd14f48
+	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906230301-b29e1698ea5e
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.6
+	github.com/ipld/go-storethehash v0.2.7-0.20220906225950-397d22b3520a
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907013935-fa15bb7a6901
+	github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907071215-cd8f0d1c1959
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.7-0.20220907013838-23bbe8d26468
+	github.com/ipld/go-storethehash v0.2.7-0.20220907071047-3e80d40cbb6b
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908085718-d7d76226455f
+	github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908095514-87fa16aa443e
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.8-0.20220908085557-265ad1cbe86d
+	github.com/ipld/go-storethehash v0.2.8-0.20220908095358-f6de4e14d609
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.2-0.20220907225128-a17fd289063c
+	github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908085718-d7d76226455f
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.8-0.20220907224923-4c692fe90cb6
+	github.com/ipld/go-storethehash v0.2.8-0.20220908085557-265ad1cbe86d
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.1
+	github.com/filecoin-project/go-indexer-core v0.6.2-0.20220907225128-a17fd289063c
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.7
+	github.com/ipld/go-storethehash v0.2.8-0.20220907224923-4c692fe90cb6
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.1 h1:qrrxDEkY/ddSURy0IFQqE7XmiHLkbm5vRMs3FgakBSw=
-github.com/filecoin-project/go-indexer-core v0.6.1/go.mod h1:M22nfn4ZzbyU6xqI6ighvUuCUIfqs49x+Ecru2fVt2Q=
+github.com/filecoin-project/go-indexer-core v0.6.2-0.20220907225128-a17fd289063c h1:9F3GfmBOvo3xHiGx7bsGyF16PH3lFWa3w1D8XIPfiHM=
+github.com/filecoin-project/go-indexer-core v0.6.2-0.20220907225128-a17fd289063c/go.mod h1:utiAC442HXZi8Wmd20v2H0rOJ9VJKmiINbguliRnYII=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.7 h1:bEAwyNZqUQmY2M5tOwa8LG+6rpIVYqGX0riKh9pCzH8=
-github.com/ipld/go-storethehash v0.2.7/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.8-0.20220907224923-4c692fe90cb6 h1:fPrfmOrmmhAnxZ03DshJKpLLNmY0eu/KkpL6RWBnSXk=
+github.com/ipld/go-storethehash v0.2.8-0.20220907224923-4c692fe90cb6/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906204935-8314bbd14f48 h1:xR65PnX3I7mAzKSekYdFC0DjRKbb0MB9by8LyEBHBTQ=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906204935-8314bbd14f48/go.mod h1:EKow3Mo54H4zAVQtCriX/YzGYbUN75GnCS/8bvwFeqg=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906230301-b29e1698ea5e h1:Z9ps9I2DcaVrlXN5reXHVrGjtQmfN/4IB8vExKFjvjA=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906230301-b29e1698ea5e/go.mod h1:CkSz2gu71hSYTpzGs45tSSTgs8sKhWEz37sdA669qs8=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.6 h1:gy/u/wvfKybE+7FwvvzD4y6t/chkZmaZngSA+dorxuA=
-github.com/ipld/go-storethehash v0.2.6/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.7-0.20220906225950-397d22b3520a h1:WdR955lEzRn/rsAREayQ4pyzcnDlmzyzqVknIFqMLLY=
+github.com/ipld/go-storethehash v0.2.7-0.20220906225950-397d22b3520a/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907071215-cd8f0d1c1959 h1:6How0+lA9sbayCenH2NuGP1pp15mTKZXWGZG3F7wlh8=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907071215-cd8f0d1c1959/go.mod h1:eaYsJ55cqzyAmh7nvF9prTVzy9WHqe5CbdAeT94RnuQ=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907075326-ba437b4e7353 h1:LETq+nAAqqerU/pPaT+bS/cXyPJO8yJzdcg1FBKoAr8=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907075326-ba437b4e7353/go.mod h1:TWfG1BilB9Ysr3YC9q6O9jGE0P5s8icoazeixBZmBRg=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.7-0.20220907071047-3e80d40cbb6b h1:5Hoz815p1R+6nZpsCO1cYd2s7qCxW2DsOecIJB5OGuU=
-github.com/ipld/go-storethehash v0.2.7-0.20220907071047-3e80d40cbb6b/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.7-0.20220907074626-45aa8601a7f4 h1:pkOyWY25vhTFSthQ9M+5kUJY1tvggAZvTxi/aaL2pnw=
+github.com/ipld/go-storethehash v0.2.7-0.20220907074626-45aa8601a7f4/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.2-0.20220907225128-a17fd289063c h1:9F3GfmBOvo3xHiGx7bsGyF16PH3lFWa3w1D8XIPfiHM=
-github.com/filecoin-project/go-indexer-core v0.6.2-0.20220907225128-a17fd289063c/go.mod h1:utiAC442HXZi8Wmd20v2H0rOJ9VJKmiINbguliRnYII=
+github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908085718-d7d76226455f h1:Fe1SWJs/9aX+LpFhATrT6blxy5K2Wcvm+P7+wUCD+X0=
+github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908085718-d7d76226455f/go.mod h1:D10/uS3y/nrCOU+HNjnLDNRdrew0AbLeuVVR0DwW4Go=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.8-0.20220907224923-4c692fe90cb6 h1:fPrfmOrmmhAnxZ03DshJKpLLNmY0eu/KkpL6RWBnSXk=
-github.com/ipld/go-storethehash v0.2.8-0.20220907224923-4c692fe90cb6/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.8-0.20220908085557-265ad1cbe86d h1:xDUgB/E+vz7hh/peUk1Szx//Pge6bPQAMRd8FSX2kZo=
+github.com/ipld/go-storethehash v0.2.8-0.20220908085557-265ad1cbe86d/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906230301-b29e1698ea5e h1:Z9ps9I2DcaVrlXN5reXHVrGjtQmfN/4IB8vExKFjvjA=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906230301-b29e1698ea5e/go.mod h1:CkSz2gu71hSYTpzGs45tSSTgs8sKhWEz37sdA669qs8=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907012008-8f21f523fd6f h1:ES1CjxbblfQ8/vPNfmFM/7Yf5Ghjf0/4xtXOKTmkrKw=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907012008-8f21f523fd6f/go.mod h1:MmeC9IGcETF+rGgrFBYzIJLNQmDa0KgfUcwP0o64vr4=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.7-0.20220906225950-397d22b3520a h1:WdR955lEzRn/rsAREayQ4pyzcnDlmzyzqVknIFqMLLY=
-github.com/ipld/go-storethehash v0.2.7-0.20220906225950-397d22b3520a/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.7-0.20220907011855-273d1de85662 h1:ut9yNI9TvTVdtlizSXoH6NBXoG/J62wQ7hTsY/zYVYM=
+github.com/ipld/go-storethehash v0.2.7-0.20220907011855-273d1de85662/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907012008-8f21f523fd6f h1:ES1CjxbblfQ8/vPNfmFM/7Yf5Ghjf0/4xtXOKTmkrKw=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907012008-8f21f523fd6f/go.mod h1:MmeC9IGcETF+rGgrFBYzIJLNQmDa0KgfUcwP0o64vr4=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907013935-fa15bb7a6901 h1:A5z5lB9a8ePWSYxb93n5YxZwC3mBTrrrTFClMlNJ8GQ=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907013935-fa15bb7a6901/go.mod h1:if4n1Rh+LMEmma7A5nuHWkFM3g+rZbWP6WPVEFneVWk=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.7-0.20220907011855-273d1de85662 h1:ut9yNI9TvTVdtlizSXoH6NBXoG/J62wQ7hTsY/zYVYM=
-github.com/ipld/go-storethehash v0.2.7-0.20220907011855-273d1de85662/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.7-0.20220907013838-23bbe8d26468 h1:nHGtDY6V0bCyisg0dU30XhXP8iA0qYwYhu/Cl18vjHg=
+github.com/ipld/go-storethehash v0.2.7-0.20220907013838-23bbe8d26468/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908085718-d7d76226455f h1:Fe1SWJs/9aX+LpFhATrT6blxy5K2Wcvm+P7+wUCD+X0=
-github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908085718-d7d76226455f/go.mod h1:D10/uS3y/nrCOU+HNjnLDNRdrew0AbLeuVVR0DwW4Go=
+github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908095514-87fa16aa443e h1:t3EijJt/Rqdo3ctCvtmAXZtubh3btmtm5mpyxj5ICuc=
+github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908095514-87fa16aa443e/go.mod h1:2wxzwJvYTRsBIGtn/2DabNLwk5+Scc8rg6lNJlD2m8U=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.8-0.20220908085557-265ad1cbe86d h1:xDUgB/E+vz7hh/peUk1Szx//Pge6bPQAMRd8FSX2kZo=
-github.com/ipld/go-storethehash v0.2.8-0.20220908085557-265ad1cbe86d/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.8-0.20220908095358-f6de4e14d609 h1:voDwm2RYa0ft/7f7JtGSmGZIywV6Iytl9ZY9yxyaCS8=
+github.com/ipld/go-storethehash v0.2.8-0.20220908095358-f6de4e14d609/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.0 h1:QjYNXm1zCXv5on7mKPNmcUfLm43gpLIO2zBE01iwFbQ=
-github.com/filecoin-project/go-indexer-core v0.6.0/go.mod h1:ZDoJJ97xe8Gy/X0O+OsrjjBF4Xshfo4OTnd8I03S4nk=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906204935-8314bbd14f48 h1:xR65PnX3I7mAzKSekYdFC0DjRKbb0MB9by8LyEBHBTQ=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220906204935-8314bbd14f48/go.mod h1:EKow3Mo54H4zAVQtCriX/YzGYbUN75GnCS/8bvwFeqg=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907013935-fa15bb7a6901 h1:A5z5lB9a8ePWSYxb93n5YxZwC3mBTrrrTFClMlNJ8GQ=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907013935-fa15bb7a6901/go.mod h1:if4n1Rh+LMEmma7A5nuHWkFM3g+rZbWP6WPVEFneVWk=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907071215-cd8f0d1c1959 h1:6How0+lA9sbayCenH2NuGP1pp15mTKZXWGZG3F7wlh8=
+github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907071215-cd8f0d1c1959/go.mod h1:eaYsJ55cqzyAmh7nvF9prTVzy9WHqe5CbdAeT94RnuQ=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.7-0.20220907013838-23bbe8d26468 h1:nHGtDY6V0bCyisg0dU30XhXP8iA0qYwYhu/Cl18vjHg=
-github.com/ipld/go-storethehash v0.2.7-0.20220907013838-23bbe8d26468/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.7-0.20220907071047-3e80d40cbb6b h1:5Hoz815p1R+6nZpsCO1cYd2s7qCxW2DsOecIJB5OGuU=
+github.com/ipld/go-storethehash v0.2.7-0.20220907071047-3e80d40cbb6b/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907075326-ba437b4e7353 h1:LETq+nAAqqerU/pPaT+bS/cXyPJO8yJzdcg1FBKoAr8=
-github.com/filecoin-project/go-indexer-core v0.6.1-0.20220907075326-ba437b4e7353/go.mod h1:TWfG1BilB9Ysr3YC9q6O9jGE0P5s8icoazeixBZmBRg=
+github.com/filecoin-project/go-indexer-core v0.6.1 h1:qrrxDEkY/ddSURy0IFQqE7XmiHLkbm5vRMs3FgakBSw=
+github.com/filecoin-project/go-indexer-core v0.6.1/go.mod h1:M22nfn4ZzbyU6xqI6ighvUuCUIfqs49x+Ecru2fVt2Q=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.7-0.20220907074626-45aa8601a7f4 h1:pkOyWY25vhTFSthQ9M+5kUJY1tvggAZvTxi/aaL2pnw=
-github.com/ipld/go-storethehash v0.2.7-0.20220907074626-45aa8601a7f4/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.7 h1:bEAwyNZqUQmY2M5tOwa8LG+6rpIVYqGX0riKh9pCzH8=
+github.com/ipld/go-storethehash v0.2.7/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -44,8 +44,7 @@ import (
 )
 
 const (
-	testCorePutConcurrency      = 4
-	testEntriesChunkConcurrency = 2
+	testCorePutConcurrency = 4
 
 	testRetryInterval = 2 * time.Second
 	testRetryTimeout  = 15 * time.Second
@@ -57,7 +56,6 @@ const (
 var (
 	defaultTestIngestConfig = config.Ingest{
 		AdvertisementDepthLimit: 100,
-		EntriesChunkConcurrency: testEntriesChunkConcurrency,
 		EntriesDepthLimit:       100,
 		IngestWorkerCount:       1,
 		PubSubTopic:             "test/ingest",

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -340,7 +340,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		var asyncDone chan struct{}
 		var asyncEntries bool
 
-		if !ing.syncWriteEntries() {
+		if !ing.writeEntriesSynchronously() {
 			asyncEntries = true
 			asyncDone = make(chan struct{})
 			chunkFuncs = make(chan func(), 1)


### PR DESCRIPTION
There is no performance benefit to having a pool of goroutines over having one asynchronous goroutine per publisher/worker to asynchronously process and entries chunks. Having one additional goroutine provides a simpler implementation that uses less memory. It is also simpler to configure since the choice is to enable or disable the asynchronous behavior.

The default behavior is asynchronous.

Make the configuration setting `Indexer.CorePutConcurrency` run-time reloadable.