### PR TITLE
Add Extended Providers implementation

### DIFF
--- a/api/v0/ingest/schema/envelope.go
+++ b/api/v0/ingest/schema/envelope.go
@@ -19,6 +19,7 @@ var log = logging.Logger("indexer/schema")
 const (
 	adSignatureCodec  = "/indexer/ingest/adSignature"
 	adSignatureDomain = "indexer"
+	epSignatureCodec  = "/indexer/ingest/extendedProviderSignature"
 )
 
 type advSignatureRecord struct {
@@ -47,6 +48,35 @@ func (r *advSignatureRecord) MarshalRecord() ([]byte, error) {
 
 func (r *advSignatureRecord) UnmarshalRecord(buf []byte) error {
 	r.advID = buf
+	return nil
+}
+
+type epSignatureRecord struct {
+	domain  *string
+	codec   []byte
+	payload []byte
+}
+
+func (r *epSignatureRecord) Domain() string {
+	if r.domain != nil {
+		return *r.domain
+	}
+	return adSignatureDomain
+}
+
+func (r *epSignatureRecord) Codec() []byte {
+	if r.codec != nil {
+		return r.codec
+	}
+	return []byte(epSignatureCodec)
+}
+
+func (r *epSignatureRecord) MarshalRecord() ([]byte, error) {
+	return r.payload, nil
+}
+
+func (r *epSignatureRecord) UnmarshalRecord(buf []byte) error {
+	r.payload = buf
 	return nil
 }
 
@@ -89,8 +119,62 @@ func signaturePayload(ad *Advertisement, oldFormat bool) ([]byte, error) {
 	return multihash.Sum(sigBuf.Bytes(), multihash.SHA2_256, -1)
 }
 
+// extendedSignaturePayload generates the data payload used to compute the signature for a provider from the ExtendedProviders list.
+// This payload *doesn't* contain enough information to sign the ad itself.
+func extendedProviderSignaturePayload(ad *Advertisement, p *Provider) ([]byte, error) {
+	if ad.IsRm {
+		return nil, fmt.Errorf("rm ads are not supported for extended provider signatures")
+	}
+
+	bindex := cid.Undef.Bytes()
+	if ad.PreviousID != nil {
+		bindex = ad.PreviousID.(cidlink.Link).Cid.Bytes()
+	}
+	ent := ad.Entries.(cidlink.Link).Cid.Bytes()
+
+	// Extended signature is an authrorisation for the publisher of the main Ad to publish on behalf of the signee.
+	// For more details see https://github.com/filecoin-project/storetheindex/pull/804/files
+	// The signature must contain the following fields:
+	// - the main provider's identity
+	// - the signee's identity addrs and metadata so that they can't be misrepresented
+	// - contextID and override flag as they change the behaviour of how extended providers are interpreted (see the spec)
+
+	var sigBuf bytes.Buffer
+
+	var addrsLen int
+	for _, addr := range p.Addresses {
+		addrsLen += len(addr)
+	}
+
+	sigBuf.Grow(len(bindex) + len(ent) + len(ad.Provider) + len(ad.ContextID) + len(p.ID) + addrsLen + len(p.Metadata) + 1)
+	sigBuf.Write(bindex)
+	sigBuf.Write(ent)
+	sigBuf.WriteString(ad.Provider)
+	sigBuf.Write(ad.ContextID)
+	sigBuf.WriteString(p.ID)
+	for _, addr := range p.Addresses {
+		sigBuf.WriteString(addr)
+	}
+	sigBuf.Write(p.Metadata)
+	if ad.ExtendedProvider.Override {
+		sigBuf.WriteByte(1)
+	} else {
+		sigBuf.WriteByte(0)
+	}
+
+	return multihash.Sum(sigBuf.Bytes(), multihash.SHA2_256, -1)
+}
+
 // Sign signs an advertisement using the given private key.
+// This function will return an error if used to sign an ad with extended providers.
 func (ad *Advertisement) Sign(key crypto.PrivKey) error {
+	if ad.ExtendedProvider != nil {
+		return fmt.Errorf("the ad can not be signed because it has extended providers")
+	}
+	return ad.signAd(key)
+}
+
+func (ad *Advertisement) signAd(key crypto.PrivKey) error {
 	advID, err := signaturePayload(ad, false)
 	if err != nil {
 		return err
@@ -108,12 +192,68 @@ func (ad *Advertisement) Sign(key crypto.PrivKey) error {
 	return nil
 }
 
+// SignWithExtendedProviders signs an advertisement by the main provider as well as by all extended providers if they are present.
+func (ad *Advertisement) SignWithExtendedProviders(key crypto.PrivKey, extendedProviderKeyFetcher func(string) (crypto.PrivKey, error)) error {
+	err := ad.signAd(key)
+	if err != nil {
+		return err
+	}
+
+	if ad.ExtendedProvider == nil {
+		return nil
+	}
+
+	seenTopLevelProvider := false
+
+	for i := range ad.ExtendedProvider.Providers {
+		p := &ad.ExtendedProvider.Providers[i]
+		if p.ID == ad.Provider {
+			seenTopLevelProvider = true
+		}
+
+		payload, err := extendedProviderSignaturePayload(ad, p)
+		if err != nil {
+			return err
+		}
+
+		var privKey crypto.PrivKey
+		if p.ID == ad.Provider {
+			privKey = key
+		} else {
+			privKey, err = extendedProviderKeyFetcher(p.ID)
+			if err != nil {
+				return err
+			}
+		}
+
+		envelope, err := record.Seal(&epSignatureRecord{payload: payload}, privKey)
+		if err != nil {
+			return err
+		}
+
+		sig, err := envelope.Marshal()
+		if err != nil {
+			return err
+		}
+
+		p.Signature = sig
+	}
+
+	if !seenTopLevelProvider && len(ad.ExtendedProvider.Providers) > 0 {
+		return fmt.Errorf("extended providers must contain provider from the encapsulating advertisement")
+	}
+
+	return nil
+}
+
 // VerifySignature verifies that the advertisement has been signed and
 // generated correctly.  Returns the peer ID of the signer.
 //
 // The signer may be different than the provider ID in the advertisement, so
 // the caller will need to check if the signer is allowed to sign this
 // advertisement.
+//
+// Extended providers signatures are also verified.
 func (ad *Advertisement) VerifySignature() (peer.ID, error) {
 	// sigSize is the size of the current signature.  Any signature that is not
 	// this size is the old signature format.
@@ -148,6 +288,38 @@ func (ad *Advertisement) VerifySignature() (peer.ID, error) {
 
 	if oldFormat {
 		log.Warnw("advertisement has deprecated signature format", "signer", signerID)
+	}
+
+	if ad.ExtendedProvider != nil {
+		rec := &epSignatureRecord{}
+		// The top level provider must appear in the list of extended providers otherwise the ad is considered invalid
+		seenTopLevelProv := false
+		for _, p := range ad.ExtendedProvider.Providers {
+
+			_, err = record.ConsumeTypedEnvelope(p.Signature, rec)
+			if err != nil {
+				return "", err
+			}
+
+			// Calculate our signature payload
+			genPayload, err := extendedProviderSignaturePayload(ad, &p)
+			if err != nil {
+				return "", err
+			}
+
+			// Check that our own hash is equal to the hash from the signature.
+			if !bytes.Equal(genPayload, rec.payload) {
+				return "", errors.New("invalid signature")
+			}
+
+			if p.ID == ad.Provider {
+				seenTopLevelProv = true
+			}
+		}
+
+		if !seenTopLevelProv && len(ad.ExtendedProvider.Providers) > 0 {
+			return "", fmt.Errorf("extended providers must contain provider from the encapsulating advertisement")
+		}
 	}
 
 	return signerID, nil

--- a/api/v0/ingest/schema/envelope_test.go
+++ b/api/v0/ingest/schema/envelope_test.go
@@ -1,8 +1,10 @@
 package schema_test
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	stischema "github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/filecoin-project/storetheindex/test/util"
@@ -17,7 +19,21 @@ import (
 )
 
 func TestAdvertisement_SignAndVerify(t *testing.T) {
-	rng := rand.New(rand.NewSource(1413))
+	testSignAndVerify(t, func(a *stischema.Advertisement, pk crypto.PrivKey) error {
+		return a.Sign(pk)
+	})
+}
+
+func TestAdWithoutExtendedProvidersCanBeSignedAndVerified(t *testing.T) {
+	testSignAndVerify(t, func(a *stischema.Advertisement, pk crypto.PrivKey) error {
+		return a.SignWithExtendedProviders(pk, func(s string) (crypto.PrivKey, error) {
+			return nil, fmt.Errorf("there are no extended providers")
+		})
+	})
+}
+
+func testSignAndVerify(t *testing.T, signer func(*stischema.Advertisement, crypto.PrivKey) error) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
 	lsys := cidlink.DefaultLinkSystem()
 	store := &memstore.Store{}
 	lsys.SetReadStorage(store)
@@ -46,7 +62,7 @@ func TestAdvertisement_SignAndVerify(t *testing.T) {
 		ContextID: []byte("test-context-id"),
 		Metadata:  []byte("test-metadata"),
 	}
-	err = adv.Sign(priv)
+	err = signer(&adv, priv)
 	require.NoError(t, err)
 
 	signerID, err := adv.VerifySignature()
@@ -64,4 +80,305 @@ func TestAdvertisement_SignAndVerify(t *testing.T) {
 	adv.Provider = ""
 	_, err = adv.VerifySignature()
 	require.NotNil(t, err)
+}
+
+func TestSignShouldFailIfAdHasExtendedProviders(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	lsys := cidlink.DefaultLinkSystem()
+	store := &memstore.Store{}
+	lsys.SetReadStorage(store)
+	lsys.SetWriteStorage(store)
+
+	priv, pub, err := test.RandTestKeyPair(crypto.Ed25519, 256)
+	require.NoError(t, err)
+	peerID, err := peer.IDFromPublicKey(pub)
+	require.NoError(t, err)
+
+	ec := stischema.EntryChunk{
+		Entries: util.RandomMultihashes(10, rng),
+	}
+
+	node, err := ec.ToNode()
+	require.NoError(t, err)
+	elnk, err := lsys.Store(ipld.LinkContext{}, stischema.Linkproto, node)
+	require.NoError(t, err)
+
+	_, ep1PeerID := generateIdentityAndKey(t)
+
+	adv := stischema.Advertisement{
+		Provider: peerID.String(),
+		Addresses: []string{
+			"/ip4/127.0.0.1/tcp/9999",
+		},
+		Entries:   elnk,
+		ContextID: []byte("test-context-id"),
+		Metadata:  []byte("test-metadata"),
+		ExtendedProvider: &stischema.ExtendedProvider{
+			Providers: []stischema.Provider{
+				{
+					ID:        ep1PeerID.String(),
+					Addresses: randomAddrs(2),
+					Metadata:  []byte("ep1-metadata"),
+				},
+			},
+		},
+	}
+	err = adv.Sign(priv)
+	require.Error(t, err, "the ad can not be signed because it has extended providers")
+}
+
+func TestSignWithExtendedProviderAndVerify(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	lsys := cidlink.DefaultLinkSystem()
+	store := &memstore.Store{}
+	lsys.SetReadStorage(store)
+	lsys.SetWriteStorage(store)
+
+	ec := stischema.EntryChunk{
+		Entries: util.RandomMultihashes(10, rng),
+	}
+
+	node, err := ec.ToNode()
+	require.NoError(t, err)
+	elnk, err := lsys.Store(ipld.LinkContext{}, stischema.Linkproto, node)
+	require.NoError(t, err)
+
+	ep1Priv, ep1PeerID := generateIdentityAndKey(t)
+	ep2Priv, ep2PeerID := generateIdentityAndKey(t)
+	mpPriv, mpPeerID := generateIdentityAndKey(t)
+	mpAddrs := randomAddrs(2)
+
+	adv := stischema.Advertisement{
+		Provider:  mpPeerID.String(),
+		Addresses: mpAddrs,
+		Entries:   elnk,
+		ContextID: []byte("test-context-id"),
+		Metadata:  []byte("test-metadata"),
+		ExtendedProvider: &stischema.ExtendedProvider{
+			Providers: []stischema.Provider{
+				{
+					ID:        ep1PeerID.String(),
+					Addresses: randomAddrs(2),
+					Metadata:  []byte("ep1-metadata"),
+				},
+				{
+					ID:        ep2PeerID.String(),
+					Addresses: randomAddrs(2),
+					Metadata:  []byte("ep2-metadata"),
+				},
+				{
+					ID:        mpPeerID.String(),
+					Addresses: mpAddrs,
+					Metadata:  []byte("main-metadata"),
+				},
+			},
+		},
+	}
+
+	err = adv.SignWithExtendedProviders(mpPriv, func(p string) (crypto.PrivKey, error) {
+		switch p {
+		case ep1PeerID.String():
+			return ep1Priv, nil
+		case ep2PeerID.String():
+			return ep2Priv, nil
+		default:
+			return nil, fmt.Errorf("Unknown provider %s", p)
+		}
+	})
+
+	require.NoError(t, err)
+
+	signerID, err := adv.VerifySignature()
+	require.NoError(t, err)
+	require.Equal(t, mpPeerID, signerID)
+	require.Equal(t, signerID, mpPeerID)
+}
+
+func TestSigVerificationFailsIfTheAdProviderIdentityIsIncorrect(t *testing.T) {
+	extendedSignatureTest(t, func(adv stischema.Advertisement) {
+		_, randomID := generateIdentityAndKey(t)
+		adv.Provider = randomID.String()
+		_, err := adv.VerifySignature()
+		require.Error(t, err)
+	})
+}
+
+func TestSigVerificationFailsIfTheExtendedProviderIdentityIsIncorrect(t *testing.T) {
+	extendedSignatureTest(t, func(adv stischema.Advertisement) {
+		// main provider is the first one on the list
+		_, randomID := generateIdentityAndKey(t)
+		adv.ExtendedProvider.Providers[1].ID = randomID.String()
+		_, err := adv.VerifySignature()
+		require.Error(t, err)
+	})
+}
+
+func TestSigVerificationFailsIfTheExtendedProviderMetadataIsIncorrect(t *testing.T) {
+	extendedSignatureTest(t, func(adv stischema.Advertisement) {
+		rng := rand.New(rand.NewSource(time.Now().Unix()))
+		meta := make([]byte, 10)
+		rng.Read(meta)
+		adv.ExtendedProvider.Providers[1].Metadata = meta
+		_, err := adv.VerifySignature()
+		require.Error(t, err)
+	})
+}
+
+func TestSigVerificationFailsIfTheExtendedProviderAddrsAreIncorrect(t *testing.T) {
+	extendedSignatureTest(t, func(adv stischema.Advertisement) {
+		adv.ExtendedProvider.Providers[1].Addresses = randomAddrs(10)
+		_, err := adv.VerifySignature()
+		require.Error(t, err)
+	})
+}
+
+func TestSigVerificationFailsIfOverrideIsIncorrect(t *testing.T) {
+	extendedSignatureTest(t, func(adv stischema.Advertisement) {
+		adv.ExtendedProvider.Override = !adv.ExtendedProvider.Override
+		_, err := adv.VerifySignature()
+		require.Error(t, err)
+	})
+}
+
+func TestSigVerificationFailsIfContextIDIsIncorrect(t *testing.T) {
+	extendedSignatureTest(t, func(adv stischema.Advertisement) {
+		adv.ContextID = []byte("ABC")
+		_, err := adv.VerifySignature()
+		require.Error(t, err)
+	})
+}
+
+func TestSigVerificationFailsIfMainProviderIsNotInExtendedList(t *testing.T) {
+	extendedSignatureTest(t, func(adv stischema.Advertisement) {
+		// main provider is the first one on the list
+		adv.ExtendedProvider.Providers = adv.ExtendedProvider.Providers[1:]
+		_, err := adv.VerifySignature()
+		require.Error(t, err)
+		require.Equal(t, "extended providers must contain provider from the encapsulating advertisement", err.Error())
+	})
+}
+
+func TestSignFailsIfMainProviderIsNotInExtendedList(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	lsys := cidlink.DefaultLinkSystem()
+	store := &memstore.Store{}
+	lsys.SetReadStorage(store)
+	lsys.SetWriteStorage(store)
+
+	ec := stischema.EntryChunk{
+		Entries: util.RandomMultihashes(10, rng),
+	}
+
+	node, err := ec.ToNode()
+	require.NoError(t, err)
+	elnk, err := lsys.Store(ipld.LinkContext{}, stischema.Linkproto, node)
+	require.NoError(t, err)
+
+	ep1Priv, ep1PeerID := generateIdentityAndKey(t)
+	mpPriv, mpPeerID := generateIdentityAndKey(t)
+	mpAddrs := randomAddrs(2)
+
+	adv := stischema.Advertisement{
+		Provider:  mpPeerID.String(),
+		Addresses: mpAddrs,
+		Entries:   elnk,
+		ContextID: []byte("test-context-id"),
+		Metadata:  []byte("test-metadata"),
+		ExtendedProvider: &stischema.ExtendedProvider{
+			Providers: []stischema.Provider{
+				{
+					ID:        ep1PeerID.String(),
+					Addresses: randomAddrs(2),
+					Metadata:  []byte("ep1-metadata"),
+				},
+			},
+		},
+	}
+
+	err = adv.SignWithExtendedProviders(mpPriv, func(p string) (crypto.PrivKey, error) {
+		switch p {
+		case ep1PeerID.String():
+			return ep1Priv, nil
+		default:
+			return nil, fmt.Errorf("Unknown provider %s", p)
+		}
+	})
+
+	require.Error(t, err, "extended providers must contain provider from the encapsulating advertisement")
+}
+
+func extendedSignatureTest(t *testing.T, testFunc func(adv stischema.Advertisement)) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	lsys := cidlink.DefaultLinkSystem()
+	store := &memstore.Store{}
+	lsys.SetReadStorage(store)
+	lsys.SetWriteStorage(store)
+
+	ec := stischema.EntryChunk{
+		Entries: util.RandomMultihashes(10, rng),
+	}
+
+	node, err := ec.ToNode()
+	require.NoError(t, err)
+	elnk, err := lsys.Store(ipld.LinkContext{}, stischema.Linkproto, node)
+	require.NoError(t, err)
+
+	ep1Priv, ep1PeerID := generateIdentityAndKey(t)
+	mpPriv, mpPeerID := generateIdentityAndKey(t)
+	mpAddrs := randomAddrs(2)
+
+	adv := stischema.Advertisement{
+		Provider:  mpPeerID.String(),
+		Addresses: mpAddrs,
+		Entries:   elnk,
+		ContextID: []byte("test-context-id"),
+		Metadata:  []byte("test-metadata"),
+		ExtendedProvider: &stischema.ExtendedProvider{
+			Providers: []stischema.Provider{
+				{
+					ID:        mpPeerID.String(),
+					Addresses: mpAddrs,
+					Metadata:  []byte("main-metadata"),
+				},
+				{
+					ID:        ep1PeerID.String(),
+					Addresses: randomAddrs(2),
+					Metadata:  []byte("ep1-metadata"),
+				},
+			},
+		},
+	}
+
+	err = adv.SignWithExtendedProviders(mpPriv, func(p string) (crypto.PrivKey, error) {
+		switch p {
+		case ep1PeerID.String():
+			return ep1Priv, nil
+		default:
+			return nil, fmt.Errorf("Unknown provider %s", p)
+		}
+	})
+
+	require.NoError(t, err)
+
+	_, err = adv.VerifySignature()
+	require.NoError(t, err)
+
+	testFunc(adv)
+}
+
+func randomAddrs(n int) []string {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	addrs := make([]string, n)
+	for i := 0; i < n; i++ {
+		addrs[i] = fmt.Sprintf("/ip4/%d.%d.%d.%d/tcp/%d", rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%10751)
+	}
+	return addrs
+}
+
+func generateIdentityAndKey(t *testing.T) (crypto.PrivKey, peer.ID) {
+	priv, pub, err := test.RandTestKeyPair(crypto.Ed25519, 256)
+	require.NoError(t, err)
+	peerID, err := peer.IDFromPublicKey(pub)
+	require.NoError(t, err)
+	return priv, peerID
 }

--- a/api/v0/ingest/schema/schema.ipldsch
+++ b/api/v0/ingest/schema/schema.ipldsch
@@ -7,6 +7,34 @@ type EntryChunk struct {
     Next optional Link
 }
 
+# ExtendedProvider specifies an additional set of providers where the ad entries are available from
+type ExtendedProvider   struct {
+    # Providers is an additional list of providers where the ad entries are available from
+    Providers [Provider]
+    # Override defines mechanics for extending chain-level extended providers in the following way:
+    # * If Override is set on an ExtendedProvider entry on an advertisement with a ContextID, it indicates that any specified chain-level 
+    #   set of providers should not be returned for that context ID. Providers will be returned Instead.
+    # * If Override is not set on an entry for an advertisement with a ContextID, it will be combined as a union with any chain-level ExtendedProviders (Addresses, Metadata).
+    # * If Override is set on ExtendedProvider for an advertisement without a ContextID, the entry is invalid and should be ignored.
+    Override Bool
+} 
+
+# Provider contains details of a peer where ad entries are available from
+type Provider struct {
+    # ID is a peer ID of the Provider 
+    ID String
+    # Addresses is a list of multiaddresses of the Provider
+    Addresses [String]
+    # Metadata captures contextual information about how to retrieve the advertised content.
+    Metadata Bytes
+    # Signature is created by each provider with their corresponding private key
+    # * The full advertisement object is serialized, with all instances of Signature replaced with an empty array of bytes.
+    # * This serialization is then hashed, and the hash is then signed.
+    # * The Provider from the encapsulating advertisement must be present in the Providers of the ExtendedProvider object, 
+    #   and must sign in this way as well. It may omit Metadata and Addresses if they match the values already set at the encapsulating advertisement. However, Signature must be present.
+    Signature Bytes
+}
+
 # Advertisement signals availability of content to the indexer nodes in form of a chunked list of 
 # multihashes, where to retrieve them from, and over protocol they are retrievable.
 type Advertisement struct {
@@ -29,9 +57,14 @@ type Advertisement struct {
     #  * https://ipld.io/specs/advanced-data-layouts/hamt/spec/#use-as-a-set
     Entries Link
     # ContextID is the unique identifier for the collection of advertised multihashes.
+    # If a Provider listing is written with no ContextID and IsRm=false, peers from ExtendedProvider 
+    # will be returned for all advertisements published by the publisher.
     ContextID Bytes
     # Metadata captures contextual information about how to retrieve the advertised content.
     Metadata Bytes
     # IsRm specifies whether this advertisement represents the content are no longer retrievalbe fom the provider.
     IsRm Bool
+    # ExtendedProvider might optionally specify a set of providers where the ad entries are available from. 
+    # See: https://github.com/filecoin-project/storetheindex/blob/main/doc/ingest.md#extendedprovider
+    ExtendedProvider optional ExtendedProvider
 }

--- a/api/v0/ingest/schema/types.go
+++ b/api/v0/ingest/schema/types.go
@@ -10,15 +10,28 @@ import (
 )
 
 type (
+	ExtendedProvider struct {
+		Providers []Provider
+		Override  bool
+	}
+
+	Provider struct {
+		ID        string
+		Addresses []string
+		Metadata  []byte
+		Signature []byte
+	}
+
 	Advertisement struct {
-		PreviousID ipld.Link
-		Provider   string
-		Addresses  []string
-		Signature  []byte
-		Entries    ipld.Link
-		ContextID  []byte
-		Metadata   []byte
-		IsRm       bool
+		PreviousID       ipld.Link
+		Provider         string
+		Addresses        []string
+		Signature        []byte
+		Entries          ipld.Link
+		ContextID        []byte
+		Metadata         []byte
+		IsRm             bool
+		ExtendedProvider *ExtendedProvider
 	}
 	EntryChunk struct {
 		Entries []multihash.Multihash

--- a/api/v0/ingest/schema/types_test.go
+++ b/api/v0/ingest/schema/types_test.go
@@ -1,6 +1,8 @@
 package schema_test
 
 import (
+	_ "embed"
+	"fmt"
 	"math/rand"
 	"strings"
 	"testing"
@@ -12,49 +14,180 @@ import (
 	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
+	ipldSchema "github.com/ipld/go-ipld-prime/schema"
 	"github.com/ipld/go-ipld-prime/storage/memstore"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_OldSchemaIsCompatibleWithNewStructs(t *testing.T) {
-	oldSchema, err := ipld.LoadSchemaBytes([]byte(`
-		type EntryChunk struct {
-			Entries List_Bytes
-			Next optional Link_EntryChunk
-		}
-		
-		type Link_EntryChunk &EntryChunk
-		type List_String [String]
-		type List_Bytes [Bytes]
-		
-		type Advertisement struct {
-			PreviousID optional Link_Advertisement
-			Provider String
-			Addresses List_String
-			Signature Bytes
-			Entries Link
-			ContextID Bytes
-			Metadata Bytes
-			IsRm Bool
-		}
-		
-		type Link_Advertisement &Advertisement`))
+// This struct captures Advertisement before ExtendedProviders have been added.
+// It's needed to make sure that changes to Advertisement struct are backward compatible.
+type OldAdvertisement struct {
+	PreviousID ipld.Link
+	Provider   string
+	Addresses  []string
+	Signature  []byte
+	Entries    ipld.Link
+	ContextID  []byte
+	Metadata   []byte
+	IsRm       bool
+}
+
+// testSchema mimics the logic of schema.go. The test requires that to be able to load both old and new schemas in the same time.
+type testSchema struct {
+	noEntries              cidlink.Link
+	linkproto              cidlink.LinkPrototype
+	advertisementPrototype ipldSchema.TypedPrototype
+	entryChunkPrototype    ipldSchema.TypedPrototype
+	typeSystem             *ipldSchema.TypeSystem
+}
+
+func createTestSchema(t *testing.T, schemaBytes []byte, adInterfacePtr interface{}) *testSchema {
+	ts := &testSchema{
+		linkproto: cidlink.LinkPrototype{
+			Prefix: cid.Prefix{
+				Version:  1,
+				Codec:    uint64(multicodec.DagJson),
+				MhType:   uint64(multicodec.Sha2_256),
+				MhLength: -1,
+			},
+		},
+	}
+
+	typeSystem, err := ipld.LoadSchemaBytes(schemaBytes)
 	require.NoError(t, err)
 
+	ts.typeSystem = typeSystem
+	ts.advertisementPrototype = bindnode.Prototype(adInterfacePtr, typeSystem.TypeByName("Advertisement"))
+	ts.entryChunkPrototype = bindnode.Prototype((*stischema.EntryChunk)(nil), typeSystem.TypeByName("EntryChunk"))
+
+	// Define NoEntries as the CID of a sha256 hash of nil.
+	m, err := multihash.Sum(nil, multihash.SHA2_256, 16)
+	if err != nil {
+		panic(fmt.Errorf("failed to sum NoEntries multihash: %w", err))
+	}
+	ts.noEntries = cidlink.Link{Cid: cid.NewCidV1(cid.Raw, m)}
+	return ts
+}
+
+// oldSchema defines Advertisemnt schema before ExtendedProviders have been added
+var oldSchema = []byte(`
+	type EntryChunk struct {
+		Entries List_Bytes
+		Next optional Link_EntryChunk
+	}
+
+	type Link_EntryChunk &EntryChunk
+	type List_String [String]
+	type List_Bytes [Bytes]
+
+	type Advertisement struct {
+		PreviousID optional Link_Advertisement
+		Provider String
+		Addresses List_String
+		Signature Bytes
+		Entries Link
+		ContextID Bytes
+		Metadata Bytes
+		IsRm Bool
+	}
+
+	type Link_Advertisement &Advertisement
+`)
+
+//go:embed schema.ipldsch
+var newSchema []byte
+
+func TestOldAdsCanBeReadWithNewStructs(t *testing.T) {
+	oldSchema := createTestSchema(t, oldSchema, (*OldAdvertisement)(nil))
+
 	rng := rand.New(rand.NewSource(1413))
-	ad := generateAdvertisement(rng)
-	oldAdType := oldSchema.TypeByName("Advertisement")
-	nodeFromOldAdType := bindnode.Wrap(ad, oldAdType).Representation()
+
+	mhs := util.RandomMultihashes(7, rng)
+	prev := ipld.Link(cidlink.Link{Cid: cid.NewCidV1(cid.Raw, mhs[0])})
+	oldAd := &OldAdvertisement{
+		PreviousID: prev,
+		Provider:   mhs[1].String(),
+		Addresses: []string{
+			mhs[2].String(),
+		},
+		Entries:   cidlink.Link{Cid: cid.NewCidV1(cid.Raw, mhs[3])},
+		ContextID: mhs[4],
+		Metadata:  mhs[5],
+		Signature: mhs[6],
+		IsRm:      false,
+	}
+
+	oldAdType := oldSchema.typeSystem.TypeByName("Advertisement")
+	nodeFromOldAdType := bindnode.Wrap(oldAd, oldAdType).Representation()
 
 	newAd, err := stischema.UnwrapAdvertisement(nodeFromOldAdType)
 	require.NoError(t, err)
-	require.Equal(t, ad, newAd)
+
+	// we have to compare manually field by field as old struct doesn't have ExtendedProvider
+	require.Equal(t, oldAd.PreviousID, newAd.PreviousID)
+	require.Equal(t, oldAd.Provider, newAd.Provider)
+	require.Equal(t, oldAd.Addresses, newAd.Addresses)
+	require.Equal(t, oldAd.Signature, newAd.Signature)
+	require.Equal(t, oldAd.Entries, newAd.Entries)
+	require.Equal(t, oldAd.ContextID, newAd.ContextID)
+	require.Equal(t, oldAd.Metadata, newAd.Metadata)
+	require.Equal(t, oldAd.IsRm, newAd.IsRm)
+	require.Nil(t, newAd.ExtendedProvider)
 
 	chunk := generateEntryChunk(rng)
-	oldChunkType := oldSchema.TypeByName("EntryChunk")
+	oldChunkType := oldSchema.typeSystem.TypeByName("EntryChunk")
 	nodeFromOldChunkType := bindnode.Wrap(chunk, oldChunkType).Representation()
 
 	newChunk, err := stischema.UnwrapEntryChunk(nodeFromOldChunkType)
+	require.NoError(t, err)
+	require.Equal(t, chunk, newChunk)
+}
+
+func TestNewAdsCanBeReadWithOldStructs(t *testing.T) {
+	oldSchema := createTestSchema(t, oldSchema, (*OldAdvertisement)(nil))
+	newSchema := createTestSchema(t, newSchema, (*stischema.Advertisement)(nil))
+
+	rng := rand.New(rand.NewSource(1413))
+
+	mhs := util.RandomMultihashes(7, rng)
+	prev := ipld.Link(cidlink.Link{Cid: cid.NewCidV1(cid.Raw, mhs[0])})
+	newAd := &stischema.Advertisement{
+		PreviousID: prev,
+		Provider:   mhs[1].String(),
+		Addresses: []string{
+			mhs[2].String(),
+		},
+		Entries:   cidlink.Link{Cid: cid.NewCidV1(cid.Raw, mhs[3])},
+		ContextID: mhs[4],
+		Metadata:  mhs[5],
+		Signature: mhs[6],
+		IsRm:      false,
+	}
+
+	newAdType := newSchema.typeSystem.TypeByName("Advertisement")
+	nodeFromNewAdType := bindnode.Wrap(newAd, newAdType).Representation()
+
+	oldAd, err := oldUnwrap(nodeFromNewAdType, oldSchema.advertisementPrototype)
+	require.NoError(t, err)
+
+	// we have to compare manually field by field as old struct doesn't have ExtendedProvider
+	require.Equal(t, oldAd.PreviousID, newAd.PreviousID)
+	require.Equal(t, oldAd.Provider, newAd.Provider)
+	require.Equal(t, oldAd.Addresses, newAd.Addresses)
+	require.Equal(t, oldAd.Signature, newAd.Signature)
+	require.Equal(t, oldAd.Entries, newAd.Entries)
+	require.Equal(t, oldAd.ContextID, newAd.ContextID)
+	require.Equal(t, oldAd.Metadata, newAd.Metadata)
+	require.Equal(t, oldAd.IsRm, newAd.IsRm)
+	require.Nil(t, newAd.ExtendedProvider)
+
+	chunk := generateEntryChunk(rng)
+	newChunkType := oldSchema.typeSystem.TypeByName("EntryChunk")
+	nodeFromNewChunkType := bindnode.Wrap(chunk, newChunkType).Representation()
+
+	newChunk, err := stischema.UnwrapEntryChunk(nodeFromNewChunkType)
 	require.NoError(t, err)
 	require.Equal(t, chunk, newChunk)
 }
@@ -155,4 +288,22 @@ func generateEntryChunk(rng *rand.Rand) *stischema.EntryChunk {
 		Entries: mhs,
 		Next:    next,
 	}
+}
+
+func oldUnwrap(node ipld.Node, oldAdPrototype ipldSchema.TypedPrototype) (*OldAdvertisement, error) {
+	if node.Prototype() != oldAdPrototype {
+		adBuilder := oldAdPrototype.NewBuilder()
+		err := adBuilder.AssignNode(node)
+		if err != nil {
+			return nil, fmt.Errorf("faild to convert node prototype: %w", err)
+		}
+		node = adBuilder.Build()
+	}
+
+	unwrapped := bindnode.Unwrap(node)
+	ad, ok := unwrapped.(*OldAdvertisement)
+	if !ok || ad == nil {
+		return nil, fmt.Errorf("unwrapped node does not match schema.Advertisement")
+	}
+	return ad, nil
 }

--- a/server/finder/libp2p/protocol_test.go
+++ b/server/finder/libp2p/protocol_test.go
@@ -57,6 +57,33 @@ func TestFindIndexData(t *testing.T) {
 	}
 }
 
+func TestFindIndexWithExtendedProviders(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Initialize everything
+	ind := test.InitIndex(t, true)
+	reg := test.InitRegistryWithRestrictivePolicy(t, false)
+	s, sh := setupServer(ctx, ind, reg, nil, t)
+	c := setupClient(s.ID(), t)
+	err := c.ConnectAddrs(ctx, sh.Addrs()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	test.ProvidersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx, t, c, ind, reg)
+	test.ExtendedProviderShouldHaveOwnMetadataTest(ctx, t, c, ind, reg)
+	test.ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx, t, c, ind, reg)
+	test.ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx, t, c, ind, reg)
+	test.ContextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx, t, c, ind, reg)
+
+	if err = reg.Close(); err != nil {
+		t.Errorf("Error closing registry: %s", err)
+	}
+	if err = ind.Close(); err != nil {
+		t.Errorf("Error closing indexer core: %s", err)
+	}
+}
+
 func TestProviderInfo(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -44,16 +44,27 @@ func InitIndex(t *testing.T, withCache bool) indexer.Interface {
 	return engine.New(resultCache, valueStore)
 }
 
-// InitRegistry initializes a new registry
 func InitRegistry(t *testing.T) *registry.Registry {
+	return InitRegistryWithRestrictivePolicy(t, true)
+}
+
+// InitRegistry initializes a new registry
+func InitRegistryWithRestrictivePolicy(t *testing.T, restrictive bool) *registry.Registry {
 	var discoveryCfg = config.Discovery{
-		Policy: config.Policy{
+		PollInterval:   config.Duration(time.Minute),
+		RediscoverWait: config.Duration(time.Minute),
+	}
+	if restrictive {
+		discoveryCfg.Policy = config.Policy{
 			Allow:   false,
 			Except:  []string{providerID},
 			Publish: false,
-		},
-		PollInterval:   config.Duration(time.Minute),
-		RediscoverWait: config.Duration(time.Minute),
+		}
+	} else {
+		discoveryCfg.Policy = config.Policy{
+			Allow:   true,
+			Publish: false,
+		}
 	}
 	reg, err := registry.NewRegistry(context.Background(), discoveryCfg, nil, nil)
 	if err != nil {

--- a/server/finder/test/test_extended_providers.go
+++ b/server/finder/test/test_extended_providers.go
@@ -1,0 +1,351 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-indexer-core"
+	"github.com/filecoin-project/storetheindex/api/v0/finder/client"
+	"github.com/filecoin-project/storetheindex/api/v0/finder/model"
+	"github.com/filecoin-project/storetheindex/internal/registry"
+	"github.com/filecoin-project/storetheindex/test/util"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+func ProvidersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	ctxId1 := []byte("test-context-id-1")
+	metadata1 := []byte("test-metadata-1")
+	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
+	ep1, _, _ := util.RandomIdentity(t)
+	ep1Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9997"})
+	createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+		Providers: []registry.ExtendedProviderInfo{
+			{
+				PeerID: ep1,
+				Addrs:  ep1Addrs,
+			},
+		},
+	})
+
+	ctxId2 := []byte("test-context-id-2")
+	metadata2 := []byte("test-metadata-2")
+	addrs2 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9998"})
+	prov2, mhs2 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId2, metadata2, addrs2, nil)
+
+	resp, err := c.FindBatch(ctx, mhs2[:10])
+	require.NoError(t, err)
+	err = checkResponse(resp, mhs2[:10], []model.ProviderResult{
+		{
+			ContextID: ctxId2,
+			Provider: peer.AddrInfo{
+				ID:    prov2,
+				Addrs: addrs2,
+			},
+			Metadata: metadata2,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func ExtendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	ctxId1 := []byte("test-context-id-1")
+	metadata1 := []byte("test-metadata-1")
+	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
+
+	ep1, _, _ := util.RandomIdentity(t)
+	ep1Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9997"})
+	ep1Metadata := []byte("test-metadata-ep1")
+
+	ep2, _, _ := util.RandomIdentity(t)
+	ep2Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9996"})
+	ep2Metadata := []byte("test-metadata-ep2")
+	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+		Providers: []registry.ExtendedProviderInfo{
+			{
+				PeerID:   ep1,
+				Addrs:    ep1Addrs,
+				Metadata: ep1Metadata,
+			},
+		},
+		ContextualProviders: map[string]registry.ContextualExtendedProviders{
+			string(ctxId1): {
+				ContextID: ctxId1,
+				Providers: []registry.ExtendedProviderInfo{
+					{
+						PeerID:   ep2,
+						Addrs:    ep2Addrs,
+						Metadata: ep2Metadata,
+					},
+				},
+			},
+		},
+	})
+
+	resp, err := c.FindBatch(ctx, mhs1)
+	require.NoError(t, err)
+	err = checkResponse(resp, mhs1, []model.ProviderResult{
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    prov1,
+				Addrs: addrs1,
+			},
+			Metadata: metadata1,
+		},
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    ep2,
+				Addrs: ep2Addrs,
+			},
+			Metadata: ep2Metadata,
+		},
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    ep1,
+				Addrs: ep1Addrs,
+			},
+			Metadata: ep1Metadata,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	ctxId1 := []byte("test-context-id-1")
+	metadata1 := []byte("test-metadata-1")
+	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
+
+	ep1, _, _ := util.RandomIdentity(t)
+	ep1Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9997"})
+	ep2, _, _ := util.RandomIdentity(t)
+	ep2Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9996"})
+
+	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+		Providers: []registry.ExtendedProviderInfo{
+			{
+				PeerID: ep1,
+				Addrs:  ep1Addrs,
+			},
+		},
+		ContextualProviders: map[string]registry.ContextualExtendedProviders{
+			string(ctxId1): {
+				ContextID: ctxId1,
+				Providers: []registry.ExtendedProviderInfo{
+					{
+						PeerID: ep2,
+						Addrs:  ep2Addrs,
+					},
+				},
+			},
+		},
+	})
+
+	resp, err := c.FindBatch(ctx, mhs1)
+	require.NoError(t, err)
+	err = checkResponse(resp, mhs1, []model.ProviderResult{
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    prov1,
+				Addrs: addrs1,
+			},
+			Metadata: metadata1,
+		},
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    ep2,
+				Addrs: ep2Addrs,
+			},
+			Metadata: metadata1,
+		},
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    ep1,
+				Addrs: ep1Addrs,
+			},
+			Metadata: metadata1,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	ctxId1 := []byte("test-context-id-1")
+	metadata1 := []byte("test-metadata-1")
+	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
+
+	ep1, _, _ := util.RandomIdentity(t)
+	ep1Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9997"})
+
+	ep2, _, _ := util.RandomIdentity(t)
+	ep2Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9996"})
+
+	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+		Providers: []registry.ExtendedProviderInfo{
+			{
+				PeerID: ep1,
+				Addrs:  ep1Addrs,
+			},
+		},
+		ContextualProviders: map[string]registry.ContextualExtendedProviders{string(ctxId1): {
+			Override:  false,
+			ContextID: ctxId1,
+			Providers: []registry.ExtendedProviderInfo{
+				{
+					PeerID: ep2,
+					Addrs:  ep2Addrs,
+				},
+			},
+		}},
+	})
+
+	ctxId2 := []byte("test-context-id-2")
+	mhs2 := util.RandomMultihashes(10, rng)
+
+	v := indexer.Value{
+		ProviderID:    prov1,
+		ContextID:     ctxId2,
+		MetadataBytes: metadata1,
+	}
+	populateIndex(ind, mhs2, v, t)
+
+	resp, err := c.FindBatch(ctx, mhs1)
+	require.NoError(t, err)
+	err = checkResponse(resp, mhs1, []model.ProviderResult{
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    prov1,
+				Addrs: addrs1,
+			},
+			Metadata: metadata1,
+		},
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    ep2,
+				Addrs: ep2Addrs,
+			},
+			Metadata: metadata1,
+		},
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    ep1,
+				Addrs: ep1Addrs,
+			},
+			Metadata: metadata1,
+		},
+	})
+	require.NoError(t, err)
+
+	// for contextId2 we should get only chain-level extended providers
+	resp, err = c.FindBatch(ctx, mhs2)
+	require.NoError(t, err)
+	err = checkResponse(resp, mhs2, []model.ProviderResult{
+		{
+			ContextID: ctxId2,
+			Provider: peer.AddrInfo{
+				ID:    prov1,
+				Addrs: addrs1,
+			},
+			Metadata: metadata1,
+		},
+		{
+			ContextID: ctxId2,
+			Provider: peer.AddrInfo{
+				ID:    ep1,
+				Addrs: ep1Addrs,
+			},
+			Metadata: metadata1,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func ContextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	ctxId1 := []byte("test-context-id-1")
+	metadata1 := []byte("test-metadata-1")
+	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
+
+	ep1, _, _ := util.RandomIdentity(t)
+	ep1Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9997"})
+
+	ep2, _, _ := util.RandomIdentity(t)
+	ep2Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9996"})
+
+	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+		Providers: []registry.ExtendedProviderInfo{
+			{
+				PeerID: ep1,
+				Addrs:  ep1Addrs,
+			},
+		},
+		ContextualProviders: map[string]registry.ContextualExtendedProviders{string(ctxId1): {
+			Override:  true,
+			ContextID: ctxId1,
+			Providers: []registry.ExtendedProviderInfo{
+				{
+					PeerID: ep2,
+					Addrs:  ep2Addrs,
+				},
+			},
+		}},
+	})
+
+	resp, err := c.FindBatch(ctx, mhs1)
+	require.NoError(t, err)
+	err = checkResponse(resp, mhs1, []model.ProviderResult{
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    prov1,
+				Addrs: addrs1,
+			},
+			Metadata: metadata1,
+		},
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    ep2,
+				Addrs: ep2Addrs,
+			},
+			Metadata: metadata1,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func createProviderAndPopulateIndexer(t *testing.T, ctx context.Context, ind indexer.Interface, reg *registry.Registry, contextID []byte, metadata []byte, addrs []multiaddr.Multiaddr, extendedProviders *registry.ExtendedProviders) (peer.ID, []multihash.Multihash) {
+	providerID, _, _ := util.RandomIdentity(t)
+
+	// Generate some multihashes and populate indexer
+	mhs := util.RandomMultihashes(10, rng)
+
+	v := indexer.Value{
+		ProviderID:    providerID,
+		ContextID:     contextID,
+		MetadataBytes: metadata,
+	}
+	populateIndex(ind, mhs, v, t)
+
+	info := &registry.ProviderInfo{
+		AddrInfo: peer.AddrInfo{
+			ID:    providerID,
+			Addrs: addrs,
+		},
+		ExtendedProviders: extendedProviders,
+	}
+
+	err := reg.Register(ctx, info)
+	require.NoError(t, err, "could not register provider info: %v", err)
+
+	return providerID, mhs
+}

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -103,7 +103,7 @@ func (h *IngestHandler) IndexContent(ctx context.Context, data []byte) error {
 	}
 
 	// Register provider if not registered, or update addreses if already registered
-	err = h.registry.RegisterOrUpdate(ctx, provider, cid.Undef, peer.AddrInfo{})
+	err = h.registry.RegisterOrUpdate(ctx, provider, cid.Undef, peer.AddrInfo{}, nil)
 	if err != nil {
 		return err
 	}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -2,9 +2,15 @@ package util
 
 import (
 	"math/rand"
+	"testing"
 
 	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
 )
 
 func RandomMultihashes(n int, rng *rand.Rand) []multihash.Multihash {
@@ -26,4 +32,23 @@ func RandomMultihashes(n int, rng *rand.Rand) []multihash.Multihash {
 		mhashes[i] = c.Hash()
 	}
 	return mhashes
+}
+
+func RandomIdentity(t *testing.T) (peer.ID, crypto.PrivKey, crypto.PubKey) {
+	privKey, pubKey, err := test.RandTestKeyPair(crypto.Ed25519, 256)
+	require.NoError(t, err)
+
+	providerID, err := peer.IDFromPublicKey(pubKey)
+	require.NoError(t, err)
+	return providerID, privKey, pubKey
+}
+
+func StringToMultiaddrs(t *testing.T, addrs []string) []multiaddr.Multiaddr {
+	mAddrs := make([]multiaddr.Multiaddr, len(addrs))
+	for i, addr := range addrs {
+		ma, err := multiaddr.NewMultiaddr(addr)
+		require.NoError(t, err)
+		mAddrs[i] = ma
+	}
+	return mAddrs
 }


### PR DESCRIPTION
This PR adds implementation for extended providers. For more details refer to the spec [here](https://github.com/filecoin-project/storetheindex/pull/804/files).

This PR adds backward-compatible support on the indexer side only. There going to be a second part to it that will have user-facing changes in index-provider. 