### PR TITLE
Remove option to write entries synchronously

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -621,7 +621,6 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 		}
 		ingester.SetBatchSize(cfg.Ingest.StoreBatchSize)
 		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
-		ingester.SetWriteEntriesSynchronously(cfg.Ingest.WriteEntriesSynchronously)
 	}
 
 	err = setLoggingConfig(cfg.Logging)

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -70,11 +70,6 @@ type Ingest struct {
 	// or a chain of advertisement entries. The value is an integer string
 	// ending in "s", "m", "h" for seconds. minutes, hours.
 	SyncTimeout Duration
-	// Synchronously, when true, tells the indexer to process entry chunks
-	// synchronously, waiting for each to complete before fetching the next.
-	// Otherwise, the indexer processes entry chunks asynchronously. This value
-	// is updated when the configuration is reloaded.
-	WriteEntriesSynchronously bool
 }
 
 // NewIngest returns Ingest with values set to their defaults.

--- a/doc/config.md
+++ b/doc/config.md
@@ -93,8 +93,7 @@ config file at runtime.
     "ResendDirectAnnounce": true,
     "StoreBatchSize": 4096,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "WriteEntriesSynchronously": false
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",
@@ -232,8 +231,7 @@ Default:
   "ResendDirectAnnounce": false,
   "StoreBatchSize": 4096,
   "SyncSegmentDepthLimit": 2000,
-  "SyncTimeout": "2h0m0s",
-  "WriteEntriesSynchronously": false
+  "SyncTimeout": "2h0m0s"
 }
 ```
 
@@ -286,6 +284,5 @@ The storetheindex daemon can reload some portions of its config without restarti
 - [`Ingest.IngestWorkerCount`](#ingest)
 - [`Ingest.RateLimit`](#ingestratelimit)
 - [`Ingest.StoreBatchSize`](#ingest)
-- [`Ingest.WriteEntriesSynchronously`](#ingest)
 - [`Logging`](#logging)
 - [`Peering`](#peering)


### PR DESCRIPTION
Do not support writing entries asynchronously as it adds complexity for little or no gain in performance.

When ingesting from a single source, asynchronously writing entries may have a small performance improvement. This is because the next entries chunk can be already loaded when the previous chunk is done being written to the value store. When ingesting from multiple sources, this does not matter since any gap between ingesting one entries chunk and the next is utilized by another worker writing data to the value store.

Since any indexer is generally ingesting from multiple sources, the added complexity of asynchronously ingesting entries chunks does not result in any advantage. When ingesting from multiple sources, avoiding the more complex asynchronous behavior appears to have a slight performance improvement.

Fixes #883

Note: This PR was not done to fix #883, but was done to remove unnecessary complexity. It happens to fix #883 by removing the sections of code that causes the issue.