### PR TITLE
Add pod disruption budget to indexstar

### DIFF
--- a/deploy/manifests/base/indexstar/kustomization.yaml
+++ b/deploy/manifests/base/indexstar/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml
 
 commonLabels:
   app: indexstar


### PR DESCRIPTION
This was defined but not included in the `kustomization`.
