### PR TITLE
Handle IPLD `SkipMe` errors as content not found during ad ingest

### DIFF
--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -274,10 +274,15 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		//
 		// Use string search until then.
 		wrappedErr := fmt.Errorf("failed to sync first entry while checking entries type: %w", err)
-		if strings.Contains(err.Error(), "content not found") {
+		msg := err.Error()
+		switch {
+		case
+			strings.Contains(msg, "content not found"),
+			strings.Contains(msg, "graphsync request failed to complete: skip"):
 			return adIngestError{adIngestContentNotFound, wrappedErr}
+		default:
+			return adIngestError{adIngestSyncEntriesErr, wrappedErr}
 		}
-		return adIngestError{adIngestSyncEntriesErr, wrappedErr}
 	}
 
 	node, err := ing.loadNode(syncedFirstEntryCid, basicnode.Prototype.Any)


### PR DESCRIPTION
IPLD `SkipMe` errors returned during traversal via GraphSync signal partial availability of blocks. We already skip over "content not found" errors that occur while fetching entries associated to an ad. Therefore, it makes sense to do the same on `SkipMe` errors. To summarise, this means their ingest of ads that their entries are not traversable will not be processed. Otherwise, ad ingest for a provider may halt indefinitely.

Fixes #866

