### PR TITLE
Add `dido` and `oden` back to `indexstar`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -18,6 +18,8 @@ spec:
             - '--backends=http://tara-indexer:3000/'
             - '--backends=http://vega-indexer:3000/'
             - '--backends=http://xabi-indexer:3000/'
+            - '--backends=http://dido-indexer:3000/'
+            - '--backends=http://oden-indexer:3000/'
           resources:
             limits:
               cpu: "3"


### PR DESCRIPTION
Now that the latest is deployed on `dido` and `oden`, add them back to `indexstar` backends.

