### PR TITLE
Deploy fixes to provider exclusion on `oden`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20221021183253-9df396fbbc40ca634872a47acae5a6b4008cf2e1
+    newTag: 20221021183253-db83b7c9fab3615621063378fdda568c6e8ba209


### PR DESCRIPTION
The fix to provider exclusion heuristic was not deploeyd on `oden`. As a result it seems to stop fetching from nft.storage and mark the provider as inactive.

Deploy the same vesion as `dido` on `oden`.
