### PR TITLE
Deploy a new node `cali` on dev

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/snapshots/cali-dido-vsc.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/snapshots/cali-dido-vsc.yaml
@@ -1,0 +1,15 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: cali-dido-021122
+spec:
+  deletionPolicy: Retain
+  driver: ebs.csi.aws.com
+  source:
+    # Taken on prod cluster from dido
+    snapshotHandle: snap-054c4cf7b5e8fd419
+  sourceVolumeMode: Filesystem
+  volumeSnapshotClassName: csi-aws-vsc
+  volumeSnapshotRef:
+    name: cali-dido-021122
+    namespace: storetheindex

--- a/deploy/manifests/dev/us-east-2/cluster/snapshots/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/snapshots/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - ber-dido-vsc.yaml
+  - cali-dido-vsc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
@@ -2,6 +2,7 @@
 
 List of individually configurable instances:
 
-| Instance | IOPS per GiB | Backing store | Running |
-|----------|--------------|---------------|-----------------------|
-| `ber`    | 1            | Pebble        | [db83b7c9fab3615621063378fdda568c6e8ba209](https://github.com/filecoin-project/storetheindex/commit/db83b7c9fab3615621063378fdda568c6e8ba209) |
+| Instance | Storage Class |IOPS per GiB | Backing store | Running                                                                                                                                       |
+|----------|---------------|-------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `ber`    | io2           |1            | Pebble        | [db83b7c9fab3615621063378fdda568c6e8ba209](https://github.com/filecoin-project/storetheindex/commit/db83b7c9fab3615621063378fdda568c6e8ba209) |
+| `cali`   | io2           |1            | Pebble        | [db83b7c9fab3615621063378fdda568c6e8ba209](https://github.com/filecoin-project/storetheindex/commit/db83b7c9fab3615621063378fdda568c6e8ba209) |

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
@@ -1,0 +1,99 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web.cid.contact/dev",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": true,
+      "Except": [
+      ],
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "1h0m0s",
+    "PollRetryAfter": "5m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s"
+  },
+  "Indexer": {
+    "CacheSize": -1,
+    "ConfigCheckInterval": "30s",
+    "ShutdownTimeout": "15m",
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "pebble",
+    "DisableWAL": true
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount": 20,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 0,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": true,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": [
+      "/dns4/ber-indexer/tcp/3003/p2p/12D3KooWSQpUgBZwbNuMN3ctZjMesnoH9UDhwEXroxParXQCgurN"
+    ]
+  }
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      terminationGracePeriodSeconds: 600
+      containers:
+        - name: indexer
+          resources:
+            limits:
+              cpu: "10"
+              memory: 120Gi
+            requests:
+              cpu: "10"
+              memory: 120Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5b.4xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2c
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5b-4xl
+          effect: NoSchedule

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/dido-snapshot.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/dido-snapshot.yaml
@@ -8,4 +8,4 @@ spec:
     # Note: Because the snapshot itself is taken on the prod cluster,
     # the VolumeSnapshotContent is created manually and Managed
     # at cluster level.
-    volumeSnapshotContentName: ber-dido-021122
+    volumeSnapshotContentName: cali-dido-021122

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:+hx8/u/uXtVzrtqmpMZ9yIhBV3ddYBM2nAhvhOXTkMJ8mWy/Cr7VF3OupzzJKIxpYvWCywJYW+Pkog4SotUd5oCgnBA=,iv:IegYj09/pSC1HATqjoAs2mFtntsUwKQdXlHM3YGfSEw=,tag:8Tm2srBx9JmqMJ3Dqcfmug==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2022-08-15T16:12:42Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAEWM+4tUkdb0O+HzjSYTJYtAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMqOcBqVy4ZmVcjr3+AgEQgDv6A5Fg1GDONgq1NpEk3GPXEGpvQHw95GWE03Miirbnkt23srwHwBh7YpRN/DuXHCwiZtT5T4ZweyTiVw==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-08-15T16:12:43Z",
+		"mac": "ENC[AES256_GCM,data:kFtSK+GEE365FSz5SjCBVJ0Lkfwg9K0P6ijPqry8lSW+qwpLPGxyQGrmlvJTmAic3+RYfzO+m2h8KVSLaxnkS0MHjJwjBVD9czfeAkSI1z8C2w9PmYvGZMdOhpvYA+Lh4fu9b0Fn7Wt/RrjZ2UlyqtpR8/f/wLhCVQ3QWtnjSr4=,iv:MuBx4dChUlCEGZYbpEJWNo42YYtNBm/j23pGjpP79sw=,tag:QLVLRceFv/wzAdsg95UJXw==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - cali.dev.cid.contact
+      secretName: cali-indexer-ingress-tls
+  rules:
+    - host: cali.dev.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+  - dido-snapshot.yaml
+
+namePrefix: cali-
+
+commonLabels:
+  name: cali
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWHGHu3jVjya9sDSAYRmAVtUnQGTwnWeqan1smfJdjzscB
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - pvc.yaml
+  - deployment.yaml
+
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20221029095953-db83b7c9fab3615621063378fdda568c6e8ba209

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  resources:
+    requests:
+      storage: 10Ti
+  dataSource:
+    name: cali-dido-021122
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  storageClassName: io2
+

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - pdb.yaml
   - pod-monitor.yaml
   - ber
+  - cali


### PR DESCRIPTION
The node cali also uses the dido snapshot as its initial state and replaces `indexer-0` but without reusing its identity. This provides us with total of 2 nodes in `dev` both backed by pebble in order to offer redundancy and facilitate testing of coordination over more than one node.
