### PR TITLE
Upgrade CSI driver and install external snapshotter on `prod`

### DIFF
--- a/deploy/manifests/base/aws-ebs-csi-driver/kustomization.yaml
+++ b/deploy/manifests/base/aws-ebs-csi-driver/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable?ref=v1.5.1
+  - github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable?ref=v1.12.1

--- a/deploy/manifests/dev/us-east-2/cluster/aws-ebs-csi-driver/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/aws-ebs-csi-driver/kustomization.yaml
@@ -2,9 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  # Deploy upgrade to dev for testing before changing the base which will impact both dev and prod.
-  #  - ../../../../base/aws-ebs-csi-driver
-  - github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable?ref=v1.12.1
+  - ../../../../base/aws-ebs-csi-driver
 
 
 patchesStrategicMerge:

--- a/deploy/manifests/prod/us-east-2/cluster/external-snapshotter/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/external-snapshotter/kustomization.yaml
@@ -2,6 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - aws-auth.yaml
-  - io2-storage-class.yaml
-  - volume-snapshot-class.yaml
+  - ../../../../base/external-snapshotter

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/volume-snapshot-class.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/volume-snapshot-class.yaml
@@ -1,0 +1,6 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-aws-vsc
+driver: ebs.csi.aws.com
+deletionPolicy: Delete

--- a/deploy/manifests/prod/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - monitoring
   - aws-ebs-csi-driver
   - promtail
+  - external-snapshotter


### PR DESCRIPTION
Upgrade to the latest CSI driver on `prod` now that it have been tested on `dev` and deploy external snapshotter on `prod` so that we can take snapshot of existing node's PVC and mount it as the state of new nodes. This then would reduce time spent on catching up as well as making testing on real data much easier.

Fixes #890
Fixes #891
