### PR TITLE
Prepare existing indexer for use with assigner service

### DIFF
--- a/announce/receiver_test.go
+++ b/announce/receiver_test.go
@@ -110,7 +110,7 @@ func TestReceiverCloseWaitingDirect(t *testing.T) {
 	select {
 	case err = <-errChan:
 		require.ErrorIs(t, err, announce.ErrClosed)
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for error return")
 	}
 }

--- a/api/v0/admin/client/http/client.go
+++ b/api/v0/admin/client/http/client.go
@@ -183,12 +183,6 @@ func (c *Client) ReloadConfig(ctx context.Context) error {
 	return nil
 }
 
-// Allow configures the indexer to allow the peer to publish messages and
-// provide content.
-func (c *Client) Allow(ctx context.Context, peerID peer.ID) error {
-	return c.ingestRequest(ctx, peerID, "allow", http.MethodPut, nil)
-}
-
 // ListAssignedPeers gets a list of explicitly allowed peers, if indexer is
 // configured to work with an assigner service.
 func (c *Client) ListAssignedPeers(ctx context.Context) ([]peer.ID, error) {
@@ -220,6 +214,24 @@ func (c *Client) ListAssignedPeers(ctx context.Context) ([]peer.ID, error) {
 	}
 
 	return allowed, nil
+}
+
+// Assign assigns a publish to an indexer, when the indexer is configured to
+// work with an assigner service.
+func (c *Client) Assign(ctx context.Context, peerID peer.ID) error {
+	return c.ingestRequest(ctx, peerID, "assign", http.MethodPut, nil)
+}
+
+// Unassign unassigns a publish from an indexer, when the indexer is configured
+// to work with an assigner service.
+func (c *Client) Unassign(ctx context.Context, peerID peer.ID) error {
+	return c.ingestRequest(ctx, peerID, "unassign", http.MethodPut, nil)
+}
+
+// Allow configures the indexer to allow the peer to publish messages and
+// provide content.
+func (c *Client) Allow(ctx context.Context, peerID peer.ID) error {
+	return c.ingestRequest(ctx, peerID, "allow", http.MethodPut, nil)
 }
 
 // Block configures indexer to block the peer from publishing messages and
@@ -283,7 +295,6 @@ func (c *Client) SetLogLevels(ctx context.Context, sysLvl map[string]string) err
 
 func (c *Client) ingestRequest(ctx context.Context, peerID peer.ID, action, method string, data []byte, queryPairs ...string) error {
 	u := c.baseURL + path.Join(ingestResource, action, peerID.String())
-
 	var body io.Reader
 	if data != nil {
 		body = bytes.NewBuffer(data)

--- a/assigner/core/assigner.go
+++ b/assigner/core/assigner.go
@@ -462,7 +462,7 @@ func assignIndexer(ctx context.Context, indexer indexerInfo, amsg announce.Annou
 	if err != nil {
 		return err
 	}
-	err = cl.Allow(ctx, amsg.PeerID)
+	err = cl.Assign(ctx, amsg.PeerID)
 	if err != nil {
 		return err
 	}

--- a/assigner/server/server_test.go
+++ b/assigner/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	adminclient "github.com/filecoin-project/storetheindex/api/v0/admin/client/http"
 	client "github.com/filecoin-project/storetheindex/api/v0/ingest/client/http"
 	"github.com/filecoin-project/storetheindex/assigner/config"
 	"github.com/filecoin-project/storetheindex/assigner/core"
@@ -144,7 +145,7 @@ func TestAnnounce(t *testing.T) {
 	}
 
 	// Allow a peer to test that assigner reads this at startup.
-	e.run(indexer, "admin", "allow", "-i", "localhost:3602", "--peer", pubIdent2.PeerID)
+	assign(ctx, "localhost:3602", pubIdent2.PeerID)
 
 	// Initialize everything
 	peerID, _, err := pubIdent.Decode()
@@ -306,4 +307,20 @@ func (e *e2eTestRunner) stop(cmd *exec.Cmd, timeout time.Duration) {
 	case err := <-waitErr:
 		require.NoError(e.t, err)
 	}
+}
+
+func assign(ctx context.Context, indexer, peerIDStr string) error {
+	cl, err := adminclient.New(indexer)
+	if err != nil {
+		return err
+	}
+	peerID, err := peer.Decode(peerIDStr)
+	if err != nil {
+		return err
+	}
+	err = cl.Assign(ctx, peerID)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/command/init.go
+++ b/command/init.go
@@ -136,7 +136,6 @@ func initCommand(cctx *cli.Context) error {
 	}
 
 	if cctx.Bool("use-assigner") {
-		cfg.Discovery.Policy.Allow = false
 		cfg.Discovery.UseAssigner = true
 	}
 

--- a/config/policy.go
+++ b/config/policy.go
@@ -1,17 +1,19 @@
 package config
 
-// Policy configures which peers are allowed to publish advertisements and
-// which may publish on behalf of other providers. The Allow policy determines
-// which peers the indexer will request advertisements from. The Publish policy
-// determines is a publisher may supply an advertisement that has a provider
-// that is not the same as the publisher.
+// Policy configures which peers are allowed to be providers, publish
+// advertisements and publish on behalf of other providers. The Allow policy
+// determines which peers the indexer will request advertisements from and
+// index content for. The Publish policy determines if a publisher may supply
+// an advertisement that has a provider that is different from the publisher.
 //
 // Publishers and providers are not the same. Publishers are peers that supply
 // data to the indexer. Providers are the peers that appear in advertisements
-// and are where clients will retrieve content from.
+// and are where retrieval clients get content from.
 type Policy struct {
 	// Allow is either false or true, and determines whether a peer is allowed
-	// (true) or is blocked (false), by default.
+	// (true) or is blocked (false), by default. If a peer if blocked, then it
+	// cannot publish advertisements to this indexer or be listed as a provider
+	// by this indexer.
 	Allow bool
 	// Except is a list of peer IDs that are exceptions to the Allow policy.
 	// If Allow is true, then all peers are allowed except those listed in

--- a/internal/registry/errors.go
+++ b/internal/registry/errors.go
@@ -5,9 +5,10 @@ import "errors"
 var (
 	ErrInProgress          = errors.New("discovery already in progress")
 	ErrCannotPublish       = errors.New("publisher not allowed to publish to other provider")
-	ErrNotAllowed          = errors.New("provider not allowed by policy")
+	ErrNotAllowed          = errors.New("peer not allowed by policy")
 	ErrNoDiscovery         = errors.New("discovery not available")
 	ErrNotVerified         = errors.New("provider cannot be verified")
 	ErrPublisherNotAllowed = errors.New("publisher not allowed by policy")
 	ErrTooSoon             = errors.New("not enough time since previous discovery")
+	ErrNoAssigner          = errors.New("not configured to work with assigner service")
 )

--- a/internal/registry/policy/policy.go
+++ b/internal/registry/policy/policy.go
@@ -115,15 +115,3 @@ func (p *Policy) ToConfig() config.Policy {
 func (p *Policy) NoneAllowed() bool {
 	return !p.allow.Any(true)
 }
-
-// ListAllowedPeers returns list of explicitly allowed peer IDs. or false if policy
-// allows by default and does not have list of allowed peers.
-func (p *Policy) ListAllowedPeers() ([]peer.ID, bool) {
-	p.rwmutex.RLock()
-	defer p.rwmutex.RUnlock()
-
-	if p.allow.Default() {
-		return nil, false
-	}
-	return p.allow.Except(), true
-}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -307,6 +307,21 @@ func TestDatastore(t *testing.T) {
 
 	err = r.Close()
 	require.NoError(t, err)
+
+	// Test that configuring existing registry to use assigner service
+	// self-assigns existing publishers.
+	t.Log("Converted registry to work with assigner service")
+	discoveryCfg.UseAssigner = true
+	dstore, err = leveldb.NewDatastore(dataStorePath, nil)
+	require.NoError(t, err)
+	r, err = NewRegistry(ctx, discoveryCfg, dstore, mockDiscoverer)
+	require.NoError(t, err)
+
+	assigned, err := r.ListAssignedPeers()
+	require.NoError(t, err)
+	// There should be 1 publisher allowed.
+	require.Equal(t, 1, len(assigned))
+	require.NoError(t, r.Close())
 }
 
 func TestAllowed(t *testing.T) {

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -64,9 +64,12 @@ func New(listen string, indexer indexer.Interface, ingester *ingest.Ingester, re
 
 	// Ingester routes
 	r.HandleFunc("/ingest/allow/{peer}", h.allowPeer).Methods(http.MethodPut)
-	r.HandleFunc("/ingest/assigned", h.listAssignedPeers).Methods(http.MethodGet)
 	r.HandleFunc("/ingest/block/{peer}", h.blockPeer).Methods(http.MethodPut)
 	r.HandleFunc("/ingest/sync/{peer}", h.sync).Methods(http.MethodPost)
+
+	r.HandleFunc("/ingest/assigned", h.listAssignedPeers).Methods(http.MethodGet)
+	r.HandleFunc("/ingest/assign/{peer}", h.assignPeer).Methods(http.MethodPut)
+	r.HandleFunc("/ingest/unassign/{peer}", h.unassignPeer).Methods(http.MethodPut)
 
 	// Metrics routes
 	r.Handle("/metrics", metrics.Start(coremetrics.DefaultViews))


### PR DESCRIPTION
When an existing indexer is configured to work with an assigner service, automatically self-assign the publishers from all of the indexer's providers.

This PR also decouples assignment from allow/block policy, making the two independent of each other. This makes it easier to reason about what the policy does, whether or not the indexer is using an assigner service. It also means that an indexer's policy does not need to change to work with an assigner service, and allows more capabilities such as being able to reject the assignment of specific publishers on an indexer.
