### PR TITLE
Remove redundant `WriteEntriesSynchronously` config value

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexer-config.yaml
@@ -87,8 +87,7 @@ data:
         "ResendDirectAnnounce": true,
         "StoreBatchSize": 8192,
         "SyncSegmentDepthLimit": 2000,
-        "SyncTimeout": "2h0m0s",
-        "WriteEntriesSynchronously": true
+        "SyncTimeout": "2h0m0s"
       },
       "Logging": {
         "Level": "info",

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/arvo/config.json
@@ -57,7 +57,7 @@
     "CacheSize": -1,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
-    "GCTimeout": "5m",  
+    "GCTimeout": "5m",
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
@@ -84,8 +84,7 @@
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "WriteEntriesSynchronously": false
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/mya/config.json
@@ -57,7 +57,7 @@
     "CacheSize": -1,
     "ConfigCheckInterval": "30s",
     "GCInterval": "30m0s",
-    "GCTimeout": "5m",  
+    "GCTimeout": "5m",
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
@@ -84,8 +84,7 @@
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "WriteEntriesSynchronously": false
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexer-config.yaml
@@ -85,8 +85,7 @@ data:
         "ResendDirectAnnounce": true,
         "StoreBatchSize": 8192,
         "SyncSegmentDepthLimit": 2000,
-        "SyncTimeout": "2h0m0s",
-        "WriteEntriesSynchronously": true
+        "SyncTimeout": "2h0m0s"
       },
       "Logging": {
         "Level": "info",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -79,8 +79,7 @@
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "WriteEntriesSynchronously": false
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -86,8 +86,7 @@
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "WriteEntriesSynchronously": true
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
@@ -83,8 +83,7 @@
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "WriteEntriesSynchronously": true
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
@@ -84,8 +84,7 @@
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "WriteEntriesSynchronously": false
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
@@ -65,7 +65,7 @@
     "ConfigCheckInterval": "30s",
     "CorePutConcurrency": 64,
     "GCInterval": "30m0s",
-    "GCTimeLimit": "5m", 
+    "GCTimeLimit": "5m",
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "sth",
@@ -93,8 +93,7 @@
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s",
-    "WriteEntriesSynchronously": false
+    "SyncTimeout": "2h0m0s"
   },
   "Logging": {
     "Level": "info",


### PR DESCRIPTION
Cleanup the config to reflect the fact that `WriteEntriesSynchronously` no longer exists.
