### PR TITLE
Increase worker count on `dido`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -68,12 +68,12 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 20,
+    "IngestWorkerCount": 200,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {
       "Apply": false,
       "Except": null,
-      "BlocksPerSecond": 100,
+      "BlocksPerSecond": 0,
       "BurstSize": 500
     },
     "ResendDirectAnnounce": false,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -73,7 +73,7 @@
     "RateLimit": {
       "Apply": false,
       "Except": null,
-      "BlocksPerSecond": 100,
+      "BlocksPerSecond": 0,
       "BurstSize": 500
     },
     "ResendDirectAnnounce": false,


### PR DESCRIPTION
Investigate high queue times on `dido` by increasing worker count.

While at it, set the rate limit to zero to make it clear that it is disabled.

