### PR TITLE
Expand `vega` PVC to 40Ti

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/pvc.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 20Ti
+      storage: 40Ti
   storageClassName: io2-iops5


### PR DESCRIPTION
The node is at 100% utilisation, having grown around 50% over the last 7 days.

Potentially related to #826.
