### PR TITLE
Enable prometheus metric collection from nginx ingress

### DIFF
--- a/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../../../base/ingress-nginx
+  - pod-monitor.yaml
 
 patchesStrategicMerge:
   - patch.yaml

--- a/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/patch.yaml
@@ -12,6 +12,9 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
       containers:
         - name: controller
+          ports:
+            - name: prometheus
+              containerPort: 10254
           resources:
             limits:
               cpu: 500m

--- a/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
+  namespaceSelector:
+    matchNames:
+      - ingress-nginx
+  podMetricsEndpoints:
+    - path: /metrics
+      port: prometheus


### PR DESCRIPTION
Export prometheus monitoring port on ngnix pods and write metrics out to PL grafana.

Relates to #786
