### PR TITLE
Give more resources to `prod` nginx ingress and up replicas by 1

### DIFF
--- a/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/ingress-nginx
+
+patchesStrategicMerge:
+  - patch.yaml
+
+replicas:
+  - name: ingress-nginx-controller
+    count: 3

--- a/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: controller
+          resources:
+            limits:
+              cpu: 500m
+              memory: 3Gi
+            requests:
+              cpu: 500m
+              memory: 3Gi

--- a/deploy/manifests/prod/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../../base/ingress-nginx
+  - ingress-nginx
   - kube-system
   - flux-system
   - external-dns
@@ -12,7 +12,3 @@ resources:
   - monitoring
   - aws-ebs-csi-driver
   - promtail
-
-replicas:
-  - name: ingress-nginx-controller
-    count: 2


### PR DESCRIPTION
Patch resources given to nginx to increase the defaults for better tolerance at the face of high concurrent connections. Spread the ingress instances across 3 AZs and up the replica count to a total of 3.

Fixes #769

