### PR TITLE
Include Bitswap providers with multiple transport in reframe response

### DIFF
--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/filecoin-project/storetheindex/api/v0/finder/model"
 	"github.com/filecoin-project/storetheindex/config"
 	"github.com/filecoin-project/storetheindex/internal/registry"
-	"github.com/filecoin-project/storetheindex/server/reframe"
 	"github.com/filecoin-project/storetheindex/test/util"
 	"github.com/ipfs/go-cid"
 	reframeclient "github.com/ipfs/go-delegated-routing/client"
@@ -91,7 +91,10 @@ func ReframeFindIndexTest(ctx context.Context, t *testing.T, c client.Finder, rc
 		t.Fatal(err)
 	}
 	ctxID := []byte("test-context-id")
-	metadata := reframe.BitswapMetadataBytes
+
+	// Use a sample metadata with multiple protocols that includes BitSwap
+	// among others to make a stronger test.
+	metadata, err := base64.StdEncoding.DecodeString("gBKQEqNoUGllY2VDSUTYKlgoAAGB4gOSICAYVAKmPqL1mpkiiDhd9iBaXoU/3rXorXxzjiyESP4hB2xWZXJpZmllZERlYWz0bUZhc3RSZXRyaWV2YWz1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/reframe/reframe.go
+++ b/server/reframe/reframe.go
@@ -58,7 +58,7 @@ func (x *ReframeService) FindProviders(ctx context.Context, key cid.Cid) (<-chan
 			continue
 		}
 		for _, pr := range mhr.ProviderResults {
-			if !isBitswapMetadata(pr.Metadata) {
+			if !containsTransportBitswap(pr.Metadata) {
 				continue
 			}
 			peerAddrs = append(peerAddrs, pr.Provider)
@@ -85,6 +85,10 @@ func (x *ReframeService) Provide(context.Context, *client.ProvideRequest) (<-cha
 
 var BitswapMetadataBytes = varint.ToUvarint(uint64(multicodec.TransportBitswap))
 
-func isBitswapMetadata(meta []byte) bool {
-	return bytes.Equal(meta, BitswapMetadataBytes)
+func containsTransportBitswap(meta []byte) bool {
+	// Metadata must be sorted according to the specification; see:
+	// - https://github.com/filecoin-project/index-provider/blob/main/metadata/metadata.go#L143
+	// This implies that if it includes Bitswap, its codec must appear at the beginning
+	// of the metadata value. Hence, bytes.HasPrefix.
+	return bytes.HasPrefix(meta, BitswapMetadataBytes)
 }


### PR DESCRIPTION
The reframe server implementation only returned providers that supported exactly one transport protocol in their metadata: `TransportBitswap`.

This implementation was added at the time where Provider record metadata did not support multiple transports. Later, when the feature was added in Metadata spec, the reframe server was not updated to reflect it.

The changes here fix the issue by checking if the metadata is prefixed with `TransportBitswap` codec and if so it will include the records in response. Check for prefix is sufficient here because, metadata bytes must be sorted by codec as stated by the network indexer protocol.

Fixes #977

