### PR TITLE
API to get addresses publisher is listening on

### DIFF
--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -190,7 +189,7 @@ func TestAnnounce_LearnsHttpPublisherAddr(t *testing.T) {
 	// Announce one CID to the subscriber. Note that announce does a sync in the background.
 	// That's why we use one cid here and another for sync so that we can concretely assert that
 	// data was synced via the sync call and not via the earlier background sync via announce.
-	err = sub.Announce(ctx, oneC, pubh.ID(), []multiaddr.Multiaddr{pub.Address()})
+	err = sub.Announce(ctx, oneC, pubh.ID(), pub.Addrs())
 	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()

--- a/dagsync/dtsync/publisher.go
+++ b/dagsync/dtsync/publisher.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
-	ma "github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr"
 )
 
 type publisher struct {
@@ -129,6 +129,10 @@ func NewPublisherFromExisting(dtManager dt.Manager, host host.Host, topic string
 	return p, nil
 }
 
+func (p *publisher) Addrs() []multiaddr.Multiaddr {
+	return p.host.Addrs()
+}
+
 func (p *publisher) SetRoot(ctx context.Context, c cid.Cid) error {
 	if c == cid.Undef {
 		return errors.New("cannot update to an undefined cid")
@@ -141,7 +145,7 @@ func (p *publisher) UpdateRoot(ctx context.Context, c cid.Cid) error {
 	return p.UpdateRootWithAddrs(ctx, c, p.host.Addrs())
 }
 
-func (p *publisher) UpdateRootWithAddrs(ctx context.Context, c cid.Cid, addrs []ma.Multiaddr) error {
+func (p *publisher) UpdateRootWithAddrs(ctx context.Context, c cid.Cid, addrs []multiaddr.Multiaddr) error {
 	err := p.SetRoot(ctx, c)
 	if err != nil {
 		return err

--- a/dagsync/http_test.go
+++ b/dagsync/http_test.go
@@ -72,7 +72,7 @@ func setupPublisherSubscriber(t *testing.T, subscriberOptions []dagsync.Option) 
 		srcStore:   srcStore,
 		srcLinkSys: srcLinkSys,
 		dstStore:   dstStore,
-		pubAddr:    httpPub.Address(),
+		pubAddr:    httpPub.Addrs()[0],
 	}
 }
 

--- a/dagsync/httpsync/publisher.go
+++ b/dagsync/httpsync/publisher.go
@@ -69,10 +69,10 @@ func NewPublisher(address string, lsys ipld.LinkSystem, peerID peer.ID, privKey 
 	return pub, nil
 }
 
-// Address returns the address, as a multiaddress, that the publisher is
+// Addrs returns the addresses, as []multiaddress, that the publisher is
 // listening on.
-func (p *publisher) Address() multiaddr.Multiaddr {
-	return p.addr
+func (p *publisher) Addrs() []multiaddr.Multiaddr {
+	return []multiaddr.Multiaddr{p.addr}
 }
 
 func (p *publisher) SetRoot(ctx context.Context, c cid.Cid) error {

--- a/dagsync/httpsync/sync_test.go
+++ b/dagsync/httpsync/sync_test.go
@@ -132,7 +132,7 @@ func TestHttpsync_AcceptsSpecCompliantDagJson(t *testing.T) {
 
 		pub, err := httpsync.NewPublisher("0.0.0.0:0", publs, pubID, pubPrK)
 		require.NoError(t, err)
-		pubAddr = pub.Address()
+		pubAddr = pub.Addrs()[0]
 		t.Cleanup(func() { require.NoError(t, pub.Close()) })
 
 		link, err := publs.Store(

--- a/dagsync/interface.go
+++ b/dagsync/interface.go
@@ -5,17 +5,19 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
-	ma "github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr"
 )
 
 // Publisher is an interface for updating the published dag.
 type Publisher interface {
+	// Addrs returns the addresses that the publisher is listening on.
+	Addrs() []multiaddr.Multiaddr
 	// SetRoot sets the root CID without publishing it.
 	SetRoot(context.Context, cid.Cid) error
 	// UpdateRoot sets the root CID and publishes its update in the pubsub channel.
 	UpdateRoot(context.Context, cid.Cid) error
 	// UpdateRootWithAddrs publishes an update for the DAG in the pubsub channel using custom multiaddrs.
-	UpdateRootWithAddrs(context.Context, cid.Cid, []ma.Multiaddr) error
+	UpdateRootWithAddrs(context.Context, cid.Cid, []multiaddr.Multiaddr) error
 	// Close publisher
 	Close() error
 }

--- a/dagsync/subscriber_test.go
+++ b/dagsync/subscriber_test.go
@@ -772,7 +772,7 @@ func (b dagsyncPubSubBuilder) Build(t *testing.T, topicName string, pubSys hostS
 		require.NoError(t, err)
 		httpPub, err := httpsync.NewPublisher("127.0.0.1:0", pubSys.lsys, id, pubSys.privKey)
 		require.NoError(t, err)
-		pubAddr = httpPub.Address()
+		pubAddr = httpPub.Addrs()[0]
 		pub = httpPub
 	} else {
 		pub, err = dtsync.NewPublisher(pubSys.host, pubSys.ds, pubSys.lsys, topicName)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.5.1"
+  "version": "v0.5.2"
 }


### PR DESCRIPTION
This allows seeing what interface/port the publisher's listener is bound to.

This is needed to fix https://github.com/filecoin-project/index-provider/issues/300
