### PR TITLE
Add `kepa` to indexstar

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -19,6 +19,7 @@ spec:
             - '--backends=http://xabi-indexer:3000/'
             - '--backends=http://dido-indexer:3000/'
             - '--backends=http://oden-indexer:3000/'
+            - '--backends=http://kepa-indexer:3000/'
           resources:
             limits:
               cpu: "3"


### PR DESCRIPTION
Add `kepa` to indexstar as an endpoint to query during find requests now that the node is up and running without issues for about a week.

