### PR TITLE
Save assignments from assigner service in datastore

### DIFF
--- a/api/v0/admin/client/http/client.go
+++ b/api/v0/admin/client/http/client.go
@@ -189,10 +189,10 @@ func (c *Client) Allow(ctx context.Context, peerID peer.ID) error {
 	return c.ingestRequest(ctx, peerID, "allow", http.MethodPut, nil)
 }
 
-// ListAllowedPeers gets a list of explicitly allowed peers, if policy is
-// configured to have allow list.
-func (c *Client) ListAllowedPeers(ctx context.Context) ([]peer.ID, error) {
-	u := c.baseURL + path.Join(ingestResource, "allowlist")
+// ListAssignedPeers gets a list of explicitly allowed peers, if indexer is
+// configured to work with an assigner service.
+func (c *Client) ListAssignedPeers(ctx context.Context) ([]peer.ID, error) {
+	u := c.baseURL + path.Join(ingestResource, "assigned")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err

--- a/assigner/core/assigner.go
+++ b/assigner/core/assigner.go
@@ -346,5 +346,5 @@ func getAssignments(ctx context.Context, adminURL string) ([]peer.ID, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cl.ListAllowedPeers(ctx)
+	return cl.ListAssignedPeers(ctx)
 }

--- a/command/admin.go
+++ b/command/admin.go
@@ -38,11 +38,11 @@ var importProviders = &cli.Command{
 	Action: importProvidersCmd,
 }
 
-var listAllowed = &cli.Command{
-	Name:   "list-allowed",
-	Usage:  "List explicitly allowed peers",
-	Flags:  adminListAllowedFlags,
-	Action: listAllowedCmd,
+var listAssigned = &cli.Command{
+	Name:   "list-assigned",
+	Usage:  "List allowed peers when configured to work with assigner service",
+	Flags:  adminListAssignedFlags,
+	Action: listAssignedCmd,
 }
 
 var reload = &cli.Command{
@@ -68,7 +68,7 @@ var AdminCmd = &cli.Command{
 		allow,
 		block,
 		importProviders,
-		listAllowed,
+		listAssigned,
 		reload,
 		sync,
 	},
@@ -116,16 +116,16 @@ func allowCmd(cctx *cli.Context) error {
 	return nil
 }
 
-func listAllowedCmd(cctx *cli.Context) error {
+func listAssignedCmd(cctx *cli.Context) error {
 	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err
 	}
-	allowed, err := cl.ListAllowedPeers(cctx.Context)
+	assigned, err := cl.ListAssignedPeers(cctx.Context)
 	if err != nil {
 		return err
 	}
-	for _, peerID := range allowed {
+	for _, peerID := range assigned {
 		fmt.Println(peerID)
 	}
 	return nil

--- a/command/flags.go
+++ b/command/flags.go
@@ -135,7 +135,7 @@ var adminReloadConfigFlags = []cli.Flag{
 	indexerHostFlag,
 }
 
-var adminListAllowedFlags = []cli.Flag{
+var adminListAssignedFlags = []cli.Flag{
 	indexerHostFlag,
 }
 
@@ -194,8 +194,8 @@ var initFlags = []cli.Flag{
 		Required: false,
 	},
 	&cli.BoolFlag{
-		Name:     "block-policy",
-		Usage:    "Set the discovery policy to block peers by default",
+		Name:     "use-assigner",
+		Usage:    "Configure the indexer to work with an assigner service",
 		Required: false,
 	},
 }

--- a/command/init.go
+++ b/command/init.go
@@ -135,8 +135,9 @@ func initCommand(cctx *cli.Context) error {
 		cfg.Ingest.PubSubTopic = topic
 	}
 
-	if cctx.Bool("block-policy") {
+	if cctx.Bool("use-assigner") {
 		cfg.Discovery.Policy.Allow = false
+		cfg.Discovery.UseAssigner = true
 	}
 
 	return cfg.Save(configFile)

--- a/config/discovery.go
+++ b/config/discovery.go
@@ -49,6 +49,12 @@ type Discovery struct {
 	// Timeout is the maximum amount of time that the indexer will spend trying
 	// to discover and verify a new provider.
 	Timeout Duration
+	// UseAssigner configures the indexer to work with an assigner service.
+	// This also requires that Policy.Allow is false, making Policy.Except into
+	// a list of allowed peers. Peers listed in Policy.Except in the
+	// configuration file are included in the set of assigned peers. This
+	// allows an indexer to be pre-configured with assigned peers.
+	UseAssigner bool
 }
 
 // Polling is a set of polling parameters that is applied to a specific

--- a/internal/registry/policy/policy.go
+++ b/internal/registry/policy/policy.go
@@ -57,20 +57,34 @@ func (p *Policy) PublishAllowed(publisherID, providerID peer.ID) bool {
 	return p.publish.Eval(publisherID)
 }
 
-// Allow alters the policy to allow the specified peer.  Returns true if the
+// Allow alters the policy to allow the specified peer. Returns true if the
 // policy needed to be updated.
-func (p *Policy) Allow(peerID peer.ID) bool {
+func (p *Policy) Allow(peerIDs ...peer.ID) bool {
 	p.rwmutex.Lock()
 	defer p.rwmutex.Unlock()
-	return p.allow.SetPeer(peerID, true)
+
+	var updated bool
+	for _, peerID := range peerIDs {
+		if p.allow.SetPeer(peerID, true) {
+			updated = true
+		}
+	}
+	return updated
 }
 
 // Block alters the policy to not allow the specified peer.  Returns true if
 // the policy needed to be updated.
-func (p *Policy) Block(peerID peer.ID) bool {
+func (p *Policy) Block(peerIDs ...peer.ID) bool {
 	p.rwmutex.Lock()
 	defer p.rwmutex.Unlock()
-	return p.allow.SetPeer(peerID, false)
+
+	var updated bool
+	for _, peerID := range peerIDs {
+		if p.allow.SetPeer(peerID, false) {
+			updated = true
+		}
+	}
+	return updated
 }
 
 // Copy copies another policy.
@@ -102,9 +116,9 @@ func (p *Policy) NoneAllowed() bool {
 	return !p.allow.Any(true)
 }
 
-// AllowList returns list of explicitly allowed peer IDs. or false if policy
-// allows by default and does not have allow list.
-func (p *Policy) AllowList() ([]peer.ID, bool) {
+// ListAllowedPeers returns list of explicitly allowed peer IDs. or false if policy
+// allows by default and does not have list of allowed peers.
+func (p *Policy) ListAllowedPeers() ([]peer.ID, bool) {
 	p.rwmutex.RLock()
 	defer p.rwmutex.RUnlock()
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -717,7 +717,7 @@ func TestRegistry_loadPersistedProvidersFiltersNilAddrGracefully(t *testing.T) {
 	pid, err := peer.Decode("12D3KooWK7CTS7cyWi51PeNE3cTjS2F2kDCZaQVU4A5xBmb9J1do")
 	require.NoError(t, err)
 
-	err = ds.Put(ctx, peerIDToDsKey(pid), []byte(`{"PublisherAddr": null,"AddrInfo": {},"LastAdvertisement":null,"LastAdvertisementTime":"0001-01-01T00:00:00Z","Publisher":"`+pid.String()+`"}`))
+	err = ds.Put(ctx, peerIDToDsKey(providerKeyPath, pid), []byte(`{"PublisherAddr": null,"AddrInfo": {},"LastAdvertisement":null,"LastAdvertisementTime":"0001-01-01T00:00:00Z","Publisher":"`+pid.String()+`"}`))
 	require.NoError(t, err)
 	cfg := config.NewDiscovery()
 	cfg.FilterIPs = true

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -57,14 +57,14 @@ func (h *adminHandler) allowPeer(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *adminHandler) allowList(w http.ResponseWriter, r *http.Request) {
-	allowed, ok := h.reg.AllowList()
-	if !ok {
-		http.Error(w, "policy not configured to have allow list", http.StatusServiceUnavailable)
+func (h *adminHandler) listAssignedPeers(w http.ResponseWriter, r *http.Request) {
+	assigned, err := h.reg.ListAssignedPeers()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
 
-	data, err := json.Marshal(allowed)
+	data, err := json.Marshal(assigned)
 	if err != nil {
 		log.Errorw("Error marshaling allow list", "err", err)
 		http.Error(w, "", http.StatusInternalServerError)

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -64,7 +64,7 @@ func New(listen string, indexer indexer.Interface, ingester *ingest.Ingester, re
 
 	// Ingester routes
 	r.HandleFunc("/ingest/allow/{peer}", h.allowPeer).Methods(http.MethodPut)
-	r.HandleFunc("/ingest/allowlist", h.allowList).Methods(http.MethodGet)
+	r.HandleFunc("/ingest/assigned", h.listAssignedPeers).Methods(http.MethodGet)
 	r.HandleFunc("/ingest/block/{peer}", h.blockPeer).Methods(http.MethodPut)
 	r.HandleFunc("/ingest/sync/{peer}", h.sync).Methods(http.MethodPost)
 


### PR DESCRIPTION
When the indexer is configured to work with an assigner service, the indexer persists assigned peers in the datastore.

Peers listed in `Discovery.Policy.Except`, in the configuration file, are included in the set of assigned peers. This allows an indexer to be pre-configured with assigned peers.

- Admin command `list-assigned` shows assigned peers configured to use assigner service
- The `/assigned/` admin endpoint gets assigned peers configured to use assigner service
- Admin `block` command can be used to administratively unassign a peer
- New init flag `use-assigner` to create configuration file with settings to use assigner service
- Test to check that assignment is persisted
