### PR TITLE
Validate advertisement

### DIFF
--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -95,6 +95,12 @@ func verifyAdvertisement(n ipld.Node, reg *registry.Registry) (peer.ID, error) {
 		log.Errorw("Cannot decode advertisement", "err", err)
 		return "", errBadAdvert
 	}
+
+	if err = ad.Validate(); err != nil {
+		log.Errorw("Advertisement validation failed", "err", err)
+		return "", errBadAdvert
+	}
+
 	// Verify advertisement signature.
 	signerID, err := ad.VerifySignature()
 	if err != nil {


### PR DESCRIPTION
## Context
This checks that the metadata and context ID is within the allowed limit, and if not causes the ad sync to fail. This was not done previously and there is evidence that some oversized data was ingested on some indexers.

The sync is ended with an error, instead of skipping the advertisement, to limit the number of possibly huge unusable ads that are downloaded for ingestion.

## Proposed Changes
Verification of the advertisement metadata length and context ID length is added to the advertisement verification that is done in the linksystem `StorageWriteOpener`

## Tests
A new test checks that an advertisement with too large of metadata does not get ingested.

## Revert Strategy
Change is safe to revert. 
