### PR TITLE
Mark provider as Seen when sync is successful

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -395,6 +395,7 @@ func (ing *Ingester) Sync(ctx context.Context, peerID peer.ID, peerAddr multiadd
 			log.Errorw("Failed to sync with provider", "err", err)
 			return
 		}
+		ing.reg.Saw(peerID)
 		// Do not persist the latest sync here, because that is done after
 		// processing the ad.
 
@@ -696,6 +697,7 @@ func (ing *Ingester) autoSync() {
 				log.Errorw("Failed to auto-sync with publisher", "err", err)
 				return
 			}
+			ing.reg.Saw(provID)
 		}(provInfo.Publisher, provInfo.PublisherAddr, provInfo.AddrInfo.ID)
 	}
 }


### PR DESCRIPTION
A provider may be marked as inactive if its last contact time is not updated for 2x longer than a configured threshold. The last contact time was previously being updated only of there was some ads from a provider: an active provider that has not published any new ads for a while could get marked as inactive.

The changes here opportunistically marks a provider as seen: i.e. whenever sync from that provider doesn't return an error. If subscriber. Sync does not return an error it means there was some successful communication to either fetch data or get the head.

Relates to #953
