### PR TITLE
Test configuration to skip 32-bit tests in unified CI

### DIFF
--- a/.github/workflows/go-test-config.json
+++ b/.github/workflows/go-test-config.json
@@ -1,0 +1,3 @@
+{
+  "skip32bit": true
+}

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,6 +13,7 @@ jobs:
         go: [ "1.18.x", "1.19.x" ]
     env:
       COVERAGES: ""
+      SKIP32BIT: false
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     name: ${{ matrix.os }} (go ${{ matrix.go }})
     steps:
@@ -37,6 +38,13 @@ jobs:
       - name: Run repo-specific setup
         uses: ./.github/actions/go-test-setup
         if: hashFiles('./.github/actions/go-test-setup') != ''
+      - name: Read config
+        if: hashFiles('./.github/workflows/go-test-config.json') != ''
+        shell: bash
+        run: |
+          if jq -re .skip32bit ./.github/workflows/go-test-config.json; then
+            echo "SKIP32BIT=true" >> $GITHUB_ENV
+          fi
       - name: Run tests
         uses: protocol/multiple-go-modules@v1.2
         with:
@@ -44,6 +52,15 @@ jobs:
           # If package ./A imports ./B, and ./A's tests also cover ./B,
           # this means ./B's coverage will be significantly higher than 0%.
           run: go test -v -shuffle=on -coverprofile=module-coverage.txt -coverpkg=./... ./...
+      - name: Run tests (32 bit)
+        if: matrix.os != 'macos' && env.SKIP32BIT == 'false' # can't run 32 bit tests on OSX.
+        uses: protocol/multiple-go-modules@v1.2
+        env:
+          GOARCH: 386
+        with:
+          run: |
+            export "PATH=${{ env.PATH_386 }}:$PATH"
+            go test -v -shuffle=on ./...
       - name: Run tests with race detector
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
         uses: protocol/multiple-go-modules@v1.2


### PR DESCRIPTION
Test out a configuration to skip 32-bit go test via JSON configuration.

Relates to https://github.com/protocol/.github/pull/412
