### PR TITLE
Record time to store multihashes

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -966,8 +966,16 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID) {
 			continue
 		}
 
+		var entsCid string
+		if ai.ad.Entries == schema.NoEntries {
+			entsCid = "NoEntries"
+		} else {
+			entsCid = ai.ad.Entries.(cidlink.Link).Cid.String()
+		}
+
 		log.Infow("Processing advertisement",
 			"adCid", ai.cid,
+			"entriesCid", entsCid,
 			"publisher", assignment.publisher,
 			"progress", fmt.Sprintf("%d of %d", count, splitAtIndex))
 

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 	"time"
 
@@ -159,8 +160,8 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		stats.Record(context.Background(), metrics.EntriesSyncLatency.M(elapsedMsec))
 
 		// Record average time to store 10000 multihashes.
-		elapsedPer10KMh := float64(entsStoreElapsed.Nanoseconds()/int64(mhCount)) / (1e6 / 1e4)
-		stats.Record(context.Background(), metrics.MhStore10KLatency.M(elapsedPer10KMh))
+		elapsedPerMh := int64(math.Round(float64(entsStoreElapsed.Nanoseconds()) / float64(mhCount)))
+		stats.Record(context.Background(), metrics.MhStoreNanoseconds.M(elapsedPerMh))
 	}()
 
 	// Get provider ID from advertisement.

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -159,7 +159,8 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		elapsedMsec = float64(elapsed.Nanoseconds()) / 1e6
 		stats.Record(context.Background(), metrics.EntriesSyncLatency.M(elapsedMsec))
 
-		// Record average time to store 10000 multihashes.
+		// Record average time to store one multihash, for all multihahses in
+		// this ad's entries.
 		elapsedPerMh := int64(math.Round(float64(entsStoreElapsed.Nanoseconds()) / float64(mhCount)))
 		stats.Record(context.Background(), metrics.MhStoreNanoseconds.M(elapsedPerMh))
 	}()

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -159,7 +159,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		stats.Record(context.Background(), metrics.EntriesSyncLatency.M(elapsedMsec))
 
 		// Record average time to store 10000 multihashes.
-		elapsedPer10KMh := float64(entsStoreElapsed.Nanoseconds()/int64(mhCount)) / 100
+		elapsedPer10KMh := float64(entsStoreElapsed.Nanoseconds()/int64(mhCount)) / (1e6 / 1e4)
 		stats.Record(context.Background(), metrics.MhStore10KLatency.M(elapsedPer10KMh))
 	}()
 

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	indexer "github.com/filecoin-project/go-indexer-core"
-	coremetrics "github.com/filecoin-project/go-indexer-core/metrics"
 	"github.com/filecoin-project/go-legs"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/filecoin-project/storetheindex/internal/metrics"
@@ -135,12 +134,34 @@ func verifyAdvertisement(n ipld.Node, reg *registry.Registry) (peer.ID, error) {
 // indexer.
 func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Advertisement) error {
 	stats.Record(context.Background(), metrics.IngestChange.M(1))
+	var mhCount int
+	var entsSyncStart time.Time
+	var entsStoreElapsed time.Duration
 	ingestStart := time.Now()
-	defer func() {
-		stats.Record(context.Background(), metrics.AdIngestLatency.M(coremetrics.MsecSince(ingestStart)))
-	}()
 
 	log := log.With("publisher", publisherID, "adCid", adCid)
+
+	defer func() {
+		now := time.Now()
+
+		// Record how long ad sync took.
+		elapsed := now.Sub(ingestStart)
+		elapsedMsec := float64(elapsed.Nanoseconds()) / 1e6
+		stats.Record(context.Background(), metrics.AdIngestLatency.M(elapsedMsec))
+		log.Infow("Finished syncing advertisement", "elapsed", elapsed.String(), "multihashes", mhCount)
+
+		if mhCount == 0 {
+			return
+		}
+		// Record how long entries sync took.
+		elapsed = now.Sub(entsSyncStart)
+		elapsedMsec = float64(elapsed.Nanoseconds()) / 1e6
+		stats.Record(context.Background(), metrics.EntriesSyncLatency.M(elapsedMsec))
+
+		// Record average time to store 10000 multihashes.
+		elapsedPer10KMh := float64(entsStoreElapsed.Nanoseconds()/int64(mhCount)) / 100
+		stats.Record(context.Background(), metrics.MhStore10KLatency.M(elapsedPer10KMh))
+	}()
 
 	// Get provider ID from advertisement.
 	providerID, err := peer.Decode(ad.Provider)
@@ -217,7 +238,6 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 	if entriesCid == cid.Undef {
 		return adIngestError{adIngestMalformedErr, fmt.Errorf("advertisement entries link is undefined")}
 	}
-	log = log.With("entriesCid", entriesCid)
 
 	ctx := context.Background()
 	if ing.syncTimeout != 0 {
@@ -226,7 +246,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		defer cancel()
 	}
 
-	startTime := time.Now()
+	entsSyncStart = time.Now()
 
 	// The ad.Entries link can point to either a chain of EntryChunks or a
 	// HAMT. Sync the very first entry so that we can check which type it is.
@@ -305,6 +325,8 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 			}
 		}
 
+		entsStoreStart := time.Now()
+
 		// Start processing now that the entire HAMT is synced. HAMT is a map,
 		// and we are using the keys in the map to represent multihashes.
 		// Therefore, we only care about the keys.
@@ -339,6 +361,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 				if err != nil {
 					return adIngestError{adIngestIndexerErr, fmt.Errorf("failed to index content from HAMT: %w", err)}
 				}
+				mhCount += len(mhs)
 				mhs = mhs[:0]
 			}
 		}
@@ -348,7 +371,9 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 			if err != nil {
 				return adIngestError{adIngestIndexerErr, fmt.Errorf("failed to index content from HAMT: %w", err)}
 			}
+			mhCount += len(mhs)
 		}
+		entsStoreElapsed = time.Since(entsStoreStart)
 	} else {
 		log = log.With("entriesKind", "EntryChunk")
 
@@ -369,11 +394,12 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		}
 
 		// We have already peeked at the first EntryChunk as part of probing
-		// the entries type, sSo process that first.
+		// the entries type, so process that first.
 		chunk, err := ing.loadEntryChunk(syncedFirstEntryCid)
 		if err != nil {
 			errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
 		} else {
+			chunkStart := time.Now()
 			if asyncEntries {
 				chunkFuncs <- func() {
 					if err := ing.ingestEntryChunk(ctx, ad, syncedFirstEntryCid, *chunk, log); err != nil {
@@ -386,6 +412,8 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 					errsIngestingEntryChunks = append(errsIngestingEntryChunks, err)
 				}
 			}
+			mhCount += len(chunk.Entries)
+			entsStoreElapsed += time.Since(chunkStart)
 		}
 
 		if chunk != nil && chunk.Next != nil {
@@ -397,6 +425,8 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 			// Traverse remaining entry chunks based on the entries selector
 			// that limits recursion depth.
 			_, err = ing.sub.Sync(ctx, publisherID, nextChunkCid, ing.entriesSel, nil, legs.ScopedBlockHook(func(p peer.ID, c cid.Cid, actions legs.SegmentSyncActions) {
+				chunkStart := time.Now()
+
 				// Load CID as entry chunk since the selector should only
 				// select entry chunk nodes.
 				chunk, err := ing.loadEntryChunk(c)
@@ -433,6 +463,8 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 						return
 					}
 				}
+				mhCount += len(chunk.Entries)
+				entsStoreElapsed += time.Since(chunkStart)
 
 				if chunk.Next != nil {
 					actions.SetNextSyncCid(chunk.Next.(cidlink.Link).Cid)
@@ -457,11 +489,6 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 			<-asyncDone
 		}
 	}
-	elapsed := time.Since(startTime)
-	// Record how long sync took.
-	stats.Record(context.Background(), metrics.EntriesSyncLatency.M(coremetrics.MsecSince(startTime)))
-	log.Infow("Finished syncing entries", "elapsed", elapsed)
-
 	ing.signalMetricsUpdate()
 
 	if len(errsIngestingEntryChunks) > 0 {

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -34,7 +34,7 @@ var (
 	AdLoadError          = stats.Int64("ingest/adLoadError", "Number of times an ad failed to load", stats.UnitDimensionless)
 	ProviderCount        = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
-	MhStore10KLatency    = stats.Float64("ingest/mhStoreLatency", "Time to store 10000 multihashes", stats.UnitMilliseconds)
+	MhStore10KLatency    = stats.Float64("ingest/mhStore10KLatency", "Time to store 10000 multihashes", stats.UnitMilliseconds)
 )
 
 // Views

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -34,6 +34,7 @@ var (
 	AdLoadError          = stats.Int64("ingest/adLoadError", "Number of times an ad failed to load", stats.UnitDimensionless)
 	ProviderCount        = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
+	MhStore10KLatency    = stats.Float64("ingest/mhStoreLatency", "Time to store 10000 multihashes", stats.UnitMilliseconds)
 )
 
 // Views
@@ -89,6 +90,10 @@ var (
 		Measure:     AdLoadError,
 		Aggregation: view.Count(),
 	}
+	mhStore10KLatencyView = &view.View{
+		Measure:     MhStore10KLatency,
+		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
+	}
 )
 
 var log = logging.Logger("indexer/metrics")
@@ -109,6 +114,7 @@ func Start(views []*view.View) http.Handler {
 		adIngestSkipped,
 		adIngestSuccess,
 		adLoadError,
+		mhStore10KLatencyView,
 	)
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -34,7 +34,7 @@ var (
 	AdLoadError          = stats.Int64("ingest/adLoadError", "Number of times an ad failed to load", stats.UnitDimensionless)
 	ProviderCount        = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
-	MhStore10KLatency    = stats.Float64("ingest/mhStore10KLatency", "Time to store 10000 multihashes", stats.UnitMilliseconds)
+	MhStoreNanoseconds   = stats.Int64("ingest/mhstorenanoseconds", "Average nanoseconds to store one multihash", stats.UnitDimensionless)
 )
 
 // Views
@@ -90,9 +90,9 @@ var (
 		Measure:     AdLoadError,
 		Aggregation: view.Count(),
 	}
-	mhStore10KLatencyView = &view.View{
-		Measure:     MhStore10KLatency,
-		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
+	mhStoreNanosecondsView = &view.View{
+		Measure:     MhStoreNanoseconds,
+		Aggregation: view.LastValue(),
 	}
 )
 
@@ -114,7 +114,7 @@ func Start(views []*view.View) http.Handler {
 		adIngestSkipped,
 		adIngestSuccess,
 		adLoadError,
-		mhStore10KLatencyView,
+		mhStoreNanosecondsView,
 	)
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)


### PR DESCRIPTION
Report metric for average nanoseconds to store a multihash. This is the average over all the multihashes stored for the last ad processed.

Also, log a message that says how long the ad took to ingest and the count of multihashes that were ingested for that ad. Example:
```
2022-09-27T08:59:15.364-0700    INFO    indexer/ingest  ingest/linksystem.go:152        Finished syncing advertisement  {"publisher": "12D3KooWKRJVaDiWcwAvvPNbzWPH8D49qzV5ExxNAGpsdRsABLmr", "adCid": "baguqeeraeigva2nffpv4xymg7x7sssfklenb4kuoz44q4ls5cn6nt66rjlhq", "contextID": "AXESIEHjf2X4P3ruFlU8HpSIR2rH3/qx2x9nALdjIhyI3oOL", "provider": "12D3KooWKRJVaDiWcwAvvPNbzWPH8D49qzV5ExxNAGpsdRsABLmr", "entriesKind": "EntryChunk", "elapsed": "2.31674075s", "multihashes": 25481}
```

- Cleanup some log messages
- Log elapsed time when finished ingesting advertisement

Fixes #744