### PR TITLE
Enable nginx ingress metrics on `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/ingress-nginx/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/ingress-nginx/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/ingress-nginx
+  - pod-monitor.yaml
+
+patchesStrategicMerge:
+  - patch.yaml
+
+replicas:
+  - name: ingress-nginx-controller
+    count: 3

--- a/deploy/manifests/dev/us-east-2/cluster/ingress-nginx/patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/ingress-nginx/patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: controller
+          ports:
+            - name: prometheus
+              containerPort: 10254
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi

--- a/deploy/manifests/dev/us-east-2/cluster/ingress-nginx/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/ingress-nginx/pod-monitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: nginx
+  namespace: ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
+  namespaceSelector:
+    matchNames:
+      - ingress-nginx
+  podMetricsEndpoints:
+    - path: /metrics
+      port: prometheus

--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../../base/ingress-nginx
+  - ingress-nginx
   - kube-system
   - flux-system
   - external-dns


### PR DESCRIPTION
Enable nginx monitoring and metrics on `dev` so that we can measure upstream latency from ingress. This is already set up for `prod`.
