### PR TITLE
Revert high ingest worker count in `dido` as it makes no difference

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -68,7 +68,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 200,
+    "IngestWorkerCount": 20,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {
       "Apply": false,


### PR DESCRIPTION
High ingest worker count in dido makes no significant difference to the ingest throughput; revert it.

Relates to:
 - #854

