### PR TITLE
Redirect HTTP announce messages to assigner node

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -220,6 +220,11 @@ func daemonCommand(cctx *cli.Context) error {
 			p2pfinderserver.New(ctx, p2pHost, indexerCore, reg, indexCounts)
 		}
 
+		// Do not resend direct announce messages if using an assigner service.
+		if cfg.Discovery.UseAssigner {
+			cfg.Ingest.ResendDirectAnnounce = false
+		}
+
 		// Initialize ingester.
 		ingester, err = ingest.NewIngester(cfg.Ingest, p2pHost, indexerCore, reg, dstore, indexCounts)
 		if err != nil {

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -53,7 +53,8 @@ type Ingest struct {
 	// ResendDirectAnnounce determines whether or not to re-publish direct
 	// announce messages over gossip pubsub. When a single indexer receives an
 	// announce message via HTTP, enabling this lets the indexers re-publish
-	// the announce so that other indexers can also receive it.
+	// the announce so that other indexers can also receive it. This is always
+	// false if configured to use an assigner.
 	ResendDirectAnnounce bool
 	// StoreBatchSize is the number of entries in each write to the value
 	// store. Specifying a value less than 2 disables batching. This should be

--- a/deploy/infrastructure/dev/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/dev/us-east-2/cloudfront.tf
@@ -13,14 +13,14 @@ resource "aws_cloudfront_distribution" "cdn" {
   ]
   price_class = "PriceClass_All"
 
-  # The node named `ber` in dev environment uses an identity that is whitelisted by Lotus 
+  # The node named `assigner` in dev environment uses an identity that is whitelisted by Lotus 
   # bootstrap nodes in order to relay gossipsub. That node is also configured to re-propagate 
   # HTTP announces over gossipsub.
   # Therefore, all HTTP announce requests are routed to it. 
   # 
-  # See: storetheindex/ber-indexer ingress object.
+  # See: storetheindex/assigner-indexer ingress object.
   origin {
-    domain_name = "ber.${aws_route53_zone.dev_external.name}"
+    domain_name = "assigner.${aws_route53_zone.dev_external.name}"
     origin_id   = local.http_announce_origin_id
     custom_origin_config {
       http_port              = 80

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
@@ -77,7 +77,7 @@
       "BlocksPerSecond": 0,
       "BurstSize": 500
     },
-    "ResendDirectAnnounce": true,
+    "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
     "SyncTimeout": "2h0m0s"

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
@@ -77,7 +77,7 @@
       "BlocksPerSecond": 0,
       "BurstSize": 500
     },
-    "ResendDirectAnnounce": true,
+    "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
     "SyncTimeout": "2h0m0s"


### PR DESCRIPTION
Direct HTTP announce messages need to be routed to the assigner node.

Also, do not have other dev indexers republish direct announce messages.
