### PR TITLE
Upgrade to the latest CSI controller on dev

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/aws-ebs-csi-driver/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/aws-ebs-csi-driver/kustomization.yaml
@@ -2,7 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../../../base/aws-ebs-csi-driver
+  # Deploy upgrade to dev for testing before changing the base which will impact both dev and prod.
+  #  - ../../../../base/aws-ebs-csi-driver
+  - github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable?ref=v1.12.1
+
 
 patchesStrategicMerge:
   - patch.yaml


### PR DESCRIPTION
Upgrade to the latest CSI controller to take advantage of fixes and Snapshot support. Deploy first on `dev` only to test out any conflicts before changing the base overlay which will impact both dev and prod.

Relates to #891
