### PR TITLE
Update vega policy

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -12,6 +12,7 @@ spec:
       containers:
         - name: indexstar
           args:
+            - '--translateReframe'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
             - '--backends=http://indexer-0.indexer:3000/'

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20220907163434-deb7cbfc8d83a565418626d5cc64eb122c9b6d68
+    newTag: 20220909114449-ba9cd59985b6290adf4ef7c2ab847395c645c05c

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20220909114449-ba9cd59985b6290adf4ef7c2ab847395c645c05c
+    newTag: 20220909145118-fce1f29db9166941564d8bd8cf127a029f213364

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
@@ -42,7 +42,8 @@
     "Policy": {
       "Allow": false,
       "Except": [
-        "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC"
+        "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC",
+        "12D3KooW9yi2xLhXds9HC4x9vRN99mphq6ds8qN2YRf8zks1F32G"
       ],
       "Publish": true,
       "PublishExcept": null


### PR DESCRIPTION
this provider is important for autoretrieve testing, and seems to have fallen off of prod pair