### PR TITLE
Deploy v5.0.0 to the rest of the cluster

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/kustomization.yaml
@@ -32,4 +32,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20221029095953-db83b7c9fab3615621063378fdda568c6e8ba209
+    newTag: 0.5.0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20221029095953-db83b7c9fab3615621063378fdda568c6e8ba209
+    newTag: 0.5.0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/vega/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20221029103133-1deb5ed222c428f2f64eeea43f970b05ea844225
+    newTag: 0.5.0


### PR DESCRIPTION
Deploy v5.0.0 to the rest of the prod cluster. 

Update to the [README](https://github.com/filecoin-project/storetheindex/tree/main/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances) will be done in the follow up PR. 