### PR TITLE
Disable indexer core cache on `oden` to avoid panic

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -62,7 +62,7 @@
     "Timeout": "2m0s"
   },
   "Indexer": {
-    "CacheSize": 300000,
+    "CacheSize": -1,
     "ConfigCheckInterval": "30s",
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",


### PR DESCRIPTION
A panic occurs when comparing values returned by cache. Disable it on `oden` to avoid panic. Aside from that the cache is hardly used by the node.

See:
 - https://github.com/filecoin-project/go-indexer-core/issues/80

