### PR TITLE
Upgrade to the latest go-indexer-core to use Pebble pooling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-indexer-core v0.6.14
+	github.com/filecoin-project/go-indexer-core v0.6.15
 	github.com/filecoin-project/go-legs v0.4.16
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.2 h1:to4pTadv3IeV1wvgbCbN6Vqd+fu+7tveXgv/rCEZy6w=
 github.com/filecoin-project/go-ds-versioning v0.1.2/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.14 h1:D5FdCSfrqDjZiZHtcRvRqDyhcgeC1fBkmmLNJpqWFDw=
-github.com/filecoin-project/go-indexer-core v0.6.14/go.mod h1:Ici+vkzfVnhA6TzScmijFvrENcN6rbcRzAPQbE92rZA=
+github.com/filecoin-project/go-indexer-core v0.6.15 h1:wQB07eRepp9DDGs4fg66dEOeXFuL/v5pB5xmdXFg6bc=
+github.com/filecoin-project/go-indexer-core v0.6.15/go.mod h1:Ici+vkzfVnhA6TzScmijFvrENcN6rbcRzAPQbE92rZA=
 github.com/filecoin-project/go-legs v0.4.16 h1:m5Ht1/NTIfJNw8FA+KAsPYfxzqW5AUHbAlNa2EzEkmU=
 github.com/filecoin-project/go-legs v0.4.16/go.mod h1:5ZrHXEhKfVXJXQNOb5mm9pzFuU5xLqY8ZIHQQtYFSSM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=


### PR DESCRIPTION

Upgrade to the latest release of pebble backing store to take advantage of pooling.