### PR TITLE
Write entries synchronously to avoid #883

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
@@ -85,7 +85,8 @@ data:
         "ResendDirectAnnounce": true,
         "StoreBatchSize": 8192,
         "SyncSegmentDepthLimit": 2000,
-        "SyncTimeout": "2h0m0s"
+        "SyncTimeout": "2h0m0s",
+        "WriteEntriesSynchronously": true
       },
       "Logging": {
         "Level": "info",


### PR DESCRIPTION
#883 happened on indexer-1, so setting config to write entries synchronously until that is fixex.