### PR TITLE
Create ECR repo for `heyfil` and grant access to build push images

### DIFF
--- a/deploy/infrastructure/common/ecr.tf
+++ b/deploy/infrastructure/common/ecr.tf
@@ -7,6 +7,7 @@ module "ecr_ue2" {
     "autoretrieve/autoretrieve",
     "index-provider/index-provider",
     "indexstar/indexstar",
+    "ipni/heyfil",
   ]
   tags = local.tags
 }

--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -58,6 +58,7 @@ module "github_actions_role" {
     "repo:filecoin-project/index-provider:*",
     "repo:filecoin-shipyard/index-observer:*",
     "repo:application-research/autoretrieve:*",
-    "repo:filecoin-shipyard/indexstar:*"
+    "repo:filecoin-shipyard/indexstar:*",
+    "repo:ipni/*:*"
   ]
 }


### PR DESCRIPTION
Create a new ECR repo to host `heyfil` images and grant access to GitHub
 Actions to build and push images.

 See: https://github.com/ipni/heyfil

