### PR TITLE
Document finder config settings

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -158,10 +158,10 @@ func daemonCommand(cctx *cli.Context) error {
 			return err
 		}
 		finderSvr, err = httpfinderserver.New(finderAddr.String(), indexerCore, reg,
-			httpfinderserver.WithHomepage(cfg.Addresses.FinderWebpage),
-			httpfinderserver.MaxConnections(cfg.Finder.MaxConnections),
 			httpfinderserver.ReadTimeout(time.Duration(cfg.Finder.ApiReadTimeout)),
 			httpfinderserver.WriteTimeout(time.Duration(cfg.Finder.ApiWriteTimeout)),
+			httpfinderserver.MaxConnections(cfg.Finder.MaxConnections),
+			httpfinderserver.WithHomepage(cfg.Finder.Webpage),
 		)
 		if err != nil {
 			return err

--- a/config/addresses.go
+++ b/config/addresses.go
@@ -8,9 +8,6 @@ type Addresses struct {
 	// Finder is the finder http isten address. Set to "none" to disable this
 	// server for both http and libp2p.
 	Finder string
-	// FinderWebpage is a domain to display when the homepage of the finder
-	// is accessed over http.
-	FinderWebpage string
 	// Ingest is the index data ingestion http listen address. Set to "none"
 	// to disable this server for both http and libp2p.
 	Ingest string
@@ -24,11 +21,10 @@ type Addresses struct {
 // NewAddresses returns Addresses with values set to their defaults.
 func NewAddresses() Addresses {
 	return Addresses{
-		Admin:         "/ip4/127.0.0.1/tcp/3002",
-		Finder:        "/ip4/0.0.0.0/tcp/3000",
-		FinderWebpage: "https://web.cid.contact/",
-		Ingest:        "/ip4/0.0.0.0/tcp/3001",
-		P2PAddr:       "/ip4/0.0.0.0/tcp/3003",
+		Admin:   "/ip4/127.0.0.1/tcp/3002",
+		Finder:  "/ip4/0.0.0.0/tcp/3000",
+		Ingest:  "/ip4/0.0.0.0/tcp/3001",
+		P2PAddr: "/ip4/0.0.0.0/tcp/3003",
 	}
 }
 
@@ -41,9 +37,6 @@ func (c *Addresses) populateUnset() {
 	}
 	if c.Finder == "" {
 		c.Finder = def.Finder
-	}
-	if c.FinderWebpage == "" {
-		c.FinderWebpage = def.FinderWebpage
 	}
 	if c.Ingest == "" {
 		c.Ingest = def.Ingest

--- a/config/finder.go
+++ b/config/finder.go
@@ -14,7 +14,8 @@ type Finder struct {
 	// negative value means there will be no timeout.
 	ApiWriteTimeout Duration
 	// MaxConnections is maximum number of simultaneous connections that the
-	// HTTP server will accept. A value of zero sets the default.
+	// HTTP server will accept. A value of zero sets the default and a negative
+	// value means there is no limit.
 	MaxConnections int
 	// Webpage is a domain to display when the homepage of the finder is
 	// accessed over HTTP.

--- a/config/finder.go
+++ b/config/finder.go
@@ -7,11 +7,11 @@ import (
 type Finder struct {
 	// ApiReadTimeout sets the HTTP server's maximum duration for reading the
 	// entire request, including the body. A value of zero sets the default,
-	// and a negative value value means there will be no timeout.
+	// and a negative value means there will be no timeout.
 	ApiReadTimeout Duration
 	// ApiWriteTimeout sets the HTTP server's maximum duration before timing
 	// out writes of the response. A value of zero sets the default and a
-	// negative value value means there will be no timeout.
+	// negative value means there will be no timeout.
 	ApiWriteTimeout Duration
 	// MaxConnections is maximum number of simultaneous connections that the
 	// HTTP server will accept. A value of zero sets the default.

--- a/config/finder.go
+++ b/config/finder.go
@@ -5,32 +5,44 @@ import (
 )
 
 type Finder struct {
-	// api write timeout
-	ApiWriteTimeout Duration
-	// api read timeout
+	// ApiReadTimeout sets the HTTP server's maximum duration for reading the
+	// entire request, including the body. A value of zero sets the default,
+	// and a negative value value means there will be no timeout.
 	ApiReadTimeout Duration
-	// maximum number of connections
+	// ApiWriteTimeout sets the HTTP server's maximum duration before timing
+	// out writes of the response. A value of zero sets the default and a
+	// negative value value means there will be no timeout.
+	ApiWriteTimeout Duration
+	// MaxConnections is maximum number of simultaneous connections that the
+	// HTTP server will accept. A value of zero sets the default.
 	MaxConnections int
+	// Webpage is a domain to display when the homepage of the finder is
+	// accessed over HTTP.
+	Webpage string
 }
 
 func NewFinder() Finder {
 	return Finder{
-		ApiWriteTimeout: Duration(30 * time.Second),
 		ApiReadTimeout:  Duration(30 * time.Second),
+		ApiWriteTimeout: Duration(30 * time.Second),
 		MaxConnections:  8_000,
+		Webpage:         "https://web.cid.contact/",
 	}
 }
 
 // populateUnset replaces zero-values in the config with default values.
 func (f *Finder) populateUnset() {
 	def := NewFinder()
-	if f.ApiWriteTimeout == 0 {
-		f.ApiWriteTimeout = def.ApiWriteTimeout
-	}
 	if f.ApiReadTimeout == 0 {
 		f.ApiReadTimeout = def.ApiReadTimeout
 	}
+	if f.ApiWriteTimeout == 0 {
+		f.ApiWriteTimeout = def.ApiWriteTimeout
+	}
 	if f.MaxConnections == 0 {
 		f.MaxConnections = def.MaxConnections
+	}
+	if f.Webpage == "" {
+		f.Webpage = def.Webpage
 	}
 }

--- a/doc/config.md
+++ b/doc/config.md
@@ -66,6 +66,12 @@ config file at runtime.
     "RediscoverWait": "5m0s",
     "Timeout": "2m0s"
   },
+  "Finder": {
+    "ApiReadTimeout": "30s",
+    "ApiWriteTimeout": "30s",
+    "MaxConnections": 8000,
+    "Webpage": "https://web.cid.contact/"
+  },
   "Indexer": {
     "CacheSize": 300000,
     "ConfigCheckInterval": "30s",
@@ -73,7 +79,12 @@ config file at runtime.
     "GCTimeLimit": "5m0s",
     "ShutdownTimeout": "10s",
     "ValueStoreDir": "valuestore",
-    "ValueStoreType": "sth"
+    "ValueStoreType": "sth",
+    "STHBits": 24,
+    "STHBurstRate": 8388608,
+    "STHFileCacheSize": 512,
+    "STHSyncInterval": "1s",
+    "PebbleDisableWAL": false
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
@@ -196,6 +207,19 @@ Description: [Polling](https://pkg.go.dev/github.com/filecoin-project/storethein
 Default: There are no default `Discovery.PollOverrides` elements. These are created manually.
 
 See Example Config for example.
+
+## `Finder`
+Description: [Indexer](https://pkg.go.dev/github.com/filecoin-project/storetheindex/config#Finder)
+
+Default:
+```json
+"Finder": {
+  "ApiReadTimeout": "30s",
+  "ApiWriteTimeout": "30s",
+  "MaxConnections": 8000,
+  "Webpage": "https://web.cid.contact/"
+}
+```
 
 ## `Indexer`
 Description: [Indexer](https://pkg.go.dev/github.com/filecoin-project/storetheindex/config#Indexer)

--- a/server/finder/http/server.go
+++ b/server/finder/http/server.go
@@ -45,8 +45,10 @@ func New(listen string, indexer indexer.Interface, registry *registry.Registry, 
 		return nil, err
 	}
 
-	// Limit the number of open connections to the listener.
-	l = xnet.LimitListener(l, cfg.maxConns)
+	if cfg.maxConns > 0 {
+		// Limit the number of open connections to the listener.
+		l = xnet.LimitListener(l, cfg.maxConns)
+	}
 
 	// Resource handler
 	h := newHandler(indexer, registry)


### PR DESCRIPTION
- Document finder config settings
- Move `Addresses.FinderWebpage` to `Finder.Webpage`
