### PR TITLE
Removed ipfs-index-provider repo from terraform

### DIFF
--- a/deploy/infrastructure/common/ecr.tf
+++ b/deploy/infrastructure/common/ecr.tf
@@ -7,7 +7,6 @@ module "ecr_ue2" {
     "autoretrieve/autoretrieve",
     "index-provider/index-provider",
     "indexstar/indexstar",
-    "ipfs-shipyard/ipfs-index-provider",
   ]
   tags = local.tags
 }

--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -52,7 +52,6 @@ module "github_actions_role" {
     "repo:filecoin-project/index-provider:*",
     "repo:filecoin-shipyard/index-observer:*",
     "repo:application-research/autoretrieve:*",
-    "repo:filecoin-shipyard/indexstar:*",
-    "repo:ipfs-shipyard/ipfs-index-provider:*"
+    "repo:filecoin-shipyard/indexstar:*"
   ]
 }


### PR DESCRIPTION
This PR removes ipfs-index-provider artifacts from terraform