### PR TITLE
Include indexer 0 and 1 in indexstar targets

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -15,6 +15,8 @@ spec:
             - '--translateReframe'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
+            - '--backends=http://indexer-0.indexer:3000/'
+            - '--backends=http://indexer-1.indexer:3000/'
             - '--backends=http://tara-indexer:3000/'
             - '--backends=http://xabi-indexer:3000/'
             - '--backends=http://vega-indexer:3000/'


### PR DESCRIPTION
With indexer-0 and indexer-1 back online, they should in included in the indexstar targets.