### PR TITLE
Keep providers in active state until deleted by default

### DIFF
--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -400,8 +400,9 @@ func TestPollProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	poll := polling{
-		retryAfter: time.Minute,
-		stopAfter:  time.Hour,
+		retryAfter:      time.Minute,
+		stopAfter:       time.Hour,
+		deactivateAfter: time.Hour,
 	}
 
 	// Check for auto-sync after pollInterval 0.
@@ -418,6 +419,7 @@ func TestPollProvider(t *testing.T) {
 
 	// Check that actions chan is not blocked by unread auto-sync channel.
 	poll.retryAfter = 0
+	poll.deactivateAfter = 0
 	r.pollProviders(poll, nil)
 	r.pollProviders(poll, nil)
 	r.pollProviders(poll, nil)


### PR DESCRIPTION
Introduce a new config parameter `DeactivateAfter` to replace the hardcoded `2xretryAfter` duration after which a provider is deactivated.

Change the default behaviour to set `DeactivateAfter` to the same value as `PollStopAfter`. This effectively disables the inactive state feature for providers: i.e. providers will remain findable via query APIs until deleted when unseen after `PollStopAfter` has elapsed.

Fixes #953

