### PR TITLE
Exclude `indexer-1` from indexstar backends

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -15,7 +15,6 @@ spec:
             - '--translateReframe'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
-            - '--backends=http://indexer-1.indexer:3000/'
             - '--backends=http://tara-indexer:3000/'
             - '--backends=http://xabi-indexer:3000/'
             - '--backends=http://vega-indexer:3000/'


### PR DESCRIPTION
The node is not ready and causing high lookup latency.
