### PR TITLE
Marshal/Unmarshal dagsync http multiaddrs

### DIFF
--- a/api/v0/finder/model/model_test.go
+++ b/api/v0/finder/model/model_test.go
@@ -41,10 +41,15 @@ func TestMarshal(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	m2, err := multiaddr.NewMultiaddr("/dns4/ipni.io/tcp/443/https/httpath/http-cid-data")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Masrhal response and check e2e
 	t.Log("e2e marshalling response")
 	resp := &FindResponse{
-		MultihashResults: make([]MultihashResult, 0),
+		MultihashResults: []MultihashResult{},
 	}
 
 	providerResult := ProviderResult{
@@ -52,7 +57,7 @@ func TestMarshal(t *testing.T) {
 		Metadata:  metadata,
 		Provider: peer.AddrInfo{
 			ID:    p,
-			Addrs: []multiaddr.Multiaddr{m1},
+			Addrs: []multiaddr.Multiaddr{m1, m2},
 		},
 	}
 

--- a/api/v0/finder/model/provider_info.go
+++ b/api/v0/finder/model/provider_info.go
@@ -3,6 +3,7 @@ package model
 import (
 	"time"
 
+	_ "github.com/filecoin-project/storetheindex/dagsync/httpsync/maconv"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"


### PR DESCRIPTION
Multiaddr needs to recognize `httppath` part of http multiaddr. Fixed by importing code to register `httppath` protocol with multiaddr.

Fixes #992
