### PR TITLE
Temporarily, do not use indexer-1 and indexer-0

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -15,8 +15,8 @@ spec:
             - '--translateReframe'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
-            - '--backends=http://indexer-0.indexer:3000/'
-            - '--backends=http://indexer-1.indexer:3000/'
+            #- '--backends=http://indexer-0.indexer:3000/'
+            #- '--backends=http://indexer-1.indexer:3000/'
             - '--backends=http://romi-indexer:3000/'
             - '--backends=http://tara-indexer:3000/'
             - '--backends=http://xabi-indexer:3000/'


### PR DESCRIPTION
Production indexer-0 is currently inoperable due to the primary file size reaching the maximum size that can be supported, and indexer-1 is currently down because it is undergoing upgrade to have the primary split across multiple files.
