### PR TITLE
Deploy latest upgrade to legs on pebble backed nodes

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -46,8 +46,8 @@
       "Publish": true,
       "PublishExcept": null
     },
-    "PollInterval": "24h0m0s",
-    "PollRetryAfter": "5h0m0s",
+    "PollInterval": "1h0m0s",
+    "PollRetryAfter": "5m0s",
     "PollStopAfter": "168h0m0s",
     "PollOverrides": null,
     "RediscoverWait": "5m0s",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220912134613-1705a46c927043fb3e2c2d34de4855bf39c906b3
+    newTag: 20220919082955-71f48c18d80587163b5376e6341b4eb01aba6d49

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/kustomization.yaml
@@ -31,5 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    # See: https://github.com/filecoin-project/storetheindex/pull/734
-    newTag: 20220908191856-498f406a73629637654c936c5d34ab768f2e417d
+    newTag: 20220919082955-71f48c18d80587163b5376e6341b4eb01aba6d49


### PR DESCRIPTION
Deploy the latest upgrade to go-legs on pebble backed nodes and reduce sync intervals on dido since announcements are not flowing on that node.
