### PR TITLE
Clear inactive flag when marking provider as seen

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -315,12 +315,14 @@ func (r *Registry) Discover(peerID peer.ID, discoveryAddr string, sync bool) err
 	return nil
 }
 
-// Saw indicates that a provider was seen. just updates
+// Saw indicates that a provider was seen.
 func (r *Registry) Saw(provider peer.ID) {
 	done := make(chan struct{})
 	r.actions <- func() {
 		if _, ok := r.providers[provider]; ok {
-			r.providers[provider].lastContactTime = time.Now()
+			pinfo := r.providers[provider]
+			pinfo.lastContactTime = time.Now()
+			pinfo.inactive = false
 		}
 		close(done)
 	}

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -44,7 +44,7 @@ func (h *FinderHandler) Find(mhashes []multihash.Multihash) (*model.FindResponse
 	for i := range mhashes {
 		values, found, err := h.indexer.Get(mhashes[i])
 		if err != nil {
-			err = fmt.Errorf("failed to query %q: %s", mhashes[i], err)
+			err = fmt.Errorf("failed to query multihash %s: %s", mhashes[i].B58String(), err)
 			return nil, v0.NewError(err, http.StatusInternalServerError)
 		}
 		if !found {


### PR DESCRIPTION
When a provider is seen, clear the inactive flag in addition to updating the last contact time. This is a follow-up to PR #953.

Also, fix a log message to log multihash in a format consistent with other log messages.
