### PR TITLE
Reloadable config for sth file cache size

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -514,6 +514,7 @@ func createValueStore(ctx context.Context, cfgIndexer config.Indexer) (indexer.I
 			sth.BurstRate(cfgIndexer.STHBurstRate),
 			sth.SyncInterval(time.Duration(cfgIndexer.STHSyncInterval)),
 			sth.IndexBitSize(cfgIndexer.STHBits),
+			sth.FileCacheSize(cfgIndexer.STHFileCacheSize),
 		)
 		minKeyLen = sthMinKeyLen
 	case vstorePogreb:
@@ -630,6 +631,7 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 	sthStore, ok := valueStore.(*storethehash.SthStorage)
 	if ok {
 		sthStore.SetPutConcurrency(cfg.Indexer.CorePutConcurrency)
+		sthStore.SetFileCacheSize(cfg.Indexer.STHFileCacheSize)
 	}
 
 	log.Info("Reloaded reloadable values from configuration")

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -27,8 +27,9 @@ type Indexer struct {
 	// A timeout of zero disables the shutdown timeout completely.
 	// if unset, defaults to no shutdown timeout.
 	ShutdownTimeout Duration
-	// ValueStoreDir is the directory where value store is kept. If this is not an absolute path
-	// then the location is relative to the indexer repo directory.
+	// ValueStoreDir is the directory where value store is kept. If this is not
+	// an absolute path then the location is relative to the indexer repo
+	// directory.
 	ValueStoreDir string
 	// ValueStoreType specifies type of valuestore to use, such as "sth" or "pogreb".
 	ValueStoreType string
@@ -38,6 +39,10 @@ type Indexer struct {
 	// STHBurstRate specifies how much unwritten data can accumulate before
 	// causing data to be flushed to disk.
 	STHBurstRate uint64
+	// STHFileCacheSize is the maximum number of open files that the STH file
+	// cache may have. A value of 0 uses the default, and a value of -1
+	// disables the file cache.
+	STHFileCacheSize int
 	// STHSyncInterval determines how frequently changes are flushed to disk.
 	STHSyncInterval Duration
 	// ValueStoreCodec configures the marshalling format of values stored by the valuestore.
@@ -67,6 +72,7 @@ func NewIndexer() Indexer {
 		ValueStoreType:      "sth",
 		STHBits:             24,
 		STHBurstRate:        4 * 1024 * 1024,
+		STHFileCacheSize:    512,
 		STHSyncInterval:     Duration(time.Second),
 		ValueStoreCodec:     "json",
 	}
@@ -102,6 +108,9 @@ func (c *Indexer) populateUnset() {
 	}
 	if c.STHBurstRate == 0 {
 		c.STHBurstRate = def.STHBurstRate
+	}
+	if c.STHFileCacheSize == 0 {
+		c.STHFileCacheSize = def.STHFileCacheSize
 	}
 	if c.STHSyncInterval == 0 {
 		c.STHSyncInterval = def.STHSyncInterval

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908113510-aaccdfbfe226
+	github.com/filecoin-project/go-indexer-core v0.6.2
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.8-0.20220908113424-f5da1f544894
+	github.com/ipld/go-storethehash v0.2.8
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908095514-87fa16aa443e
+	github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908113510-aaccdfbfe226
 	github.com/filecoin-project/go-legs v0.4.11
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/kubo v0.14.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.17.0
-	github.com/ipld/go-storethehash v0.2.8-0.20220908095358-f6de4e14d609
+	github.com/ipld/go-storethehash v0.2.8-0.20220908113424-f5da1f544894
 	github.com/libp2p/go-libp2p v0.21.0
 	github.com/libp2p/go-libp2p-core v0.19.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908095514-87fa16aa443e h1:t3EijJt/Rqdo3ctCvtmAXZtubh3btmtm5mpyxj5ICuc=
-github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908095514-87fa16aa443e/go.mod h1:2wxzwJvYTRsBIGtn/2DabNLwk5+Scc8rg6lNJlD2m8U=
+github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908113510-aaccdfbfe226 h1:L2OSWALhpqpoyrN6+hBpzW+u4V++FKGGF02t+ihVzlU=
+github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908113510-aaccdfbfe226/go.mod h1:guL01VZ6ACfin90JXoMyLB1y39XutQS31py5VRrB1D4=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.8-0.20220908095358-f6de4e14d609 h1:voDwm2RYa0ft/7f7JtGSmGZIywV6Iytl9ZY9yxyaCS8=
-github.com/ipld/go-storethehash v0.2.8-0.20220908095358-f6de4e14d609/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.8-0.20220908113424-f5da1f544894 h1:jKQLCI424W9XQhK8Sz9nORSg/kH3QI1lz/lUn+wF6tI=
+github.com/ipld/go-storethehash v0.2.8-0.20220908113424-f5da1f544894/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908113510-aaccdfbfe226 h1:L2OSWALhpqpoyrN6+hBpzW+u4V++FKGGF02t+ihVzlU=
-github.com/filecoin-project/go-indexer-core v0.6.2-0.20220908113510-aaccdfbfe226/go.mod h1:guL01VZ6ACfin90JXoMyLB1y39XutQS31py5VRrB1D4=
+github.com/filecoin-project/go-indexer-core v0.6.2 h1:uWZpU0R0trz8ouamihTuZBGw11Wrw4wPh7mj1ylgWDI=
+github.com/filecoin-project/go-indexer-core v0.6.2/go.mod h1:/XTScVcfRb18XuFEx/im2AopCgH2ZpDDkCPzutgE8Us=
 github.com/filecoin-project/go-legs v0.4.11 h1:liajMlBQY+0G/mb1p44rbBqj1qFTDEiCvCszN63W9ts=
 github.com/filecoin-project/go-legs v0.4.11/go.mod h1:GfAsDZoBKFi3y4tFhNbOOQRR2YpwF577xGdSe9vU2UA=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -669,8 +669,8 @@ github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHP
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.2.8-0.20220908113424-f5da1f544894 h1:jKQLCI424W9XQhK8Sz9nORSg/kH3QI1lz/lUn+wF6tI=
-github.com/ipld/go-storethehash v0.2.8-0.20220908113424-f5da1f544894/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.8 h1:JtyWG2cCszQ1bdgyH6RBlo12TrSlsd7zdzUVECFnw3Q=
+github.com/ipld/go-storethehash v0.2.8/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=


### PR DESCRIPTION
Provider a config file setting, `Indexer.STHFileCacheSize`, to configure the open file cache size in storethehash. This setting is run-time reloadable.