### PR TITLE
Expand PVC in `romi` since it is over 80% utilised

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/pvc.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 20Ti
+      storage: 40Ti
   storageClassName: io2-iops5


### PR DESCRIPTION
Address disk utilisation alert on `romi`.
