### PR TITLE
Replace `indexer-1` on `dev` with a new node

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
@@ -7,6 +7,7 @@
   "Addresses": {
     "Admin": "/ip4/0.0.0.0/tcp/3002",
     "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web.cid.contact/dev",
     "Ingest": "/ip4/0.0.0.0/tcp/3001",
     "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
     "NoResourceManager": true
@@ -45,31 +46,20 @@
       "Publish": true,
       "PublishExcept": null
     },
-    "PollInterval": "24h0m0s",
-    "PollRetryAfter": "5h0m0s",
+    "PollInterval": "1h0m0s",
+    "PollRetryAfter": "5m0s",
     "PollStopAfter": "168h0m0s",
     "PollOverrides": null,
     "RediscoverWait": "5m0s",
     "Timeout": "2m0s"
   },
-  "Finder": {
-    "ApiReadTimeout": "30s",
-    "ApiWriteTimeout": "30s",
-    "MaxConnections": 8000,
-    "Webpage": "https://web.cid.contact/dev/"
-  },
   "Indexer": {
     "CacheSize": -1,
     "ConfigCheckInterval": "30s",
-    "GCInterval": "15m",
-    "GCTimeout": "10m",
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
-    "ValueStoreType": "sth",
-    "STHBits": 30,
-    "STHBurstRate": 8388608,
-    "STHSyncInterval": "1s",
-    "STHFileCacheSize": 512
+    "ValueStoreType": "pebble",
+    "DisableWAL": true
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
@@ -83,10 +73,10 @@
     "RateLimit": {
       "Apply": false,
       "Except": null,
-      "BlocksPerSecond": 100,
+      "BlocksPerSecond": 0,
       "BurstSize": 500
     },
-    "ResendDirectAnnounce": false,
+    "ResendDirectAnnounce": true,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
     "SyncTimeout": "2h0m0s"
@@ -102,9 +92,6 @@
     }
   },
   "Peering": {
-    "Peers": [
-      "/dns4/indexer-0.indexer/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd",
-      "/dns4/ber-indexer/tcp/3003/p2p/12D3KooWSQpUgBZwbNuMN3ctZjMesnoH9UDhwEXroxParXQCgurN"
-    ]
+    "Peers": null
   }
 }

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      terminationGracePeriodSeconds: 600
+      containers:
+        - name: indexer
+          resources:
+            limits:
+              cpu: "10"
+              memory: 120Gi
+            requests:
+              cpu: "10"
+              memory: 120Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5b.4xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2b
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b-4xl
+          effect: NoSchedule

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/dido-snapshot-content.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/dido-snapshot-content.yaml
@@ -1,0 +1,24 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: dido-021122
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    volumeSnapshotContentName: ber-dido-021122
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: dido-021122
+spec:
+  deletionPolicy: Retain
+  driver: ebs.csi.aws.com
+  source:
+    # Taken on prod cluster from dido
+    snapshotHandle: snap-054c4cf7b5e8fd419
+  sourceVolumeMode: Filesystem
+  volumeSnapshotClassName: csi-aws-vsc
+  volumeSnapshotRef:
+    name: ber-dido-021122
+    namespace: storetheindex

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:n10oiHobvByLikWB5eXu93iUkk/KrbAQy26wWBNSjkSmiSo/8ttZoc2II1kWoYr01y7cFJ1QwTnNaYfDm4VVnIu3znc=,iv:aRvNUc3oygwJnrEYrSDIpsfyTqj93XiPby++GHOq3F4=,tag:qILPN3/cznHsQpJLgF+qfg==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2022-04-22T09:12:59Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAHeKyjdaIS3sdQ+pWfPiWtXAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMAw7ucumP7Rs0ARM3AgEQgDsjii6vnzPto0ZLdQf5wDAExv+vlEGTJT+q0V5IA/60ClOk7vVFMwGBA9AnyNCS1+njYYwrOqLpBtLRRQ==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-04-22T09:13:01Z",
+		"mac": "ENC[AES256_GCM,data:ShURvwpDPzf7PPOl1TcfyqaOlakaFE3jTC6zIxdYWM5WVOABCTBRq5XPZudb7SVVciWRzVsciDSvevP6tz1uu9E0J+1WpCa7U2t264MXBQZHOyaNeAiV7fG+mXxpqEHvxk9zKDjO29kxo7ujtLkletilG/9rjkpGulJ/zBGw8Cw=,iv:GNPFsHY+BCFMStssZx4p6fuxoweoR6FVLOhbUg1kewk=,tag:hGymhfaE8FwvtFts49d4Hg==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - ber.dev.cid.contact
+      secretName: ber-indexer-ingress-tls
+  rules:
+    - host: ber.dev.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+  - dido-snapshot-content.yaml
+
+namePrefix: ber-
+
+commonLabels:
+  name: ber
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWSQpUgBZwbNuMN3ctZjMesnoH9UDhwEXroxParXQCgurN
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - pvc.yaml
+  - deployment.yaml
+
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20221029095953-db83b7c9fab3615621063378fdda568c6e8ba209

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  resources:
+    requests:
+      storage: 10Ti
+  dataSource:
+    name: ber-dido-021122
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  storageClassName: io2
+

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/patch-indexer.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: indexer
 spec:
-  replicas: 2
+  replicas: 1
   template:
     spec:
       terminationGracePeriodSeconds: 600


### PR DESCRIPTION
Replace `indexer-1` on `dev` environment with a new node called `ber` that uses the `dido` snapshot from `prod` as its initial state.

The replacing node uses the same identity as `indexer-1`, since it is whitelisted on lotus bootrstrap nodes and will receive relayed gossip. As a result, `mya` is configured to now pair with `ber` instead of `indexer-1`.
