### PR TITLE
Fix empty providers listing by `indexstar`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20221128135450-9c7fdaa690e587a45d9d8a248b1af81d061efbdd
+    newTag:  20221201110144-97695b30018b73af427805d3a5065b357a0f41f2


### PR DESCRIPTION
Deploy latest to fix empty providers listing by `/providers` in indexstar.

