### PR TITLE
Add option for specifying existing client

### DIFF
--- a/api/v0/httpclient/client.go
+++ b/api/v0/httpclient/client.go
@@ -31,6 +31,9 @@ func New(baseURL, resource string, options ...Option) (*url.URL, *http.Client, e
 		return nil, nil, err
 	}
 
+	if cfg.client != nil {
+		return u, cfg.client, nil
+	}
 	cl := &http.Client{
 		Timeout: cfg.timeout,
 	}

--- a/api/v0/httpclient/options.go
+++ b/api/v0/httpclient/options.go
@@ -2,11 +2,13 @@ package httpclient
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 )
 
 type clientConfig struct {
 	timeout time.Duration
+	client  *http.Client
 }
 
 // Option is the option type for httpclient
@@ -38,6 +40,14 @@ func (c *clientConfig) apply(opts ...Option) error {
 func Timeout(timeout time.Duration) Option {
 	return func(cfg *clientConfig) error {
 		cfg.timeout = timeout
+		return nil
+	}
+}
+
+// WithClient allows creation of the http client using an underlying network round tripper / client
+func WithClient(c *http.Client) Option {
+	return func(cfg *clientConfig) error {
+		cfg.client = c
 		return nil
 	}
 }


### PR DESCRIPTION
There are options on the http.Client that we don't expose currently when making a finder client,

for example, configuration of `MaxConnsPerHost` and `MaxIdleConnsPerHost` on the RoundTripper are important for a high volume connection back to a single server.

This change adds an option to allow creation of clients over an already configured http.Client.