### PR TITLE
Increase PVC size in prod statefulset to 40Ti

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -57,4 +57,4 @@ spec:
         storageClassName: io2
         resources:
           requests:
-            storage: 20Ti
+            storage: 40Ti


### PR DESCRIPTION
Increase the PVC size to 40 TiB from current 20 TiB as we are near 90% utilisation at the moment. 