### PR TITLE
Exclude `rami` from indexstar and adjust resources

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   ordered_cache_behavior {
-    path_pattern = "reframe"
+    path_pattern           = "reframe"
     # CloudFront does not support configuring allowed methods selectively.
     # Hence the complete method list.
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
@@ -87,7 +87,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   ordered_cache_behavior {
-    path_pattern = "multihash/*"
+    path_pattern     = "multihash/*"
     # CloudFront does not support configuring allowed methods selectively.
     # Hence the complete method list.
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
@@ -172,6 +172,9 @@ resource "aws_cloudfront_cache_policy" "reframe" {
     query_strings_config {
       query_string_behavior = "all"
     }
+
+    enable_accept_encoding_brotli = true
+    enable_accept_encoding_gzip   = true
   }
 }
 
@@ -204,8 +207,8 @@ module "records" {
 
   records = [
     {
-      name = local.cdn_subdomain
-      type = "A"
+      name  = local.cdn_subdomain
+      type  = "A"
       alias = {
         name    = aws_cloudfront_distribution.cdn.domain_name
         zone_id = aws_cloudfront_distribution.cdn.hosted_zone_id

--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -29,7 +29,7 @@ module "eks" {
     # General purpose node-group.
     prod-ue2-m4-xl-2 = {
       min_size       = 3
-      max_size       = 7
+      max_size       = 10
       desired_size   = 3
       subnet_ids     = local.secondary_private_subnet_ids
       instance_types = ["m4.xlarge"]

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -15,15 +15,14 @@ spec:
             - '--translateReframe'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
-            - '--backends=http://romi-indexer:3000/'
             - '--backends=http://tara-indexer:3000/'
             - '--backends=http://xabi-indexer:3000/'
             - '--backends=http://vega-indexer:3000/'
             - '--backends=http://dido-indexer:3000/'
           resources:
             limits:
-              cpu: "0.5"
+              cpu: "3"
               memory: 2Gi
             requests:
-              cpu: "0.5"
+              cpu: "3"
               memory: 2Gi

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -13,7 +13,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: indexstar
-    count: 10
+    count: 3
 
 images:
   - name: indexstar


### PR DESCRIPTION
`rami` is currently going through an index file upgrade; exclude it from indexstar to avoid expensive timeouts until indexstar implements proper exclusion of unhealthy backends.

The indexstar CPU usage was hovering at 70%; increase the CPU resource to give it enough headroom at the face of request fluctuations. As a result, up the max worker count in relevant EKS nodegroup to allow scheduling of pods with higher CPU limit.

Reduce instance counts to 3 since most of the pods were mostly idle now that resource limit is elevated.

Enable compression for `/reframe` endpoint on CloudFront; unrelated to the timeout investigation. Added here since it was changed in the past and terraform update was missing.

Relates to #863
