### PR TITLE
Spin down `tara` node in `prod`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -15,7 +15,6 @@ spec:
             - '--translateReframe'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
-            - '--backends=http://tara-indexer:3000/'
             - '--backends=http://vega-indexer:3000/'
             - '--backends=http://xabi-indexer:3000/'
             - '--backends=http://dido-indexer:3000/'

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/kustomization.yaml
@@ -7,6 +7,10 @@ resources:
   - ../../../../../../base/storetheindex-single
   - ingress.yaml
 
+replicas:
+  - name: indexer
+    count: 0
+
 namePrefix: tara-
 
 commonLabels:


### PR DESCRIPTION
`tara` in `prod` environment ran out of space yesterday around 1400 UTC, and currently is not ingesting any data. The node also suffers from corrupt index files which means respnses to find queries from this node are slower than other nodes which ultimately contributes to higher upstream latency at the indexstar ingress.

Spin down `tara` to zero replicas and exclude it from indexstar. Once spun down and after some cool-off period of few days remove this node completely along with its PVC.
