### PR TITLE
Add `heyfil` deployment manifests to VCS

### DIFF
--- a/deploy/manifests/base/heyfil/deployment.yaml
+++ b/deploy/manifests/base/heyfil/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: heyfil
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: heyfil
+  template:
+    metadata:
+      labels:
+        app: heyfil
+    spec:
+      containers:
+        - name: heyfil
+          image: heyfil
+          env:
+            - name: GOLOG_LOG_LEVEL
+              value: INFO
+            - name: GOLOG_LOG_FMT
+              value: json
+          ports:
+            - containerPort: 8080
+              name: metrics

--- a/deploy/manifests/base/heyfil/kustomization.yaml
+++ b/deploy/manifests/base/heyfil/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+
+commonLabels:
+  app: heyfil

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: heyfil
+spec:
+  template:
+    spec:
+      containers:
+        - name: heyfil
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/heyfil
+  - monitor.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: heyfil
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/heyfil
+    newTag: 20221111134142-b6580fb2184bf0a6d85b69c572a83d31aa5c749d

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: heyfil
+  labels:
+    app: heyfil
+spec:
+  selector:
+    matchLabels:
+      app: heyfil
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: storetheindex
 resources:
 - instances
 - indexstar
+- heyfil
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Add the deployment manifests belonging to `heyfil` to `prod` deploy folder of storetheindex so that they are version controlled.

The structure to be revisited on move to IPNI org.

