### PR TITLE
Provide items for Dockerfile ENTRYPOINT and CMD in deployment.yaml

### DIFF
--- a/deploy/manifests/base/assigner/deployment.yaml
+++ b/deploy/manifests/base/assigner/deployment.yaml
@@ -35,7 +35,6 @@ spec:
               name: http
             - containerPort: 8081
               name: metrics
-          volumeMounts:
           readinessProbe:
             httpGet:
               port: http

--- a/deploy/manifests/base/assigner/deployment.yaml
+++ b/deploy/manifests/base/assigner/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         - name: assigner
           image: storetheindex
           command: ["/sbin/tini", "--", "/usr/local/bin/start_assigner"]
+          args: ["daemon"]
           env:
             - name: GOLOG_LOG_LEVEL
               value: INFO

--- a/deploy/manifests/base/assigner/deployment.yaml
+++ b/deploy/manifests/base/assigner/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               value: INFO
             - name: GOLOG_LOG_FMT
               value: json
-            - name: ASSIGNER_PRIV_KEY_PATH
+            - name: STORETHEINDEX_PRIV_KEY_PATH
               value: /identity/identity.key
             - name: ASSIGNER_PATH
               value: /config

--- a/deploy/manifests/base/assigner/deployment.yaml
+++ b/deploy/manifests/base/assigner/deployment.yaml
@@ -20,7 +20,8 @@ spec:
         - name: assigner
           image: storetheindex
           command: ["/sbin/tini", "--", "/usr/local/bin/start_assigner"]
-          args: ["daemon"]
+          args:
+            - 'daemon'
           env:
             - name: GOLOG_LOG_LEVEL
               value: INFO


### PR DESCRIPTION
Since `command` is used in deployment.yaml, this overrides both `ENTRYPOINT` and `CMD` in Dockerfile.
