### PR TITLE
Point `dev.cid.contact` to CloudFront backed by `indexstar`

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/dev/us-east-2/cloudfront.tf
@@ -55,7 +55,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     # We need to allow GET and PUT. CloudFront does not support configuring allowed methods selectively.
     # Hence the complete method list.
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
-    cached_methods   = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.indexstar_origin_id
 
     forwarded_values {
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     # CloudFront does not support configuring allowed methods selectively.
     # Hence the complete method list.
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
-    cached_methods         = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
     target_origin_id       = local.indexstar_origin_id
     cache_policy_id        = aws_cloudfront_cache_policy.reframe.id
     viewer_protocol_policy = "redirect-to-https"

--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -55,7 +55,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     # We need to allow GET and PUT. CloudFront does not support configuring allowed methods selectively.
     # Hence the complete method list.
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
-    cached_methods   = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.indexstar_origin_id
 
     forwarded_values {
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     # CloudFront does not support configuring allowed methods selectively.
     # Hence the complete method list.
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
-    cached_methods         = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
     target_origin_id       = local.indexstar_origin_id
     cache_policy_id        = aws_cloudfront_cache_policy.reframe.id
     viewer_protocol_policy = "redirect-to-https"
@@ -91,7 +91,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     # CloudFront does not support configuring allowed methods selectively.
     # Hence the complete method list.
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
-    cached_methods   = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.indexstar_origin_id
     forwarded_values {
       query_string = false
@@ -109,7 +109,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   ordered_cache_behavior {
     path_pattern     = "cid/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.indexstar_origin_id
     forwarded_values {
       query_string = false
@@ -127,7 +127,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   ordered_cache_behavior {
     path_pattern     = "providers"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.indexstar_origin_id
     forwarded_values {
       query_string = false

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - dev.cid.contact
+        - indexer.dev.cid.contact
       secretName: indexer-ingress-tls
   rules:
-    - host: dev.cid.contact
+    - host: indexer.dev.cid.contact
       http:
         paths:
           - path: /ingest


### PR DESCRIPTION
Change the routing of requests in `dev` environment, such that all requests to `dev.cid.contact` go through CloudFront caching, and routed via indexstar internally. This matches the routing mechanism currently employed in `prod`.

As a result of changes, ingress to `indexer-0` and `indexer-1` is changed to point to `indexer.dev.cid.contact` instead.

Fixes #856

