### PR TITLE
Use EP metadata for the main provider

### DIFF
--- a/api/v0/ingest/schema/envelope_test.go
+++ b/api/v0/ingest/schema/envelope_test.go
@@ -117,7 +117,7 @@ func TestSignShouldFailIfAdHasExtendedProviders(t *testing.T) {
 			Providers: []stischema.Provider{
 				{
 					ID:        ep1PeerID.String(),
-					Addresses: randomAddrs(2),
+					Addresses: util.RandomAddrs(2),
 					Metadata:  []byte("ep1-metadata"),
 				},
 			},
@@ -146,7 +146,7 @@ func TestSignWithExtendedProviderAndVerify(t *testing.T) {
 	ep1Priv, ep1PeerID := generateIdentityAndKey(t)
 	ep2Priv, ep2PeerID := generateIdentityAndKey(t)
 	mpPriv, mpPeerID := generateIdentityAndKey(t)
-	mpAddrs := randomAddrs(2)
+	mpAddrs := util.RandomAddrs(2)
 
 	adv := stischema.Advertisement{
 		Provider:  mpPeerID.String(),
@@ -158,12 +158,12 @@ func TestSignWithExtendedProviderAndVerify(t *testing.T) {
 			Providers: []stischema.Provider{
 				{
 					ID:        ep1PeerID.String(),
-					Addresses: randomAddrs(2),
+					Addresses: util.RandomAddrs(2),
 					Metadata:  []byte("ep1-metadata"),
 				},
 				{
 					ID:        ep2PeerID.String(),
-					Addresses: randomAddrs(2),
+					Addresses: util.RandomAddrs(2),
 					Metadata:  []byte("ep2-metadata"),
 				},
 				{
@@ -226,7 +226,7 @@ func TestSigVerificationFailsIfTheExtendedProviderMetadataIsIncorrect(t *testing
 
 func TestSigVerificationFailsIfTheExtendedProviderAddrsAreIncorrect(t *testing.T) {
 	extendedSignatureTest(t, func(adv stischema.Advertisement) {
-		adv.ExtendedProvider.Providers[1].Addresses = randomAddrs(10)
+		adv.ExtendedProvider.Providers[1].Addresses = util.RandomAddrs(10)
 		_, err := adv.VerifySignature()
 		require.Error(t, err)
 	})
@@ -276,7 +276,7 @@ func TestSignFailsIfMainProviderIsNotInExtendedList(t *testing.T) {
 
 	ep1Priv, ep1PeerID := generateIdentityAndKey(t)
 	mpPriv, mpPeerID := generateIdentityAndKey(t)
-	mpAddrs := randomAddrs(2)
+	mpAddrs := util.RandomAddrs(2)
 
 	adv := stischema.Advertisement{
 		Provider:  mpPeerID.String(),
@@ -288,7 +288,7 @@ func TestSignFailsIfMainProviderIsNotInExtendedList(t *testing.T) {
 			Providers: []stischema.Provider{
 				{
 					ID:        ep1PeerID.String(),
-					Addresses: randomAddrs(2),
+					Addresses: util.RandomAddrs(2),
 					Metadata:  []byte("ep1-metadata"),
 				},
 			},
@@ -325,7 +325,7 @@ func extendedSignatureTest(t *testing.T, testFunc func(adv stischema.Advertiseme
 
 	ep1Priv, ep1PeerID := generateIdentityAndKey(t)
 	mpPriv, mpPeerID := generateIdentityAndKey(t)
-	mpAddrs := randomAddrs(2)
+	mpAddrs := util.RandomAddrs(2)
 
 	adv := stischema.Advertisement{
 		Provider:  mpPeerID.String(),
@@ -342,7 +342,7 @@ func extendedSignatureTest(t *testing.T, testFunc func(adv stischema.Advertiseme
 				},
 				{
 					ID:        ep1PeerID.String(),
-					Addresses: randomAddrs(2),
+					Addresses: util.RandomAddrs(2),
 					Metadata:  []byte("ep1-metadata"),
 				},
 			},
@@ -364,15 +364,6 @@ func extendedSignatureTest(t *testing.T, testFunc func(adv stischema.Advertiseme
 	require.NoError(t, err)
 
 	testFunc(adv)
-}
-
-func randomAddrs(n int) []string {
-	rng := rand.New(rand.NewSource(time.Now().Unix()))
-	addrs := make([]string, n)
-	for i := 0; i < n; i++ {
-		addrs[i] = fmt.Sprintf("/ip4/%d.%d.%d.%d/tcp/%d", rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%10751)
-	}
-	return addrs
 }
 
 func generateIdentityAndKey(t *testing.T) (crypto.PrivKey, peer.ID) {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -790,7 +790,7 @@ func TestSyncWithExtendedProviders(t *testing.T) {
 		pInfo, _ := reg.ProviderInfo(providerID)
 		extendedProviders := pInfo.ExtendedProviders
 		require.NotNil(t, extendedProviders)
-		require.Equal(t, len(adv2.ExtendedProvider.Providers)-1, len(extendedProviders.Providers))
+		require.Equal(t, len(adv2.ExtendedProvider.Providers), len(extendedProviders.Providers))
 		require.Equal(t, 1, len(extendedProviders.ContextualProviders))
 
 		verifyContextualProviders(t, extendedProviders, adv1, reg)
@@ -823,7 +823,7 @@ func TestSyncWithExtendedProvidersContextualUpdate(t *testing.T) {
 		pInfo, _ := reg.ProviderInfo(providerID)
 		extendedProviders := pInfo.ExtendedProviders
 		require.NotNil(t, extendedProviders)
-		require.Equal(t, len(adv2.ExtendedProvider.Providers)-1, len(extendedProviders.Providers))
+		require.Equal(t, len(adv2.ExtendedProvider.Providers), len(extendedProviders.Providers))
 		require.Equal(t, 1, len(extendedProviders.ContextualProviders))
 
 		verifyContextualProviders(t, extendedProviders, adv3, reg)
@@ -856,7 +856,7 @@ func TestSyncWithExtendedProvidersChainLevelUpdate(t *testing.T) {
 		pInfo, _ := reg.ProviderInfo(providerID)
 		extendedProviders := pInfo.ExtendedProviders
 		require.NotNil(t, extendedProviders)
-		require.Equal(t, len(adv3.ExtendedProvider.Providers)-1, len(extendedProviders.Providers))
+		require.Equal(t, len(adv3.ExtendedProvider.Providers), len(extendedProviders.Providers))
 		require.Equal(t, 1, len(extendedProviders.ContextualProviders))
 
 		verifyContextualProviders(t, extendedProviders, adv1, reg)
@@ -889,7 +889,7 @@ func TestSyncWithExtendedProvidersContextualInsert(t *testing.T) {
 		pInfo, _ := reg.ProviderInfo(providerID)
 		extendedProviders := pInfo.ExtendedProviders
 		require.NotNil(t, extendedProviders)
-		require.Equal(t, len(adv2.ExtendedProvider.Providers)-1, len(extendedProviders.Providers))
+		require.Equal(t, len(adv2.ExtendedProvider.Providers), len(extendedProviders.Providers))
 		require.Equal(t, 2, len(extendedProviders.ContextualProviders))
 
 		verifyContextualProviders(t, extendedProviders, adv1, reg)
@@ -916,7 +916,7 @@ func verifyContextualProviders(t *testing.T, extendedProviders *registry.Extende
 	require.NotNil(t, contextualProviders)
 	require.Equal(t, adv.ContextID, contextualProviders.ContextID)
 	require.Equal(t, adv.ExtendedProvider.Override, contextualProviders.Override)
-	require.Equal(t, len(adv.ExtendedProvider.Providers)-1, len(contextualProviders.Providers))
+	require.Equal(t, len(adv.ExtendedProvider.Providers), len(contextualProviders.Providers))
 
 	contextualProviderByID := map[peer.ID]registry.ExtendedProviderInfo{}
 	for _, p := range contextualProviders.Providers {
@@ -948,10 +948,6 @@ func verifyExtendedProviders(t *testing.T,
 	for _, ep := range adExtendedProviders {
 		peerID, err := peer.Decode(ep.ID)
 		require.NoError(t, err)
-		// Skipping the main provider
-		if peerID == adProviderID {
-			continue
-		}
 
 		epInfo := providerInfosMap[peerID]
 		require.NotNil(t, epInfo)
@@ -1682,7 +1678,7 @@ func publishAdvWithExtendedProviders(t *testing.T,
 	adv.ExtendedProvider.Providers = append(adv.ExtendedProvider.Providers, schema.Provider{
 		ID:        provider.String(),
 		Addresses: addrs,
-		Metadata:  nil,
+		Metadata:  []byte{},
 	})
 	epKeys[provider.String()] = privKey
 

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -226,17 +226,11 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 
 		// Creating ExtendedProviderInfo record for each of the providers.
 		// Keeping in mind that the provider from the outer ad doesn't need to be included into the extended providers list
-		eProvs := make([]registry.ExtendedProviderInfo, 0, len(ad.ExtendedProvider.Providers)-1)
-		seenEProvs := map[peer.ID]struct{}{}
+		eProvs := make([]registry.ExtendedProviderInfo, 0, len(ad.ExtendedProvider.Providers))
 		for _, ep := range ad.ExtendedProvider.Providers {
 			epID, err := peer.Decode(ep.ID)
 			if err != nil {
 				return adIngestError{adIngestRegisterProviderErr, fmt.Errorf("could not register/update extended provider info: %w", err)}
-			}
-
-			// Skipping the record that is for provider form the main ad or if the provider has already been seen
-			if _, ok := seenEProvs[epID]; ok || ep.ID == ad.Provider {
-				continue
 			}
 
 			eProvs = append(eProvs, registry.ExtendedProviderInfo{

--- a/server/finder/http/protocol_test.go
+++ b/server/finder/http/protocol_test.go
@@ -100,6 +100,8 @@ func TestFindIndexWithExtendedProviders(t *testing.T) {
 	test.ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx, t, c, ind, reg)
 	test.ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx, t, c, ind, reg)
 	test.ContextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx, t, c, ind, reg)
+	test.MainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx, t, c, ind, reg)
+	test.MainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx, t, c, ind, reg)
 
 	err := s.Close()
 	if err != nil {

--- a/server/finder/libp2p/protocol_test.go
+++ b/server/finder/libp2p/protocol_test.go
@@ -75,6 +75,8 @@ func TestFindIndexWithExtendedProviders(t *testing.T) {
 	test.ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx, t, c, ind, reg)
 	test.ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx, t, c, ind, reg)
 	test.ContextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx, t, c, ind, reg)
+	test.MainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx, t, c, ind, reg)
+	test.MainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx, t, c, ind, reg)
 
 	if err = reg.Close(); err != nil {
 		t.Errorf("Error closing registry: %s", err)

--- a/server/finder/test/test_extended_providers.go
+++ b/server/finder/test/test_extended_providers.go
@@ -17,12 +17,13 @@ import (
 )
 
 func ProvidersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	provider1Id, _, _ := util.RandomIdentity(t)
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
 	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
 	ep1, _, _ := util.RandomIdentity(t)
 	ep1Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9997"})
-	createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+	createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, provider1Id, addrs1, &registry.ExtendedProviders{
 		Providers: []registry.ExtendedProviderInfo{
 			{
 				PeerID: ep1,
@@ -31,10 +32,11 @@ func ProvidersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.C
 		},
 	})
 
+	provider2Id, _, _ := util.RandomIdentity(t)
 	ctxId2 := []byte("test-context-id-2")
 	metadata2 := []byte("test-metadata-2")
 	addrs2 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9998"})
-	prov2, mhs2 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId2, metadata2, addrs2, nil)
+	prov2, mhs2 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId2, metadata2, provider2Id, addrs2, nil)
 
 	resp, err := c.FindBatch(ctx, mhs2[:10])
 	require.NoError(t, err)
@@ -52,6 +54,7 @@ func ProvidersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.C
 }
 
 func ExtendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	provider1Id, _, _ := util.RandomIdentity(t)
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
 	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
@@ -63,7 +66,7 @@ func ExtendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T
 	ep2, _, _ := util.RandomIdentity(t)
 	ep2Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9996"})
 	ep2Metadata := []byte("test-metadata-ep2")
-	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, provider1Id, addrs1, &registry.ExtendedProviders{
 		Providers: []registry.ExtendedProviderInfo{
 			{
 				PeerID:   ep1,
@@ -117,6 +120,7 @@ func ExtendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T
 }
 
 func ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	provider1Id, _, _ := util.RandomIdentity(t)
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
 	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
@@ -126,7 +130,7 @@ func ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context
 	ep2, _, _ := util.RandomIdentity(t)
 	ep2Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9996"})
 
-	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, provider1Id, addrs1, &registry.ExtendedProviders{
 		Providers: []registry.ExtendedProviderInfo{
 			{
 				PeerID: ep1,
@@ -178,6 +182,7 @@ func ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context
 }
 
 func ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	provider1Id, _, _ := util.RandomIdentity(t)
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
 	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
@@ -188,7 +193,7 @@ func ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 	ep2, _, _ := util.RandomIdentity(t)
 	ep2Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9996"})
 
-	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, provider1Id, addrs1, &registry.ExtendedProviders{
 		Providers: []registry.ExtendedProviderInfo{
 			{
 				PeerID: ep1,
@@ -272,6 +277,7 @@ func ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 }
 
 func ContextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	provider1Id, _, _ := util.RandomIdentity(t)
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
 	addrs1 := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9999"})
@@ -282,7 +288,7 @@ func ContextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Con
 	ep2, _, _ := util.RandomIdentity(t)
 	ep2Addrs := util.StringToMultiaddrs(t, []string{"/ip4/127.0.0.1/tcp/9996"})
 
-	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, addrs1, &registry.ExtendedProviders{
+	prov1, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, metadata1, provider1Id, addrs1, &registry.ExtendedProviders{
 		Providers: []registry.ExtendedProviderInfo{
 			{
 				PeerID: ep1,
@@ -324,9 +330,109 @@ func ContextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Con
 	require.NoError(t, err)
 }
 
-func createProviderAndPopulateIndexer(t *testing.T, ctx context.Context, ind indexer.Interface, reg *registry.Registry, contextID []byte, metadata []byte, addrs []multiaddr.Multiaddr, extendedProviders *registry.ExtendedProviders) (peer.ID, []multihash.Multihash) {
-	providerID, _, _ := util.RandomIdentity(t)
+func MainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	providerId, _, _ := util.RandomIdentity(t)
+	ctxId1 := []byte("test-context-id-1")
+	providerMetadata := []byte("provider metadata")
+	chainMetadata := []byte("chain level metadata")
+	addrs := util.StringToMultiaddrs(t, util.RandomAddrs(2))
+	chainAddrs := util.StringToMultiaddrs(t, util.RandomAddrs(2))
 
+	_, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, providerMetadata, providerId, addrs, &registry.ExtendedProviders{
+		Providers: []registry.ExtendedProviderInfo{
+			{
+				PeerID:   providerId,
+				Metadata: chainMetadata,
+				Addrs:    chainAddrs,
+			},
+		},
+		ContextualProviders: map[string]registry.ContextualExtendedProviders{string(ctxId1): {
+			ContextID: ctxId1,
+			Providers: []registry.ExtendedProviderInfo{
+				{
+					PeerID:   providerId,
+					Metadata: providerMetadata,
+					Addrs:    util.StringToMultiaddrs(t, util.RandomAddrs(2)),
+				},
+			},
+		}},
+	})
+
+	resp, err := c.FindBatch(ctx, mhs1)
+	require.NoError(t, err)
+	err = checkResponse(resp, mhs1, []model.ProviderResult{
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    providerId,
+				Addrs: addrs,
+			},
+			Metadata: providerMetadata,
+		},
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    providerId,
+				Addrs: chainAddrs,
+			},
+			Metadata: chainMetadata,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func MainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, c client.Finder, ind indexer.Interface, reg *registry.Registry) {
+	providerId, _, _ := util.RandomIdentity(t)
+	ctxId1 := []byte("test-context-id-1")
+	providerMetadata := []byte("provider metadata")
+	contextMetadata := []byte("context level metadata")
+	addrs := util.StringToMultiaddrs(t, util.RandomAddrs(2))
+	contextAddrs := util.StringToMultiaddrs(t, util.RandomAddrs(2))
+
+	_, mhs1 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId1, providerMetadata, providerId, addrs, &registry.ExtendedProviders{
+		Providers: []registry.ExtendedProviderInfo{
+			{
+				PeerID:   providerId,
+				Metadata: providerMetadata,
+				Addrs:    util.StringToMultiaddrs(t, util.RandomAddrs(2)),
+			},
+		},
+		ContextualProviders: map[string]registry.ContextualExtendedProviders{string(ctxId1): {
+			ContextID: ctxId1,
+			Providers: []registry.ExtendedProviderInfo{
+				{
+					PeerID:   providerId,
+					Metadata: contextMetadata,
+					Addrs:    contextAddrs,
+				},
+			},
+		}},
+	})
+
+	resp, err := c.FindBatch(ctx, mhs1)
+	require.NoError(t, err)
+	err = checkResponse(resp, mhs1, []model.ProviderResult{
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    providerId,
+				Addrs: addrs,
+			},
+			Metadata: providerMetadata,
+		},
+		{
+			ContextID: ctxId1,
+			Provider: peer.AddrInfo{
+				ID:    providerId,
+				Addrs: contextAddrs,
+			},
+			Metadata: contextMetadata,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func createProviderAndPopulateIndexer(t *testing.T, ctx context.Context, ind indexer.Interface, reg *registry.Registry, contextID []byte, metadata []byte, providerID peer.ID, addrs []multiaddr.Multiaddr, extendedProviders *registry.ExtendedProviders) (peer.ID, []multihash.Multihash) {
 	// Generate some multihashes and populate indexer
 	mhs := util.RandomMultihashes(10, rng)
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,8 +1,10 @@
 package util
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -51,4 +53,13 @@ func StringToMultiaddrs(t *testing.T, addrs []string) []multiaddr.Multiaddr {
 		mAddrs[i] = ma
 	}
 	return mAddrs
+}
+
+func RandomAddrs(n int) []string {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	addrs := make([]string, n)
+	for i := 0; i < n; i++ {
+		addrs[i] = fmt.Sprintf("/ip4/%d.%d.%d.%d/tcp/%d", rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%10751)
+	}
+	return addrs
 }


### PR DESCRIPTION
If metadata of the main provider's EP record is different from the one in the ad, then such records would be returned in the find resultset as separate entries. This feature is required if the the main provider would like to advertise some new endpoints for a different protocol.