### PR TITLE
Valuestore codec is not configurable and always uses binary

### DIFF
--- a/config/indexer.go
+++ b/config/indexer.go
@@ -44,16 +44,9 @@ type Indexer struct {
 	STHFileCacheSize int
 	// STHSyncInterval determines how frequently changes are flushed to disk.
 	STHSyncInterval Duration
-	// ValueStoreCodec configures the marshalling format of values stored by the valuestore.
-	// It can be one of "json" or "binary". If unspecified, json format is used by default.
-	//
-	// Note that the format must not be changed after a valuestore is initialized. Changing
-	// the format for a pre-existing valuestore will result in failure and potentially data
-	// corruption.
-	ValueStoreCodec string
-	// PebbleDisableWAL sets whether to disable write-ahead-log in Pebble which can offer better
-	// performance in specific cases. Enabled by default.
-	// Note, this option is only considered when ValueStoreType type is set to "pebble".
+	// PebbleDisableWAL sets whether to disable write-ahead-log in Pebble which
+	// can offer better performance in specific cases. Enabled by default. This
+	// option only applies when ValueStoreType is set to "pebble".
 	PebbleDisableWAL bool
 
 	// TODO: If left unspecified, could the functionality instead be to use whatever the existing
@@ -77,7 +70,6 @@ func NewIndexer() Indexer {
 		STHBurstRate:        8 * 1024 * 1024,
 		STHFileCacheSize:    512,
 		STHSyncInterval:     Duration(time.Second),
-		ValueStoreCodec:     "json",
 	}
 }
 
@@ -117,8 +109,5 @@ func (c *Indexer) populateUnset() {
 	}
 	if c.STHSyncInterval == 0 {
 		c.STHSyncInterval = def.STHSyncInterval
-	}
-	if c.ValueStoreCodec == "" {
-		c.ValueStoreCodec = def.ValueStoreCodec
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.11-0.20221007150802-45b4cdaf264e
+	github.com/filecoin-project/go-indexer-core v0.6.11
 	github.com/filecoin-project/go-legs v0.4.16
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.2 h1:to4pTadv3IeV1wvgbCbN6Vqd+fu+7tveXgv/rCEZy6w=
 github.com/filecoin-project/go-ds-versioning v0.1.2/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.11-0.20221007150802-45b4cdaf264e h1:+W/k4IvzdRm1hZvT0WdTkopJ6ZVY2rTW5CRAPFz1Hzs=
-github.com/filecoin-project/go-indexer-core v0.6.11-0.20221007150802-45b4cdaf264e/go.mod h1:0pxe92yGyIAgXp5LHD2rhXbYZivBTumL3uQpPq91GIw=
+github.com/filecoin-project/go-indexer-core v0.6.11 h1:6MbUxHGRwFyQTWu+oAGRgPREguYf/bFpdIVxGsoxtmY=
+github.com/filecoin-project/go-indexer-core v0.6.11/go.mod h1:0pxe92yGyIAgXp5LHD2rhXbYZivBTumL3uQpPq91GIw=
 github.com/filecoin-project/go-legs v0.4.16 h1:m5Ht1/NTIfJNw8FA+KAsPYfxzqW5AUHbAlNa2EzEkmU=
 github.com/filecoin-project/go-legs v0.4.16/go.mod h1:5ZrHXEhKfVXJXQNOb5mm9pzFuU5xLqY8ZIHQQtYFSSM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1237,7 +1237,7 @@ func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *test
 
 // Make new indexer engine
 func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil, testCorePutConcurrency, sth.IndexBitSize(8))
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), testCorePutConcurrency, sth.IndexBitSize(8))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -33,7 +33,7 @@ var rng = rand.New(rand.NewSource(1413))
 
 // InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil, 4)
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), 4)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -33,7 +33,7 @@ var rng = rand.New(rand.NewSource(1413))
 
 // InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil, 4)
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), 4)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The valuestore chooses the `BinaryValueCodec` or `BinaryWithJsonFallbackCodec` codec based on weather or not the valuestore is created new or already exists, respectively. The codec is no longer configurable in the confile.
