### PR TITLE
Expand `xabi` PVC to `60`Ti

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/xabi/pvc.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 40Ti
+      storage: 60Ti
   storageClassName: io2-iops5


### PR DESCRIPTION
`xabi` has fully utilised its disk; expand it to 60Ti.
