### PR TITLE
Deploy primary gc testing onto dev debug

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex-debug/kustomization.yaml
@@ -21,4 +21,4 @@ images:
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
     # Test changes in primary GC mechanism; see:
     #  - https://github.com/filecoin-project/storetheindex/pull/816
-    newTag: 20220915090309-76b88208d05ae219e05f0c2b271ed56ca0671bec
+    newTag: 20220920140717-fc4984e6474496f490cf0955983ca7266374160f

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
@@ -5,4 +5,4 @@ List of individually configurable instances:
 | Instance | sth bit-size | IOPS per GiB | Value Codec  | Whitelist           | `STHFileCacheSize` | Running |
 |----------|--------------|--------------|--------------|---------------------|--------------------|---------|
 | `arvo`   | 30           | 3            | `json`       | all                 | `-1`               | [778339d270108841997806c86203ddd3a7341fcb](https://github.com/filecoin-project/storetheindex/commit/778339d270108841997806c86203ddd3a7341fcb)        |
-| `mya`    | 30           | 3            | `json`       | all                 | `512`              | [778339d270108841997806c86203ddd3a7341fcb](https://github.com/filecoin-project/storetheindex/commit/778339d270108841997806c86203ddd3a7341fcb)        |
+| `mya`    | 30           | 3            | `json`       | all                 | `512`              | [fc4984e6474496f490cf0955983ca7266374160f](https://github.com/filecoin-project/storetheindex/commit/fc4984e6474496f490cf0955983ca7266374160f)        |

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
@@ -57,13 +57,14 @@
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
+    "GCTimeout": "5m",  
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
     "STHBits": 30,
-    "STHBurstRate": 4194304,
+    "STHBurstRate": 8388608,
     "STHSyncInterval": "1s",
-    "STHFileCacheSize": 256
+    "STHFileCacheSize": 512
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20220908192949-778339d270108841997806c86203ddd3a7341fcb
+    newTag: 20220920140717-fc4984e6474496f490cf0955983ca7266374160f


### PR DESCRIPTION
Has corrupted freelist fix and is rebased on latest sti with go-legs v0.4.14