### PR TITLE
Fix assigner deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ LABEL maintainer="Andrew Gillis <andrew.gillis@protocol.ai>"
 ENV SRC_DIR /storetheindex
 COPY --from=builder storetheindex/storetheindex /usr/local/bin/storetheindex
 COPY --from=builder storetheindex/scripts/start_storetheindex /usr/local/bin/start_storetheindex
+COPY --from=builder storetheindex/scripts/start_assigner /usr/local/bin/start_assigner
 COPY --from=builder /tmp/su-exec/su-exec-static /sbin/su-exec
 COPY --from=builder /tmp/tini /sbin/tini
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs

--- a/deploy/manifests/base/assigner/deployment.yaml
+++ b/deploy/manifests/base/assigner/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: assigner
           image: storetheindex
-          command: ["start_assigner"]
+          command: ["/sbin/tini", "--", "/usr/local/bin/start_assigner"]
           env:
             - name: GOLOG_LOG_LEVEL
               value: INFO


### PR DESCRIPTION
- Docker file needs to copy assigner start script
- Revise ENTRYPOINT override.

This will require a follow-up PR to use the new docker image.