### PR TITLE
Route HTTP announce requests to `kepa` for further propagation

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -55,7 +55,7 @@ module "eks" {
     }
     prod-ue2b-r5b-4xl = {
       min_size       = 1
-      max_size       = 4
+      max_size       = 5
       desired_size   = 1
       instance_types = ["r5b.4xlarge"]
       subnet_ids     = [data.aws_subnet.ue2b1.id]

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -93,8 +93,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/indexer-0.indexer/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor",
-      "/dns4/indexer-1.indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
+      "/dns4/kepa-indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
     ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/deployment.yaml
@@ -28,3 +28,8 @@ spec:
                     operator: In
                     values:
                       - us-east-2b
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b-4xl
+          effect: NoSchedule

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -100,8 +100,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/indexer-0.indexer/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor",
-      "/dns4/indexer-1.indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
+      "/dns4/kepa-indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
     ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/romi/config.json
@@ -98,8 +98,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/indexer-0.indexer/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor",
-      "/dns4/indexer-1.indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
+      "/dns4/kepa-indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
     ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/tara/config.json
@@ -103,8 +103,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/indexer-0.indexer/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor",
-      "/dns4/indexer-1.indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
+      "/dns4/kepa-indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
     ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/config.json
@@ -106,8 +106,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/indexer-0.indexer/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor",
-      "/dns4/indexer-1.indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
+      "/dns4/kepa-indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
     ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/config.json
@@ -96,8 +96,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/indexer-0.indexer/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor",
-      "/dns4/indexer-1.indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
+      "/dns4/kepa-indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
     ]
   }
 }


### PR DESCRIPTION
Now that `indexer-1` is retried, and `indexer-0` is on its way to be no longer, change the cloudfront routing to send all requests at `/ingest*` to `kepa`. That node has the whitelisted peer ID on Lotus Bootstrap nodes and is configured to propagate HTTP requests onto gossipsub network for other indexer nodes. To reflect this change the node peering configuration is also changed to connect to `kepa` instead of the old instances.

The changes here also include increasing the max ASG for a node group used to run indexer nodes just to have 1 node headroom, and adds missing taints to `kepa` deployment object missed in earlier PR.

The work also removes a duplicate domain entry in ACM subject alternative names to avoid redundant changes to the terraform state when it is applied, since AWS removes the duplicates automatically and causes the terraform state to be inconsistent with actual infrastructure state.

