### PR TITLE
Configure dev indexers to use assigner service

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
@@ -51,7 +51,8 @@
     "PollStopAfter": "168h0m0s",
     "PollOverrides": null,
     "RediscoverWait": "5m0s",
-    "Timeout": "2m0s"
+    "Timeout": "2m0s",
+    "UseAssigner": true
   },
   "Indexer": {
     "CacheSize": -1,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
@@ -51,7 +51,8 @@
     "PollStopAfter": "168h0m0s",
     "PollOverrides": null,
     "RediscoverWait": "5m0s",
-    "Timeout": "2m0s"
+    "Timeout": "2m0s",
+    "UseAssigner": true
   },
   "Indexer": {
     "CacheSize": -1,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 20221128155842-5eb5617401d6be67d4c4a40e2cab02924b3f25f0 # {"$imagepolicy": "storetheindex:storetheindex:tag"}
+  newTag: 20221130172901-8f39f4a96b8cdc00f46d6677b93b22a58131c573 # {"$imagepolicy": "storetheindex:storetheindex:tag"}


### PR DESCRIPTION
- Use latest image for dev indexers
- Configure ber and cali to use assigner service