### PR TITLE
Added ipfs-index-provider to terraform configs

### DIFF
--- a/deploy/infrastructure/common/ecr.tf
+++ b/deploy/infrastructure/common/ecr.tf
@@ -7,6 +7,7 @@ module "ecr_ue2" {
     "autoretrieve/autoretrieve",
     "index-provider/index-provider",
     "indexstar/indexstar",
+    "ipfs-shipyard/ipfs-index-provider",
   ]
   tags = local.tags
 }

--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -52,6 +52,7 @@ module "github_actions_role" {
     "repo:filecoin-project/index-provider:*",
     "repo:filecoin-shipyard/index-observer:*",
     "repo:application-research/autoretrieve:*",
-    "repo:filecoin-shipyard/indexstar:*"
+    "repo:filecoin-shipyard/indexstar:*",
+    "repo:ipfs-shipyard/ipfs-index-provider:*"
   ]
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1131,7 +1131,6 @@ func TestAnnounceIsNotDeferredOnNoInProgressIngest(t *testing.T) {
 }
 
 func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *testing.T) {
-
 	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
 	te := setupTestEnv(t, true, blockableLsysOpt)
 	defer te.Close(t)
@@ -1161,6 +1160,7 @@ func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *test
 	_, found := te.ingester.providersPendingAnnounce.Load(te.pubHost.ID())
 	require.False(t, found)
 
+	// This sleep is required to make sure that the messages arrive to the blocking channel in the intended order
 	time.Sleep(time.Second)
 
 	// Block head ad which should block explicit Announce call made to the ingester.

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -47,7 +47,7 @@ const (
 	testCorePutConcurrency = 4
 
 	testRetryInterval = 2 * time.Second
-	testRetryTimeout  = 25 * time.Second
+	testRetryTimeout  = 15 * time.Second
 
 	testEntriesChunkCount = 3
 	testEntriesChunkSize  = 15
@@ -1131,7 +1131,6 @@ func TestAnnounceIsNotDeferredOnNoInProgressIngest(t *testing.T) {
 }
 
 func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *testing.T) {
-	t.Skip()
 	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
 	te := setupTestEnv(t, true, blockableLsysOpt)
 	defer te.Close(t)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1161,6 +1161,8 @@ func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *test
 	_, found := te.ingester.providersPendingAnnounce.Load(te.pubHost.ID())
 	require.False(t, found)
 
+	time.Sleep(time.Second)
+
 	// Block head ad which should block explicit Announce call made to the ingester.
 	blockedReads.add(headCid)
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1130,7 +1130,7 @@ func TestAnnounceIsNotDeferredOnNoInProgressIngest(t *testing.T) {
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), mhs)
 }
 
-func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *testing.T) {
+func AnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *testing.T) {
 	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
 	te := setupTestEnv(t, true, blockableLsysOpt)
 	defer te.Close(t)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -47,7 +47,7 @@ const (
 	testCorePutConcurrency = 4
 
 	testRetryInterval = 2 * time.Second
-	testRetryTimeout  = 15 * time.Second
+	testRetryTimeout  = 25 * time.Second
 
 	testEntriesChunkCount = 3
 	testEntriesChunkSize  = 15

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1177,14 +1177,16 @@ func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *test
 	// 1. cause the ad chain C->B->A to be downloaded.
 	// 2. work to be assigned to the ingest worker which should not be processed until the
 	//    blocked background sync started by the explicit announce is unblocked.
-	<-hitBlockedRead
+	dCid := <-hitBlockedRead
+	require.Equal(t, ads[3].(cidlink.Link).Cid, dCid)
 
 	// Assert that no multihashes are indexed since entries processing should be blocked.
 	requireNotIndexed(t, te.ingester.indexer, te.pubHost.ID(), mhs)
 
 	// Now unblock the background sync started by the explicit announce, which casues the head
 	// ad (D) to also be downloaded, and should eventually get indexed
-	<-hitBlockedRead
+	cCid := <-hitBlockedRead
+	require.Equal(t, ads[2].(cidlink.Link).Cid, cCid)
 
 	// Now that there is nothing blocked anymore, and the ingest has learn about all the ads,
 	// i,e, C->B->A through publisher.UpdateRoot, and D through explicit announce, all the entries

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1130,7 +1130,8 @@ func TestAnnounceIsNotDeferredOnNoInProgressIngest(t *testing.T) {
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), mhs)
 }
 
-func AnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *testing.T) {
+func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *testing.T) {
+	t.Skip()
 	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
 	te := setupTestEnv(t, true, blockableLsysOpt)
 	defer te.Close(t)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1131,75 +1131,66 @@ func TestAnnounceIsNotDeferredOnNoInProgressIngest(t *testing.T) {
 }
 
 func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *testing.T) {
-	for i := 1; i < 100; i++ {
 
-		blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
-		te := setupTestEnv(t, true, blockableLsysOpt)
-		defer te.Close(t)
-		headLink := typehelpers.RandomAdBuilder{
-			EntryBuilders: []typehelpers.EntryBuilder{
-				typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 1}, // 0: A <- tail
-				typehelpers.RandomHamtEntryBuilder{MultihashCount: 1, Seed: 2},                  // 1: B
-				typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 3}, // 2: C
-				typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 4}, // 3: D <- head
-			}}.Build(t, te.publisherLinkSys, te.publisherPriv)
-		headCid := headLink.(cidlink.Link).Cid
-		ads := typehelpers.AllAdLinks(t, headLink, te.publisherLinkSys)
-		mhs := typehelpers.AllMultihashesFromAdLink(t, headLink, te.publisherLinkSys)
-		pubAddrInfo := te.pubHost.Peerstore().PeerInfo(te.pubHost.ID())
+	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
+	te := setupTestEnv(t, true, blockableLsysOpt)
+	defer te.Close(t)
+	headLink := typehelpers.RandomAdBuilder{
+		EntryBuilders: []typehelpers.EntryBuilder{
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 1}, // 0: A <- tail
+			typehelpers.RandomHamtEntryBuilder{MultihashCount: 1, Seed: 2},                  // 1: B
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 3}, // 2: C
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 4}, // 3: D <- head
+		}}.Build(t, te.publisherLinkSys, te.publisherPriv)
+	headCid := headLink.(cidlink.Link).Cid
+	ads := typehelpers.AllAdLinks(t, headLink, te.publisherLinkSys)
+	mhs := typehelpers.AllMultihashesFromAdLink(t, headLink, te.publisherLinkSys)
+	pubAddrInfo := te.pubHost.Peerstore().PeerInfo(te.pubHost.ID())
 
-		// Block Ad C which should block the sync triggered by publisher.UpdateRoot.
-		adCCid := ads[2].(cidlink.Link).Cid
-		blockedReads.add(adCCid)
+	// Block Ad C which should block the sync triggered by publisher.UpdateRoot.
+	adCCid := ads[2].(cidlink.Link).Cid
+	blockedReads.add(adCCid)
 
-		// Publish announce message on publisher side, which should trigger a background sync that
-		// gets blocked when attempting to sync ad C.
-		err := te.publisher.UpdateRoot(context.Background(), adCCid)
-		require.NoError(t, err)
+	// Publish announce message on publisher side, which should trigger a background sync that
+	// gets blocked when attempting to sync ad C.
+	err := te.publisher.UpdateRoot(context.Background(), adCCid)
+	require.NoError(t, err)
 
-		// Assert that there is no announce pending processing since no explicit announce was made to
-		// storetheindex ingester.
-		_, found := te.ingester.providersPendingAnnounce.Load(te.pubHost.ID())
-		require.False(t, found)
+	// Assert that there is no announce pending processing since no explicit announce was made to
+	// storetheindex ingester.
+	_, found := te.ingester.providersPendingAnnounce.Load(te.pubHost.ID())
+	require.False(t, found)
 
-		time.Sleep(1000)
+	// Block head ad which should block explicit Announce call made to the ingester.
+	blockedReads.add(headCid)
 
-		// Block head ad which should block explicit Announce call made to the ingester.
-		blockedReads.add(headCid)
+	// Make an explicit announcement of head ad and assert that it was handled immediately since
+	// there is no in-progress entries processing yet; remember ad sync triggered by
+	// publisher.UpdateRoot is still blocked.
+	// Note that the background handling of the announce should get blocked since headCid is also
+	// in the block list.
+	err = te.ingester.Announce(context.Background(), headCid, pubAddrInfo)
+	require.NoError(t, err)
+	_, found = te.ingester.providersPendingAnnounce.Load(te.pubHost.ID())
+	require.False(t, found)
 
-		// Make an explicit announcement of head ad and assert that it was handled immediately since
-		// there is no in-progress entries processing yet; remember ad sync triggered by
-		// publisher.UpdateRoot is still blocked.
-		// Note that the background handling of the announce should get blocked since headCid is also
-		// in the block list.
-		err = te.ingester.Announce(context.Background(), headCid, pubAddrInfo)
-		require.NoError(t, err)
-		_, found = te.ingester.providersPendingAnnounce.Load(te.pubHost.ID())
-		require.False(t, found)
+	// Unblock the sync triggered by publisher.UpdateRoot which should:
+	// 1. cause the ad chain C->B->A to be downloaded.
+	// 2. work to be assigned to the ingest worker which should not be processed until the
+	//    blocked background sync started by the explicit announce is unblocked.
+	<-hitBlockedRead
 
-		// Unblock the sync triggered by publisher.UpdateRoot which should:
-		// 1. cause the ad chain C->B->A to be downloaded.
-		// 2. work to be assigned to the ingest worker which should not be processed until the
-		//    blocked background sync started by the explicit announce is unblocked.
-		dCid := <-hitBlockedRead
-		require.Equal(t, ads[3].(cidlink.Link).Cid, dCid)
+	// Assert that no multihashes are indexed since entries processing should be blocked.
+	requireNotIndexed(t, te.ingester.indexer, te.pubHost.ID(), mhs)
 
-		// Assert that no multihashes are indexed since entries processing should be blocked.
-		requireNotIndexed(t, te.ingester.indexer, te.pubHost.ID(), mhs)
+	// Now unblock the background sync started by the explicit announce, which casues the head
+	// ad (D) to also be downloaded, and should eventually get indexed
+	<-hitBlockedRead
 
-		// Now unblock the background sync started by the explicit announce, which casues the head
-		// ad (D) to also be downloaded, and should eventually get indexed
-		cCid := <-hitBlockedRead
-		require.Equal(t, ads[2].(cidlink.Link).Cid, cCid)
-
-		// Now that there is nothing blocked anymore, and the ingest has learn about all the ads,
-		// i,e, C->B->A through publisher.UpdateRoot, and D through explicit announce, all the entries
-		// should get indexed eventually.
-		requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), mhs)
-
-		fmt.Println("Passed attempt %i", i)
-	}
-
+	// Now that there is nothing blocked anymore, and the ingest has learn about all the ads,
+	// i,e, C->B->A through publisher.UpdateRoot, and D through explicit announce, all the entries
+	// should get indexed eventually.
+	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), mhs)
 }
 
 // Make new indexer engine


### PR DESCRIPTION
This PR adds [ipfs-index-provider](https://github.com/ipfs-shipyard/ipfs-index-provider) to the terraform configuration. fixes  #828