### PR TITLE
Expand `tara` PVC to 40 Ti

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/pvc.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 20Ti
+      storage: 40Ti
   storageClassName: io2-iops5


### PR DESCRIPTION
`tara` is on crashloopback and ran out of disk space while upgrading sth primary files.

See [alert](https://protocollabs.grafana.net/d/pPROWOD7z/providers?tab=alert&viewPanel=72&orgId=1).
