### PR TITLE
Switch static web UI url to the new repo at IPNI GitHub Org

### DIFF
--- a/config/finder.go
+++ b/config/finder.go
@@ -27,7 +27,7 @@ func NewFinder() Finder {
 		ApiReadTimeout:  Duration(30 * time.Second),
 		ApiWriteTimeout: Duration(30 * time.Second),
 		MaxConnections:  8_000,
-		Webpage:         "https://web.cid.contact/",
+		Webpage:         "https://web-ipni.cid.contact/",
 	}
 }
 

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
@@ -7,7 +7,7 @@
   "Addresses": {
     "Admin": "/ip4/0.0.0.0/tcp/3002",
     "Finder": "/ip4/0.0.0.0/tcp/3000",
-    "FinderWebpage": "https://web.cid.contact/dev",
+    "FinderWebpage": "https://web-ipni.cid.contact/dev",
     "Ingest": "/ip4/0.0.0.0/tcp/3001",
     "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
     "NoResourceManager": true

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
@@ -7,7 +7,7 @@
   "Addresses": {
     "Admin": "/ip4/0.0.0.0/tcp/3002",
     "Finder": "/ip4/0.0.0.0/tcp/3000",
-    "FinderWebpage": "https://web.cid.contact/dev",
+    "FinderWebpage": "https://web-ipni.cid.contact/dev",
     "Ingest": "/ip4/0.0.0.0/tcp/3001",
     "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
     "NoResourceManager": true

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -7,7 +7,7 @@
   "Addresses": {
     "Admin": "/ip4/0.0.0.0/tcp/3002",
     "Finder": "/ip4/0.0.0.0/tcp/3000",
-    "FinderWebpage": "https://web.cid.contact/",
+    "FinderWebpage": "https://web-ipni.cid.contact/",
     "Ingest": "/ip4/0.0.0.0/tcp/3001",
     "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
     "NoResourceManager": true

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
@@ -7,7 +7,7 @@
   "Addresses": {
     "Admin": "/ip4/0.0.0.0/tcp/3002",
     "Finder": "/ip4/0.0.0.0/tcp/3000",
-    "FinderWebpage": "https://web.cid.contact/",
+    "FinderWebpage": "https://web-ipni.cid.contact/",
     "Ingest": "/ip4/0.0.0.0/tcp/3001",
     "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
     "NoResourceManager": true

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -7,7 +7,7 @@
   "Addresses": {
     "Admin": "/ip4/0.0.0.0/tcp/3002",
     "Finder": "/ip4/0.0.0.0/tcp/3000",
-    "FinderWebpage": "https://web.cid.contact/",
+    "FinderWebpage": "https://web-ipni.cid.contact/",
     "Ingest": "/ip4/0.0.0.0/tcp/3001",
     "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
     "NoResourceManager": true

--- a/doc/config.md
+++ b/doc/config.md
@@ -70,7 +70,7 @@ config file at runtime.
     "ApiReadTimeout": "30s",
     "ApiWriteTimeout": "30s",
     "MaxConnections": 8000,
-    "Webpage": "https://web.cid.contact/"
+    "Webpage": "https://web-ipni.cid.contact/"
   },
   "Indexer": {
     "CacheSize": 300000,
@@ -217,7 +217,7 @@ Default:
   "ApiReadTimeout": "30s",
   "ApiWriteTimeout": "30s",
   "MaxConnections": 8000,
-  "Webpage": "https://web.cid.contact/"
+  "Webpage": "https://web-ipni.cid.contact/"
 }
 ```
 

--- a/server/finder/http/handler_test.go
+++ b/server/finder/http/handler_test.go
@@ -156,5 +156,5 @@ func TestServer_Landing(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 	gotBody := rr.Body.String()
 	require.NotEmpty(t, gotBody)
-	require.True(t, strings.Contains(gotBody, "https://web.cid.contact/"))
+	require.True(t, strings.Contains(gotBody, "https://web-ipni.cid.contact/"))
 }

--- a/server/finder/http/options.go
+++ b/server/finder/http/options.go
@@ -11,7 +11,7 @@ const (
 	apiWriteTimeout = 30 * time.Second
 	apiReadTimeout  = 30 * time.Second
 	maxConns        = 8_000
-	defaultHomepage = "https://web.cid.contact/"
+	defaultHomepage = "https://web-ipni.cid.contact/"
 )
 
 // serverConfig is a structure containing all the options that can be used when constructing an http server


### PR DESCRIPTION
`CNAME`s are unique across all GitHub Pages repos. The current one is in use by repo under `willscott` and changing it requires admin access to the repo.

For faster turnaround, switch this in code. This also avoids breaking other DNS set up under `willscott.github.io`.
