### PR TITLE
Add config function to set max number of connections for http finder server

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -157,11 +157,12 @@ func daemonCommand(cctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		finderOpts := []httpfinderserver.ServerOption{
+		finderSvr, err = httpfinderserver.New(finderAddr.String(), indexerCore, reg,
 			httpfinderserver.WithHomepage(cfg.Addresses.FinderWebpage),
 			httpfinderserver.MaxConnections(cfg.Finder.MaxConnections),
-		}
-		finderSvr, err = httpfinderserver.New(finderAddr.String(), indexerCore, reg, finderOpts...)
+			httpfinderserver.ReadTimeout(time.Duration(cfg.Finder.ApiReadTimeout)),
+			httpfinderserver.WriteTimeout(time.Duration(cfg.Finder.ApiWriteTimeout)),
+		)
 		if err != nil {
 			return err
 		}

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -157,8 +157,11 @@ func daemonCommand(cctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		finderOpt := httpfinderserver.WithHomepage(cfg.Addresses.FinderWebpage)
-		finderSvr, err = httpfinderserver.New(finderAddr.String(), indexerCore, reg, finderOpt)
+		finderOpts := []httpfinderserver.ServerOption{
+			httpfinderserver.WithHomepage(cfg.Addresses.FinderWebpage),
+			httpfinderserver.MaxConnections(cfg.Finder.MaxConnections),
+		}
+		finderSvr, err = httpfinderserver.New(finderAddr.String(), indexerCore, reg, finderOpts...)
 		if err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Bootstrap Bootstrap // Peers to connect to for gossip
 	Datastore Datastore // datastore config
 	Discovery Discovery // provider pubsub peers
+	Finder    Finder    // finder code configuration
 	Indexer   Indexer   // indexer code configuration
 	Ingest    Ingest    // ingestion related configuration.
 	Logging   Logging   // logging configuration.
@@ -105,6 +106,7 @@ func Load(filePath string) (*Config, error) {
 		Bootstrap: NewBootstrap(),
 		Datastore: NewDatastore(),
 		Discovery: NewDiscovery(),
+		Finder:    NewFinder(),
 		Indexer:   NewIndexer(),
 		Ingest:    NewIngest(),
 		Logging:   NewLogging(),
@@ -180,6 +182,7 @@ func (c *Config) populateUnset() {
 	c.Addresses.populateUnset()
 	c.Datastore.populateUnset()
 	c.Discovery.populateUnset()
+	c.Finder.populateUnset()
 	c.Indexer.populateUnset()
 	c.Ingest.populateUnset()
 	c.Logging.populateUnset()

--- a/config/finder.go
+++ b/config/finder.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"time"
+)
+
+type Finder struct {
+	// api write timeout
+	ApiWriteTimeout Duration
+	// api read timeout
+	ApiReadTimeout Duration
+	// maximum number of connections
+	MaxConnections int
+}
+
+func NewFinder() Finder {
+	return Finder{
+		ApiWriteTimeout: Duration(30 * time.Second),
+		ApiReadTimeout:  Duration(30 * time.Second),
+		MaxConnections:  8_000,
+	}
+}
+
+// populateUnset replaces zero-values in the config with default values.
+func (f *Finder) populateUnset() {
+	def := NewFinder()
+	if f.ApiWriteTimeout == 0 {
+		f.ApiWriteTimeout = def.ApiWriteTimeout
+	}
+	if f.ApiReadTimeout == 0 {
+		f.ApiReadTimeout = def.ApiReadTimeout
+	}
+	if f.MaxConnections == 0 {
+		f.MaxConnections = def.MaxConnections
+	}
+}

--- a/config/init.go
+++ b/config/init.go
@@ -26,6 +26,7 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		Bootstrap: NewBootstrap(),
 		Datastore: NewDatastore(),
 		Discovery: NewDiscovery(),
+		Finder:    NewFinder(),
 		Identity:  identity,
 		Indexer:   NewIndexer(),
 		Ingest:    NewIngest(),

--- a/server/finder/http/options.go
+++ b/server/finder/http/options.go
@@ -64,6 +64,14 @@ func ReadTimeout(t time.Duration) ServerOption {
 	}
 }
 
+// MaxConnections config for API
+func MaxConnections(maxConnections int) ServerOption {
+	return func(c *serverConfig) error {
+		c.maxConns = maxConnections
+		return nil
+	}
+}
+
 // WithHomepage config for API
 func WithHomepage(URL string) ServerOption {
 	return func(c *serverConfig) error {


### PR DESCRIPTION
Default values can be overridden programatically through the config function or by altering the Finder section of the config file.

Fixes #632

## Context
<!-- What is a brief description of the problem you're solving? Imagine looking back at this PR in a year, what would you want to see? -->

## Proposed Changes
<!-- Succintly describe your changes. This should be high level, don't worry about the specifics. -->

## Tests
<!-- What tests did you add to assert the expected behavior? If no tests, why? -->

## Revert Strategy
<!-- Is this change safe to revert? -->

<!-- If yes, you can simply say:-->
<!-- Change is safe to revert. -->

<!-- If no, outline the steps required to revert this change. -->
