### PR TITLE
Exclude indexer 0 and 1 on prod from indexstar

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -15,8 +15,6 @@ spec:
             - '--translateReframe'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
-            - '--backends=http://indexer-0.indexer:3000/'
-            - '--backends=http://indexer-1.indexer:3000/'
             - '--backends=http://tara-indexer:3000/'
             - '--backends=http://vega-indexer:3000/'
             - '--backends=http://xabi-indexer:3000/'


### PR DESCRIPTION
Exclude `indexer-0` and `1` from `indexstar` on prod until they are restarted. This is a measure to reduce the impact on upstream latency caused by #931.

