### PR TITLE
Track per-provider index counts and total

### DIFF
--- a/api/v0/finder/model/provider_info.go
+++ b/api/v0/finder/model/provider_info.go
@@ -14,12 +14,14 @@ type ProviderInfo struct {
 	LastAdvertisement     cid.Cid        `json:",omitempty"`
 	LastAdvertisementTime string         `json:",omitempty"`
 	Publisher             *peer.AddrInfo `json:",omitempty"`
+	IndexCount            uint64         `json:",omitempty"`
 }
 
-func MakeProviderInfo(addrInfo peer.AddrInfo, lastAd cid.Cid, lastAdTime time.Time, publisherID peer.ID, publisherAddr multiaddr.Multiaddr) ProviderInfo {
+func MakeProviderInfo(addrInfo peer.AddrInfo, lastAd cid.Cid, lastAdTime time.Time, publisherID peer.ID, publisherAddr multiaddr.Multiaddr, indexCount uint64) ProviderInfo {
 	pinfo := ProviderInfo{
 		AddrInfo:          addrInfo,
 		LastAdvertisement: lastAd,
+		IndexCount:        indexCount,
 	}
 
 	if publisherID.Validate() == nil && publisherAddr != nil {

--- a/command/providers.go
+++ b/command/providers.go
@@ -78,6 +78,11 @@ func listProvidersCmd(cctx *cli.Context) error {
 func showProviderInfo(pinfo *model.ProviderInfo) {
 	fmt.Println("Provider", pinfo.AddrInfo.ID)
 	fmt.Println("    Addresses:", pinfo.AddrInfo.Addrs)
-	fmt.Println("    LastAdvertisement:", pinfo.LastAdvertisement)
+	var adCidStr string
+	if pinfo.LastAdvertisement.Defined() {
+		adCidStr = pinfo.LastAdvertisement.String()
+	}
+	fmt.Println("    LastAdvertisement:", adCidStr)
 	fmt.Println("    LastAdvertisementTime:", pinfo.LastAdvertisementTime)
+	fmt.Println("    IndexCount:", pinfo.IndexCount)
 }

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -22,6 +22,10 @@ type Indexer struct {
 	// GCTimeLimit configures the maximum amount of time a garbage collection
 	// cycle may run.
 	GCTimeLimit Duration
+	// IndexCountTotalAddend is a value that is added to the index count total,
+	// to account for uncounted indexes that have existed in the value store
+	// before provider index counts were tracked. This value is reloadable.
+	IndexCountTotalAddend uint64
 	// ShutdownTimeout is the duration that a graceful shutdown has to complete
 	// before the daemon process is terminated. If unset or zero, configures no
 	// shutdown timeout. This value is reloadable.

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -256,6 +256,13 @@ func TestEndToEndWithReferenceProvider(t *testing.T) {
 		return nil
 	})
 
+	outProvider := e.run(indexer, "providers", "get", "-p", providerID, "--indexer", "localhost:3000")
+	// Check that IndexCount with correct value appears in providers output.
+	expect := "IndexCount: 1043"
+	if !strings.Contains(string(outProvider), expect) {
+		t.Errorf("expected provider to contains %q, got %q", expect, string(outProvider))
+	}
+
 	// Remove a car file from the provider.  This will cause the provider to
 	// publish an advertisement that tells the indexer to remove the car file
 	// content by contextID.  The indexer will then import the advertisement
@@ -283,6 +290,13 @@ func TestEndToEndWithReferenceProvider(t *testing.T) {
 		return nil
 	})
 
+	outProvider = e.run(indexer, "providers", "get", "-p", providerID, "--indexer", "localhost:3000")
+	// Check that IndexCount is back to zero after removing car.
+	expect = "IndexCount: 0"
+	if !strings.Contains(string(outProvider), expect) {
+		t.Errorf("expected provider to contains %q, got %q", expect, string(outProvider))
+	}
+
 	root2 := filepath.Join(e.dir, ".storetheindex2")
 	e.env = append(e.env, fmt.Sprintf("%s=%s", config.EnvDir, root2))
 	e.run(indexer, "init", "--store", "memory", "--pubsub-topic", "/indexer/ingest/mainnet", "--no-bootstrap",
@@ -309,6 +323,7 @@ func TestEndToEndWithReferenceProvider(t *testing.T) {
 	if !strings.Contains(string(outProviders), providerID) {
 		t.Errorf("expected provider id in providers output after import-providers, got %q", string(outProviders))
 	}
+
 	e.stop(cmdIndexer2, time.Second)
 
 	e.stop(cmdIndexer, time.Second)

--- a/internal/counter/index_counts.go
+++ b/internal/counter/index_counts.go
@@ -1,0 +1,348 @@
+package counter
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-varint"
+)
+
+var log = logging.Logger("indexer/counters")
+
+const (
+	// indexCountPrefix identifies all provider index counts.
+	indexCountPrefix = "/indexCounts/"
+)
+
+// IndexCounts persists multihash counts associated with provider ContextIDs.
+// It is not safe to allow concurrent calls to IndexCounts methods for the same
+// provider. Concurrent calls for different providers are safe.
+type IndexCounts struct {
+	ds datastore.Datastore
+	// mutex protexts counts and total.
+	mutex sync.Mutex
+	// counts is in-mem total index counts for each provider.
+	counts map[peer.ID]uint64
+	// total is in-mem total index count for all providers.
+	total uint64
+	// totalAddend is a value that gets added to the total.
+	totalAddend uint64
+}
+
+// NewIndexCounts creates a new IndexCounts given a Datastore.
+func NewIndexCounts(ds datastore.Datastore) *IndexCounts {
+	return &IndexCounts{
+		ds:     ds,
+		counts: make(map[peer.ID]uint64),
+	}
+}
+
+// SetTotalAddent sets a value that is added to the index count returned by
+// Total. Its purpose is to account for uncounted indexes that have existed
+// since before provider index counts were tracked. This only affects Total,
+// and does not affect any individual provider values.
+func (c *IndexCounts) SetTotalAddend(totalAddend uint64) {
+	c.mutex.Lock()
+	c.totalAddend = totalAddend
+	c.mutex.Unlock()
+}
+
+// AddCount adds the index count to the existing count for the for the
+// provider's context iD, and updates in-memory totals.
+func (c *IndexCounts) AddCount(providerID peer.ID, contextID []byte, count uint64) {
+	if count == 0 {
+		return
+	}
+
+	// Update in-mem values if they are present.
+	c.mutex.Lock()
+	prevCtxTotal, ok := c.counts[providerID]
+	if ok {
+		c.counts[providerID] = prevCtxTotal + count
+	}
+	if c.total != 0 {
+		c.total += count
+	}
+	c.mutex.Unlock()
+
+	key := makeIndexCountKey(providerID, contextID)
+
+	// Get any previous count for this contextID and add to it.
+	prevCtxCount, err := c.loadContextCount(context.Background(), key)
+	if err != nil {
+		return
+	}
+	err = c.ds.Put(context.Background(), key, varint.ToUvarint(prevCtxCount+count))
+	if err != nil {
+		log.Errorw("Cannot update index count", "err", err)
+	}
+}
+
+// AddMissingCount stores the count only if there is no existing count for the
+// provider's context ID, and updates in-memory totals.
+func (c *IndexCounts) AddMissingCount(providerID peer.ID, contextID []byte, count uint64) {
+	if count == 0 {
+		return
+	}
+
+	key := makeIndexCountKey(providerID, contextID)
+
+	has, err := c.ds.Has(context.Background(), key)
+	if err != nil {
+		log.Errorw("cannot load index count", "err", err)
+		return
+	}
+	if has {
+		return
+	}
+	err = c.ds.Put(context.Background(), key, varint.ToUvarint(count))
+	if err != nil {
+		log.Errorw("Cannot store index count", "err", err)
+	}
+
+	// Update in-mem values if they are present.
+	c.mutex.Lock()
+	prevCtxTotal, ok := c.counts[providerID]
+	if ok {
+		c.counts[providerID] = prevCtxTotal + count
+	}
+	if c.total != 0 {
+		c.total += count
+	}
+	c.mutex.Unlock()
+}
+
+// RemoveCtx removes the index count for a provider's contextID.
+func (c *IndexCounts) RemoveCtx(providerID peer.ID, contextID []byte) (uint64, error) {
+	key := makeIndexCountKey(providerID, contextID)
+
+	count, err := c.loadContextCount(context.Background(), key)
+	if derr := c.ds.Delete(context.Background(), key); derr != nil {
+		log.Errorw("Cannot delete index count", "err", derr)
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	// Update in-mem values if they are present.
+	c.mutex.Lock()
+	ptotal, ok := c.counts[providerID]
+	if ok {
+		if count < ptotal {
+			c.counts[providerID] = ptotal - count
+		} else {
+			if count > ptotal {
+				log.Error("Index count in data store is greater than in memory")
+				count = ptotal
+			}
+			delete(c.counts, providerID)
+		}
+	}
+	if c.total != 0 {
+		c.total -= count
+	}
+	c.mutex.Unlock()
+
+	return count, nil
+}
+
+// Provider reads all index counts for a provider.
+func (c *IndexCounts) Provider(providerID peer.ID) (uint64, error) {
+	// Return in-mem value if available.
+	c.mutex.Lock()
+	count, ok := c.counts[providerID]
+	c.mutex.Unlock()
+	if ok {
+		return count, nil
+	}
+
+	total, err := c.loadProvider(context.Background(), providerID)
+	if err != nil {
+		return 0, err
+	}
+
+	// Track value in memory.
+	c.mutex.Lock()
+	c.counts[providerID] = total
+	c.mutex.Unlock()
+
+	return total, nil
+}
+
+// Total returns the total of all index counts for all providers.
+func (c *IndexCounts) Total() (uint64, error) {
+	// Return in-mem value if available.
+	c.mutex.Lock()
+	count := c.total
+	total := count + c.totalAddend
+	c.mutex.Unlock()
+	if count != 0 {
+		return total, nil
+	}
+
+	q := query.Query{
+		Prefix: indexCountPrefix,
+	}
+	results, err := c.ds.Query(context.Background(), q)
+	if err != nil {
+		return 0, fmt.Errorf("cannot query index counts: %v", err)
+	}
+	defer results.Close()
+
+	for r := range results.Next() {
+		if r.Error != nil {
+			return 0, fmt.Errorf("cannot read index: %v", r.Error)
+		}
+		count, _, err = varint.FromUvarint(r.Entry.Value)
+		if err != nil {
+			log.Errorw("Cannot decode index count", "err", err)
+			continue
+		}
+
+		total += count
+	}
+
+	// Track value in memory.
+	c.mutex.Lock()
+	c.total = total
+	total += c.totalAddend
+	c.mutex.Unlock()
+
+	return total, nil
+}
+
+// RemoveProvider removes all index counts for a provider.
+func (c *IndexCounts) RemoveProvider(providerID peer.ID) uint64 {
+	var count uint64
+	var ok bool
+
+	c.mutex.Lock()
+	if len(c.counts) != 0 {
+		if c.total != 0 {
+			count, ok = c.counts[providerID]
+			if ok {
+				c.total -= count
+				delete(c.counts, providerID)
+			}
+		} else {
+			ok = true
+			delete(c.counts, providerID)
+		}
+	}
+	c.mutex.Unlock()
+
+	ctx := context.Background()
+	if !ok {
+		var err error
+		count, err = c.loadProvider(ctx, providerID)
+		if err != nil {
+			c.mutex.Lock()
+			c.total = 0
+			c.mutex.Unlock()
+			log.Errorw("Cannot load provider count", "err", err)
+		}
+
+		if count != 0 {
+			c.mutex.Lock()
+			if c.total != 0 {
+				c.total -= count
+			}
+			c.mutex.Unlock()
+		}
+	}
+
+	n, err := c.deletePrefix(ctx, indexCountPrefix+providerID.String())
+	if err != nil {
+		log.Errorw("Cannot delete provider contextID counts", "err", err)
+	} else {
+		log.Debugf("Removed %d contextID counts for provider", n)
+	}
+
+	return count
+}
+
+func (c *IndexCounts) loadContextCount(ctx context.Context, key datastore.Key) (uint64, error) {
+	data, err := c.ds.Get(context.Background(), key)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("cannot load index count: %w", err)
+	}
+	count, _, err := varint.FromUvarint(data)
+	if err != nil {
+		return 0, fmt.Errorf("cannot decode index count: %w", err)
+	}
+
+	return count, nil
+}
+
+func (c *IndexCounts) loadProvider(ctx context.Context, providerID peer.ID) (uint64, error) {
+	q := query.Query{
+		Prefix: indexCountPrefix + providerID.String(),
+	}
+	results, err := c.ds.Query(ctx, q)
+	if err != nil {
+		return 0, fmt.Errorf("cannot query all index counts: %v", err)
+	}
+	defer results.Close()
+
+	var total uint64
+	for r := range results.Next() {
+		if r.Error != nil {
+			return 0, fmt.Errorf("cannot read index: %v", r.Error)
+		}
+		count, _, err := varint.FromUvarint(r.Entry.Value)
+		if err != nil {
+			log.Errorw("Cannot decode index count", "err", err)
+			continue
+		}
+
+		total += count
+	}
+
+	return total, nil
+}
+
+func makeIndexCountKey(provider peer.ID, contextID []byte) datastore.Key {
+	var keyBuf strings.Builder
+	keyBuf.WriteString(indexCountPrefix)
+	keyBuf.WriteString(provider.String())
+	keyBuf.WriteString("/")
+	keyBuf.WriteString(base64.StdEncoding.EncodeToString(contextID))
+	return datastore.NewKey(keyBuf.String())
+}
+
+func (c *IndexCounts) deletePrefix(ctx context.Context, prefix string) (int, error) {
+	q := query.Query{
+		Prefix:   prefix,
+		KeysOnly: true,
+	}
+	results, err := c.ds.Query(ctx, q)
+	if err != nil {
+		return 0, err
+	}
+
+	var delKeys []string
+	for r := range results.Next() {
+		delKeys = append(delKeys, r.Entry.Key)
+	}
+	results.Close()
+
+	for _, key := range delKeys {
+		err = c.ds.Delete(ctx, datastore.NewKey(key))
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return len(delKeys), nil
+}

--- a/internal/counter/index_counts_test.go
+++ b/internal/counter/index_counts_test.go
@@ -1,0 +1,153 @@
+package counter_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/storetheindex/internal/counter"
+	"github.com/ipfs/go-datastore"
+	crypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexCounts(t *testing.T) {
+	providerPriv, _, err := test.RandTestKeyPair(crypto.Ed25519, 256)
+	require.NoError(t, err)
+	providerID1, err := peer.IDFromPrivateKey(providerPriv)
+	require.NoError(t, err)
+	providerPriv, _, err = test.RandTestKeyPair(crypto.Ed25519, 256)
+	require.NoError(t, err)
+	providerID2, err := peer.IDFromPrivateKey(providerPriv)
+	require.NoError(t, err)
+
+	c := counter.NewIndexCounts(datastore.NewMapDatastore())
+
+	ctxid1 := []byte("ctxid1")
+	ctxid2 := []byte("ctxid2")
+	ctxid3 := []byte("ctxid3")
+	ctxid4 := []byte("ctxid4")
+
+	c.AddCount(providerID1, ctxid1, 5)
+	c.AddCount(providerID1, ctxid2, 2)
+	c.AddCount(providerID1, ctxid3, 3)
+	total, err := c.Provider(providerID1)
+	require.NoError(t, err)
+	require.Equal(t, 10, int(total))
+
+	total, err = c.Total()
+	require.NoError(t, err)
+	require.Equal(t, 10, int(total))
+
+	c.AddCount(providerID2, ctxid4, 7)
+	total, err = c.Provider(providerID2)
+	require.NoError(t, err)
+	require.Equal(t, 7, int(total))
+
+	total, err = c.Total()
+	require.NoError(t, err)
+	require.Equal(t, 17, int(total))
+
+	count, err := c.RemoveCtx(providerID1, ctxid2)
+	require.NoError(t, err)
+	require.Equal(t, 2, int(count))
+
+	total, err = c.Provider(providerID1)
+	require.NoError(t, err)
+	require.Equal(t, 8, int(total))
+
+	total, err = c.Provider(providerID2)
+	require.NoError(t, err)
+	require.Equal(t, 7, int(total))
+
+	total, err = c.Total()
+	require.NoError(t, err)
+	require.Equal(t, 15, int(total))
+
+	// Remove context that provider does not have should change nothing.
+	count, err = c.RemoveCtx(providerID2, ctxid1)
+	require.NoError(t, err)
+	require.Zero(t, count)
+
+	total, err = c.Total()
+	require.NoError(t, err)
+	require.Equal(t, 15, int(total))
+
+	// Remove first provider.
+	count = c.RemoveProvider(providerID1)
+	require.Equal(t, 8, int(count))
+	count = c.RemoveProvider(providerID1)
+	require.Zero(t, int(count))
+
+	total, err = c.Total()
+	require.NoError(t, err)
+	require.Equal(t, 7, int(total))
+
+	// Remove the last provider.
+	count, err = c.RemoveCtx(providerID2, ctxid4)
+	require.NoError(t, err)
+	require.Equal(t, 7, int(count))
+
+	total, err = c.Total()
+	require.NoError(t, err)
+	require.Zero(t, total)
+
+	// Remove provider with total not yet in mem.
+	c = counter.NewIndexCounts(datastore.NewMapDatastore())
+	c.AddCount(providerID1, ctxid1, 5)
+	c.AddCount(providerID2, ctxid4, 7)
+	count = c.RemoveProvider(providerID1)
+	require.Equal(t, 5, int(count))
+
+	total, err = c.Total()
+	require.NoError(t, err)
+	require.Equal(t, 7, int(total))
+}
+
+func TestAddCount(t *testing.T) {
+	providerPriv, _, err := test.RandTestKeyPair(crypto.Ed25519, 256)
+	require.NoError(t, err)
+	providerID, err := peer.IDFromPrivateKey(providerPriv)
+	require.NoError(t, err)
+
+	c := counter.NewIndexCounts(datastore.NewMapDatastore())
+
+	ctxid1 := []byte("ctxid1")
+	ctxid2 := []byte("ctxid2")
+
+	c.AddCount(providerID, ctxid1, 5)
+	c.AddCount(providerID, ctxid2, 2)
+	total, err := c.Total()
+	require.NoError(t, err)
+	require.Equal(t, 7, int(total))
+
+	// Show that AddCount adds to existing value.
+	c.AddCount(providerID, ctxid2, 2)
+	total, err = c.Provider(providerID)
+	require.NoError(t, err)
+	require.Equal(t, 9, int(total))
+
+	c.AddCount(providerID, ctxid1, 3)
+	total, err = c.Provider(providerID)
+	require.NoError(t, err)
+	require.Equal(t, 12, int(total))
+
+	c.AddMissingCount(providerID, ctxid1, 5)
+	total, err = c.Provider(providerID)
+	require.NoError(t, err)
+	require.Equal(t, 12, int(total))
+
+	total, err = c.Total()
+	require.NoError(t, err)
+	require.Equal(t, 12, int(total))
+
+	ctxid3 := []byte("ctxid3")
+	c.AddMissingCount(providerID, ctxid3, 5)
+	total, err = c.Provider(providerID)
+	require.NoError(t, err)
+	require.Equal(t, 17, int(total))
+
+	total, err = c.Total()
+	require.NoError(t, err)
+	require.Equal(t, 17, int(total))
+}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -160,6 +160,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		if mhCount == 0 {
 			return
 		}
+
 		// Record how long entries sync took.
 		elapsed = now.Sub(entsSyncStart)
 		elapsedMsec = float64(elapsed.Nanoseconds()) / 1e6
@@ -213,11 +214,12 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		return adIngestError{adIngestRegisterProviderErr, fmt.Errorf("could not register/update provider info: %w", err)}
 	}
 
-	log = log.With("contextID", base64.StdEncoding.EncodeToString(ad.ContextID), "provider", providerID)
+	b64ContextID := base64.StdEncoding.EncodeToString(ad.ContextID)
+	log = log.With("contextID", b64ContextID, "provider", providerID)
 
 	if ad.IsRm {
 		log.Infow("Advertisement is for removal by context id")
-
+		ing.removeIndexCount(providerID, b64ContextID)
 		err = ing.indexer.RemoveProviderContext(providerID, ad.ContextID)
 		if err != nil {
 			return adIngestError{adIngestIndexerErr, fmt.Errorf("failed to remove provider context: %w", err)}
@@ -370,8 +372,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 			// TODO: See how we can refactor code to make batching logic more
 			// flexible in indexContentBlock.
 			if len(mhs) >= int(ing.batchSize) {
-				err := ing.indexAdMultihashes(ad, mhs, log)
-				if err != nil {
+				if err = ing.indexAdMultihashes(ad, mhs, log); err != nil {
 					return adIngestError{adIngestIndexerErr, fmt.Errorf("failed to index content from HAMT: %w", err)}
 				}
 				mhCount += len(mhs)
@@ -380,8 +381,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		}
 		// Process any remaining multihashes from the batch cut-off.
 		if len(mhs) > 0 {
-			err := ing.indexAdMultihashes(ad, mhs, log)
-			if err != nil {
+			if err = ing.indexAdMultihashes(ad, mhs, log); err != nil {
 				return adIngestError{adIngestIndexerErr, fmt.Errorf("failed to index content from HAMT: %w", err)}
 			}
 			mhCount += len(mhs)
@@ -444,6 +444,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 			}
 		}
 	}
+	ing.addIndexCount(providerID, b64ContextID, uint64(mhCount))
 	ing.signalMetricsUpdate()
 
 	if len(errsIngestingEntryChunks) > 0 {
@@ -480,16 +481,18 @@ func (ing *Ingester) ingestEntryChunk(ctx context.Context, ad schema.Advertiseme
 	return nil
 }
 
-// indexAdMultihashes indexes the content multihashes in a block of data. First
-// the advertisement is loaded to get the context ID and metadata. Then the
-// metadata and multihashes in the content block are indexed by the
-// indexer-core.
+// indexAdMultihashes indexes filters out invalid multihashed and indexes those
+// remaining in the indexer core.
 func (ing *Ingester) indexAdMultihashes(ad schema.Advertisement, mhs []multihash.Multihash, log *zap.SugaredLogger) error {
-	// Load the advertisement data for this chunk. If there are more chunks to
-	// follow, then cache the ad data.
-	value, isRm, err := getAdData(ad)
+	// Build indexer.Value from ad data.
+	providerID, err := peer.Decode(ad.Provider)
 	if err != nil {
 		return err
+	}
+	value := indexer.Value{
+		ProviderID:    providerID,
+		ContextID:     ad.ContextID,
+		MetadataBytes: ad.Metadata,
 	}
 
 	// Iterate over multihashes and remove bad ones.
@@ -524,17 +527,17 @@ func (ing *Ingester) indexAdMultihashes(ad schema.Advertisement, mhs []multihash
 		return nil
 	}
 
-	if isRm {
-		if err := ing.indexer.Remove(value, mhs...); err != nil {
-			return fmt.Errorf("cannot remove multihashes from indexer: %w", err)
-		}
-		log.Infow("Removed multihashes in entry chunk", "count", len(mhs))
-	} else {
-		if err := ing.indexer.Put(value, mhs...); err != nil {
-			return fmt.Errorf("cannot put multihashes into indexer: %w", err)
-		}
-		log.Infow("Put multihashes in entry chunk", "count", len(mhs))
+	// No code path should ever allow this, so it is a programming error if
+	// this ever happens.
+	if ad.IsRm {
+		panic("removing individual multihashes no allowed")
 	}
+
+	if err = ing.indexer.Put(value, mhs...); err != nil {
+		return fmt.Errorf("cannot put multihashes into indexer: %w", err)
+	}
+	log.Infow("Put multihashes in entry chunk", "count", len(mhs))
+
 	return nil
 }
 
@@ -581,21 +584,6 @@ func (ing *Ingester) loadNode(c cid.Cid, prototype ipld.NodePrototype) (ipld.Nod
 		return nil, fmt.Errorf("cannot fetch the node from datastore: %w", err)
 	}
 	return decodeIPLDNode(c.Prefix().Codec, bytes.NewBuffer(val), prototype)
-}
-
-func getAdData(ad schema.Advertisement) (value indexer.Value, isRm bool, err error) {
-	providerID, err := peer.Decode(ad.Provider)
-	if err != nil {
-		return indexer.Value{}, false, err
-	}
-
-	value = indexer.Value{
-		ProviderID:    providerID,
-		ContextID:     ad.ContextID,
-		MetadataBytes: ad.Metadata,
-	}
-
-	return value, ad.IsRm, nil
 }
 
 // decodeIPLDNode decodes an ipld.Node from bytes read from an io.Reader.

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -120,6 +120,7 @@ func Start(views []*view.View) http.Handler {
 		adIngestSuccess,
 		adLoadError,
 		mhStoreNanosecondsView,
+		indexCountView,
 	)
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -35,6 +35,7 @@ var (
 	ProviderCount        = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 	MhStoreNanoseconds   = stats.Int64("ingest/mhstorenanoseconds", "Average nanoseconds to store one multihash", stats.UnitDimensionless)
+	IndexCount           = stats.Int64("provider/indexCount", "Number of indexes stored for all providers", stats.UnitDimensionless)
 )
 
 // Views
@@ -92,6 +93,10 @@ var (
 	}
 	mhStoreNanosecondsView = &view.View{
 		Measure:     MhStoreNanoseconds,
+		Aggregation: view.LastValue(),
+	}
+	indexCountView = &view.View{
+		Measure:     IndexCount,
 		Aggregation: view.LastValue(),
 	}
 )

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -544,6 +544,7 @@ func (r *Registry) ProviderInfo(providerID peer.ID) (*ProviderInfo, bool) {
 	if pinfo == nil {
 		return nil, false
 	}
+
 	return pinfo, r.policy.Allowed(providerID)
 }
 

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -115,8 +115,16 @@ func (h *FinderHandler) ListProviders() ([]byte, error) {
 
 	responses := make([]model.ProviderInfo, len(infos))
 	for i := range infos {
+		var indexCount uint64
+		if h.indexCounts != nil {
+			var err error
+			indexCount, err = h.indexCounts.Provider(infos[i].AddrInfo.ID)
+			if err != nil {
+				log.Errorw("Could not get provider index count", "err", err)
+			}
+		}
 		responses[i] = model.MakeProviderInfo(infos[i].AddrInfo, infos[i].LastAdvertisement,
-			infos[i].LastAdvertisementTime, infos[i].Publisher, infos[i].PublisherAddr, 0)
+			infos[i].LastAdvertisementTime, infos[i].Publisher, infos[i].PublisherAddr, indexCount)
 	}
 
 	return json.Marshal(responses)

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/go-indexer-core"
 	v0 "github.com/filecoin-project/storetheindex/api/v0"
 	"github.com/filecoin-project/storetheindex/api/v0/finder/model"
+	"github.com/filecoin-project/storetheindex/internal/counter"
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -24,14 +25,16 @@ const avg_mh_size = 40
 // FinderHandler provides request handling functionality for the finder server
 // that is common to all protocols.
 type FinderHandler struct {
-	indexer  indexer.Interface
-	registry *registry.Registry
+	indexer     indexer.Interface
+	registry    *registry.Registry
+	indexCounts *counter.IndexCounts
 }
 
-func NewFinderHandler(indexer indexer.Interface, registry *registry.Registry) *FinderHandler {
+func NewFinderHandler(indexer indexer.Interface, registry *registry.Registry, indexCounts *counter.IndexCounts) *FinderHandler {
 	return &FinderHandler{
-		indexer:  indexer,
-		registry: registry,
+		indexer:     indexer,
+		registry:    registry,
+		indexCounts: indexCounts,
 	}
 }
 
@@ -113,7 +116,7 @@ func (h *FinderHandler) ListProviders() ([]byte, error) {
 	responses := make([]model.ProviderInfo, len(infos))
 	for i := range infos {
 		responses[i] = model.MakeProviderInfo(infos[i].AddrInfo, infos[i].LastAdvertisement,
-			infos[i].LastAdvertisementTime, infos[i].Publisher, infos[i].PublisherAddr)
+			infos[i].LastAdvertisementTime, infos[i].Publisher, infos[i].PublisherAddr, 0)
 	}
 
 	return json.Marshal(responses)
@@ -125,7 +128,15 @@ func (h *FinderHandler) GetProvider(providerID peer.ID) ([]byte, error) {
 		return nil, nil
 	}
 
-	rsp := model.MakeProviderInfo(info.AddrInfo, info.LastAdvertisement, info.LastAdvertisementTime, info.Publisher, info.PublisherAddr)
+	var indexCount uint64
+	if h.indexCounts != nil {
+		var err error
+		indexCount, err = h.indexCounts.Provider(providerID)
+		if err != nil {
+			log.Errorw("Could not get provider index count", "err", err)
+		}
+	}
+	rsp := model.MakeProviderInfo(info.AddrInfo, info.LastAdvertisement, info.LastAdvertisementTime, info.Publisher, info.PublisherAddr, indexCount)
 
 	return json.Marshal(&rsp)
 }

--- a/server/finder/http/handler.go
+++ b/server/finder/http/handler.go
@@ -11,6 +11,7 @@ import (
 	indexer "github.com/filecoin-project/go-indexer-core"
 	coremetrics "github.com/filecoin-project/go-indexer-core/metrics"
 	"github.com/filecoin-project/storetheindex/api/v0/finder/model"
+	"github.com/filecoin-project/storetheindex/internal/counter"
 	"github.com/filecoin-project/storetheindex/internal/httpserver"
 	"github.com/filecoin-project/storetheindex/internal/metrics"
 	"github.com/filecoin-project/storetheindex/internal/registry"
@@ -29,9 +30,9 @@ type httpHandler struct {
 	finderHandler *handler.FinderHandler
 }
 
-func newHandler(indexer indexer.Interface, registry *registry.Registry) *httpHandler {
+func newHandler(indexer indexer.Interface, registry *registry.Registry, indexCounts *counter.IndexCounts) *httpHandler {
 	return &httpHandler{
-		finderHandler: handler.NewFinderHandler(indexer, registry),
+		finderHandler: handler.NewFinderHandler(indexer, registry, indexCounts),
 	}
 }
 

--- a/server/finder/http/options.go
+++ b/server/finder/http/options.go
@@ -3,6 +3,8 @@ package httpfinderserver
 import (
 	"fmt"
 	"time"
+
+	"github.com/filecoin-project/storetheindex/internal/counter"
 )
 
 const (
@@ -18,6 +20,7 @@ type serverConfig struct {
 	apiReadTimeout  time.Duration
 	maxConns        int
 	homepageURL     string
+	indexCounts     *counter.IndexCounts
 }
 
 // ServerOption for httpserver
@@ -76,6 +79,13 @@ func MaxConnections(maxConnections int) ServerOption {
 func WithHomepage(URL string) ServerOption {
 	return func(c *serverConfig) error {
 		c.homepageURL = URL
+		return nil
+	}
+}
+
+func WithIndexCounts(indexCounts *counter.IndexCounts) ServerOption {
+	return func(c *serverConfig) error {
+		c.indexCounts = indexCounts
 		return nil
 	}
 }

--- a/server/finder/http/server.go
+++ b/server/finder/http/server.go
@@ -51,7 +51,7 @@ func New(listen string, indexer indexer.Interface, registry *registry.Registry, 
 	}
 
 	// Resource handler
-	h := newHandler(indexer, registry)
+	h := newHandler(indexer, registry, cfg.indexCounts)
 
 	// Compile index template.
 	t, err := template.ParseFS(webUI, "index.html")

--- a/server/finder/libp2p/handler.go
+++ b/server/finder/libp2p/handler.go
@@ -13,6 +13,7 @@ import (
 	v0 "github.com/filecoin-project/storetheindex/api/v0"
 	"github.com/filecoin-project/storetheindex/api/v0/finder/model"
 	pb "github.com/filecoin-project/storetheindex/api/v0/finder/pb"
+	"github.com/filecoin-project/storetheindex/internal/counter"
 	"github.com/filecoin-project/storetheindex/internal/libp2pserver"
 	"github.com/filecoin-project/storetheindex/internal/metrics"
 	"github.com/filecoin-project/storetheindex/internal/registry"
@@ -35,9 +36,9 @@ type libp2pHandler struct {
 // handlerFunc is the function signature required by handlers in this package
 type handlerFunc func(context.Context, peer.ID, *pb.FinderMessage) ([]byte, error)
 
-func newHandler(indexer indexer.Interface, registry *registry.Registry) *libp2pHandler {
+func newHandler(indexer indexer.Interface, registry *registry.Registry, indexCounts *counter.IndexCounts) *libp2pHandler {
 	return &libp2pHandler{
-		finderHandler: handler.NewFinderHandler(indexer, registry),
+		finderHandler: handler.NewFinderHandler(indexer, registry, indexCounts),
 	}
 }
 

--- a/server/finder/libp2p/server.go
+++ b/server/finder/libp2p/server.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	indexer "github.com/filecoin-project/go-indexer-core"
+	"github.com/filecoin-project/storetheindex/internal/counter"
 	"github.com/filecoin-project/storetheindex/internal/libp2pserver"
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	"github.com/libp2p/go-libp2p/core/host"
 )
 
 // New creates a new libp2p server
-func New(ctx context.Context, h host.Host, indexer indexer.Interface, registry *registry.Registry) *libp2pserver.Server {
-	return libp2pserver.New(ctx, h, newHandler(indexer, registry))
+func New(ctx context.Context, h host.Host, indexer indexer.Interface, registry *registry.Registry, indexCounts *counter.IndexCounts) *libp2pserver.Server {
+	return libp2pserver.New(ctx, h, newHandler(indexer, registry, indexCounts))
 }

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -270,6 +270,9 @@ func GetProviderTest(t *testing.T, c client.Finder, providerID peer.ID) {
 	if provInfo.AddrInfo.ID != providerID {
 		t.Fatal("wrong peer id")
 	}
+	if provInfo.IndexCount != 939 {
+		t.Fatal("expected IndexCount to be 939, got", provInfo.IndexCount)
+	}
 }
 
 func ListProvidersTest(t *testing.T, c client.Finder, providerID peer.ID) {

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -85,7 +85,7 @@ func init() {
 		panic(err)
 	}
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds)
+	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -71,7 +71,7 @@ func InitIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *i
 		t.Fatal(err)
 	}
 
-	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds)
+	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/reframe/reframe.go
+++ b/server/reframe/reframe.go
@@ -25,7 +25,7 @@ import (
 )
 
 func NewReframeHTTPHandler(indexer indexer.Interface, registry *registry.Registry) http.HandlerFunc {
-	return server.DelegatedRoutingAsyncHandler(NewReframeService(handler.NewFinderHandler(indexer, registry)))
+	return server.DelegatedRoutingAsyncHandler(NewReframeService(handler.NewFinderHandler(indexer, registry, nil)))
 }
 
 func NewReframeService(fh *handler.FinderHandler) *ReframeService {


### PR DESCRIPTION
Keep track of the number of indexes stored for each provider. For each provider, store a map of contextID to number of associated multihashes. When that context ID is removed, remove the entry from the map.  Get the total number of multihashes for a provider by summing all the counts for their contextIDs. Get the total stored index count by summing all counts for all contextIDs for all providers.

Counts are cached in memory after the first time they are retrieved.

- New config value `Indexer.IndexCountTotalAddend `. This is a value that is added to the index count total, to account for uncounted indexes that have existed in the value store before provider index counts were tracked. This value is reloadable.

Follow-up PR can supply metric histogram showing relative index contributions from all providers. 

Other Changes:
- Move index counters to separate package
- `/providers/{providerID}` API reports provider index count
- Unit and e2e tests for index counts
- IndexCounts works with both new sync and resync

Addresses #982