### PR TITLE
Point landing page to `indexstar`

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -56,7 +56,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     # Hence the complete method list.
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = local.cdn_origin_id
+    target_origin_id = local.indexstar_origin_id
 
     forwarded_values {
       query_string = false


### PR DESCRIPTION
The landing page at `cid.contact` was powered by `indexer-0` and `indexer-1`. Now that they are down it meant the landing page was returning 503.

`indexstar` includes logic to bounce off landing page requests to the first configured backend. Though not ideal this means the landing page will continue to operate as long as the list of backends in `indexstar` are maintained.

Note, this change means we cannot use `cid.contact` directly as a backend in indexstar; otherwise it will result in an infinite redirect.
