### PR TITLE
Move volume snapshot content to cluster-level CD

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - autoretrieve
   - index-provider
   - external-snapshotter
+  - snapshots

--- a/deploy/manifests/dev/us-east-2/cluster/snapshots/ber-dido-vsc.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/snapshots/ber-dido-vsc.yaml
@@ -1,16 +1,7 @@
 apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshot
-metadata:
-  name: dido-021122
-spec:
-  volumeSnapshotClassName: csi-aws-vsc
-  source:
-    volumeSnapshotContentName: ber-dido-021122
----
-apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotContent
 metadata:
-  name: dido-021122
+  name: ber-dido-021122
 spec:
   deletionPolicy: Retain
   driver: ebs.csi.aws.com

--- a/deploy/manifests/dev/us-east-2/cluster/snapshots/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/snapshots/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ber-dido-vsc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/dido-snapshot.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/dido-snapshot.yaml
@@ -1,0 +1,11 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: dido-021122
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    # Note: Because the snapshot itself is taken on thte prod cluster,
+    # the VolumeSnapshotContent is created manually and Managed
+    # at cluster level.
+    volumeSnapshotContentName: ber-dido-021122

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: storetheindex
 resources:
   - ../../../../../../base/storetheindex-single
   - ingress.yaml
-  - dido-snapshot-content.yaml
+  - dido-snapshot.yaml
 
 namePrefix: ber-
 


### PR DESCRIPTION
Because inside the namespace the service account managing CD does not have permission to touch cluster-level objects.
