### PR TITLE
Exclude `dido` from indexstar while investigating merger CPU footprint

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -17,7 +17,6 @@ spec:
             # TLS handshake overhead.
             - '--backends=http://indexer-0.indexer:3000/'
             - '--backends=http://indexer-1.indexer:3000/'
-            - '--backends=http://dido-indexer:3000/'
             - '--backends=http://vega-indexer:3000/'
             - '--backends=http://xabi-indexer:3000/'
           resources:


### PR DESCRIPTION
Exclude `dido` backend from indexstar while working on improving CPU footprint of f pebble merger. This is to offer a stable upstream find latency in indexstar.

