### PR TITLE
Set termination grace period for prod indexers

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -6,6 +6,7 @@ spec:
   replicas: 2
   template:
     spec:
+      terminationGracePeriodSeconds: 600
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Prod indexers 0 and 1 need more time to have a clean shutodown. 