### PR TITLE
Define an EKS node group dedicated to us-east2a for autoretrieve

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -29,10 +29,18 @@ module "eks" {
       subnet_ids     = module.vpc.private_subnets
     }
     dev-ue2-r5a-2xl = {
+      min_size       = 0
+      max_size       = 7
+      desired_size   = 1
+      instance_types = ["r5a.2xlarge"]
+    }
+    # Node group primarily used by autoretrieve with PVC in us-east2a availability zone.
+    dev-ue2a-r5a-2xl = {
       min_size       = 1
       max_size       = 7
       desired_size   = 1
       instance_types = ["r5a.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2a1.id]
     }
     dev-ue2-r5b-xl = {
       min_size       = 3

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -17,6 +17,11 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2a-r5a-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2-r5b-xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
     - groups:


### PR DESCRIPTION
The node group primarily getting used by autoretrieve is configured to use all subnets. This means ASG can spin up new nodes in any AZ which may not match the AZ on which PV was originally created.

The work here creates a node group with AZ dedicated to the zone on which the autoretrieve PV is currently presenent, i.e. `us-east2a`, in order to avoid unschedulable pods caused by AZ mismatch between worker node and PV.

The minimum instance count in the existing ASG is decreased to zero in order to avoid running idle workers once the autoretrieve pod migrates to the newly set up node group.

