### PR TITLE
Exclude `xabi` from indexstar to avoid high response latency

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -18,7 +18,6 @@ spec:
             - '--backends=http://indexer-0.indexer:3000/'
             - '--backends=http://indexer-1.indexer:3000/'
             - '--backends=http://tara-indexer:3000/'
-            - '--backends=http://xabi-indexer:3000/'
             - '--backends=http://vega-indexer:3000/'
             - '--backends=http://dido-indexer:3000/'
           resources:


### PR DESCRIPTION
Because `xabi` is going through index file migration it is downgraded.
