### PR TITLE
Fix typo in aws-auth permissions to the new node group

### DIFF
--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -8,12 +8,7 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/prod-ue2-r5b-xl-2-eks-node-group
-      username: system:node:{{EC2PrivateDNSName}}
-    - groups:
-      - system:bootstrappers
-      - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/prod-ue2-m4-xl-eks-node-group
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2-m4-xl-2-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
     - groups:
       - system:bootstrappers


### PR DESCRIPTION
Also remove the node groups that no longer exist.
