### PR TITLE
Do not auto-assign all publishers

### DIFF
--- a/assigner/config/assignment.go
+++ b/assigner/config/assignment.go
@@ -14,8 +14,9 @@ type Assignment struct {
 	// PubSubTopic sets the topic name to which to subscribe for ingestion
 	// announcements.
 	PubSubTopic string
-	// Replication is the number of indexers to assign each publisher to. If
-	// set to 0, the default, then assign to all indexers.
+	// Replication is the number of indexers to assign each publisher to, when
+	// the publisher does not have a preset assignment. A value <= 0 assigns
+	// each publisher to one indexer.
 	Replication int
 }
 
@@ -37,6 +38,7 @@ func NewAssignment() Assignment {
 	return Assignment{
 		Policy:      NewPolicy(),
 		PubSubTopic: "/indexer/ingest/mainnet",
+		Replication: 1,
 	}
 }
 
@@ -46,5 +48,8 @@ func (c *Assignment) populateUnset() {
 
 	if c.PubSubTopic == "" {
 		c.PubSubTopic = def.PubSubTopic
+	}
+	if c.Replication <= 0 {
+		c.Replication = def.Replication
 	}
 }

--- a/assigner/core/assigner_test.go
+++ b/assigner/core/assigner_test.go
@@ -68,6 +68,7 @@ func TestAssignerAll(t *testing.T) {
 			Allow: true,
 		},
 		PubSubTopic: "testtopic",
+		Replication: 2,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/assigner/core/assigner_test.go
+++ b/assigner/core/assigner_test.go
@@ -43,11 +43,11 @@ func init() {
 	}
 }
 
-func TestNewAssigner(t *testing.T) {
-	fakeIndexer1 := newTestIndexer()
+func TestAssignerAll(t *testing.T) {
+	fakeIndexer1 := newTestIndexer(nil)
 	defer fakeIndexer1.close()
 
-	fakeIndexer2 := newTestIndexer()
+	fakeIndexer2 := newTestIndexer(nil)
 	defer fakeIndexer2.close()
 
 	cfgAssignment := config.Assignment{
@@ -87,11 +87,16 @@ func TestNewAssigner(t *testing.T) {
 	assigned = assigner.Assigned(peer2ID)
 	require.Zero(t, len(assigned), "peer2 should not be assigned to any indexers")
 
+	counts := assigner.IndexerAssignedCounts()
+	require.Equal(t, 2, len(counts))
+	require.Equal(t, 1, counts[0])
+	require.Equal(t, 1, counts[1])
+
 	asmtChan, cancel := assigner.OnAssignment(peer2ID)
 	defer cancel()
 
 	// Send announce message for publisher peer2. It has a preset assignment to
-	// indexer1, so should only be assigned to that indexer.
+	// indexer0, so should only be assigned to that indexer.
 	adCid, _ := cid.Decode("bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy")
 	a, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/9999")
 	addrInfo := peer.AddrInfo{
@@ -122,6 +127,11 @@ func TestNewAssigner(t *testing.T) {
 	}
 	require.Equal(t, 1, len(assigns))
 	require.Equal(t, 0, assigns[0])
+
+	counts = assigner.IndexerAssignedCounts()
+	require.Equal(t, 2, len(counts))
+	require.Equal(t, 2, counts[0])
+	require.Equal(t, 1, counts[1])
 
 	asmtChan, cancel = assigner.OnAssignment(peer3ID)
 	defer cancel()
@@ -155,6 +165,11 @@ func TestNewAssigner(t *testing.T) {
 	sort.Ints(assigns)
 	require.Equal(t, []int{0, 1}, assigns)
 
+	counts = assigner.IndexerAssignedCounts()
+	require.Equal(t, 2, len(counts))
+	require.Equal(t, 3, counts[0])
+	require.Equal(t, 2, counts[1])
+
 	_, lateCancel := assigner.OnAssignment(peer2ID)
 	require.NoError(t, assigner.Close())
 	// Test that second close is OK.
@@ -163,20 +178,299 @@ func TestNewAssigner(t *testing.T) {
 	lateCancel()
 }
 
+func TestAssignerOne(t *testing.T) {
+	fakeIndexer1 := newTestIndexer(nil)
+	defer fakeIndexer1.close()
+
+	fakeIndexer2 := newTestIndexer(nil)
+	defer fakeIndexer2.close()
+
+	cfgAssignment := config.Assignment{
+		// IndexerPool is the set of indexers the pool.
+		IndexerPool: []config.Indexer{
+			{
+				AdminURL:  fakeIndexer1.adminServer.URL,
+				IngestURL: fakeIndexer1.ingestServer.URL,
+			},
+			{
+				AdminURL:  fakeIndexer2.adminServer.URL,
+				IngestURL: fakeIndexer2.ingestServer.URL,
+			},
+		},
+		Policy: config.Policy{
+			Allow: true,
+		},
+		PubSubTopic: "testtopic",
+		Replication: 1,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	assigner, err := core.NewAssigner(ctx, cfgAssignment, nil)
+	require.NoError(t, err)
+
+	assigned := assigner.Assigned(peer1ID)
+	require.Equal(t, 2, len(assigned), "peer1 should be assigned to 2 indexers")
+
+	assigned = assigner.Assigned(peer2ID)
+	require.Zero(t, len(assigned), "peer2 should not be assigned to any indexers")
+
+	counts := assigner.IndexerAssignedCounts()
+	require.Equal(t, 2, len(counts))
+	require.Equal(t, 1, counts[0])
+	require.Equal(t, 1, counts[1])
+
+	asmtChan, cancel := assigner.OnAssignment(peer2ID)
+	defer cancel()
+
+	// Send announce for publisher peer2. It should be assigned to indexer 0.
+	adCid, _ := cid.Decode("bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy")
+	a, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/9999")
+	addrInfo := peer.AddrInfo{
+		ID:    peer2ID,
+		Addrs: []multiaddr.Multiaddr{a},
+	}
+	err = assigner.Announce(ctx, adCid, addrInfo)
+	require.NoError(t, err)
+
+	var assignNum int
+	var assigns []int
+	timeout := time.NewTimer(3 * time.Second)
+	open := true
+	for open {
+		select {
+		case assignNum, open = <-asmtChan:
+			if !open {
+				break
+			}
+			t.Log("Publisher", peer2IDStr, "assigned to indexer", assignNum)
+			assigns = append(assigns, assignNum)
+		case <-timeout.C:
+			t.Fatal("timed out waiting for assignment")
+		}
+	}
+	if !timeout.Stop() {
+		<-timeout.C
+	}
+	require.Equal(t, 1, len(assigns))
+	require.Equal(t, 0, assigns[0])
+
+	counts = assigner.IndexerAssignedCounts()
+	require.Equal(t, 2, len(counts))
+	require.Equal(t, 2, counts[0])
+	require.Equal(t, 1, counts[1])
+
+	asmtChan, cancel = assigner.OnAssignment(peer3ID)
+	defer cancel()
+
+	// Send announce for publisher peer3. It should be assigned to indexer 1.
+	adCid, _ = cid.Decode("QmNiV8rwXeC92hufGNu5qJ6L9AygrvDyi63gEpCQaqsE9B")
+	addrInfo.ID = peer3ID
+	err = assigner.Announce(ctx, adCid, addrInfo)
+	require.NoError(t, err)
+
+	assigns = assigns[:0]
+	timeout.Reset(3 * time.Second)
+	open = true
+	for open {
+		select {
+		case assignNum, open = <-asmtChan:
+			if !open {
+				break
+			}
+			assigns = append(assigns, assignNum)
+			t.Log("Publisher", peer3IDStr, "assigned to indexer", assignNum)
+		case <-timeout.C:
+			t.Fatal("timed out waiting for assignment")
+		}
+	}
+	if !timeout.Stop() {
+		<-timeout.C
+	}
+	require.Equal(t, 1, len(assigns))
+	require.Equal(t, 1, assigns[0])
+
+	counts = assigner.IndexerAssignedCounts()
+	require.Equal(t, 2, len(counts))
+	require.Equal(t, 2, counts[0])
+	require.Equal(t, 2, counts[1])
+
+	require.NoError(t, assigner.Close())
+}
+
+func TestAssignerPreferred(t *testing.T) {
+	testAdminHandler0 := func(w http.ResponseWriter, req *http.Request) {
+		defer req.Body.Close()
+		if req.Method == "GET" {
+			writeJsonResponse(w, http.StatusNoContent, nil)
+		} else {
+			writeJsonResponse(w, http.StatusOK, nil)
+		}
+	}
+
+	testAdminHandler1 := func(w http.ResponseWriter, req *http.Request) {
+		defer req.Body.Close()
+		if req.Method == "GET" {
+			switch req.URL.String() {
+			case "/ingest/preferred":
+				peers := []string{peer1IDStr, peer2IDStr, peer3IDStr}
+				data, err := json.Marshal(peers)
+				if err != nil {
+					panic(err.Error())
+				}
+				writeJsonResponse(w, http.StatusOK, data)
+			case "/ingest/assigned":
+				writeJsonResponse(w, http.StatusNoContent, nil)
+			default:
+				http.Error(w, "", http.StatusNotFound)
+			}
+		} else {
+			writeJsonResponse(w, http.StatusOK, nil)
+		}
+	}
+
+	fakeIndexer1 := newTestIndexer(testAdminHandler0)
+	defer fakeIndexer1.close()
+
+	fakeIndexer2 := newTestIndexer(testAdminHandler1)
+	defer fakeIndexer2.close()
+
+	cfgAssignment := config.Assignment{
+		// IndexerPool is the set of indexers the pool.
+		IndexerPool: []config.Indexer{
+			{
+				AdminURL:  fakeIndexer1.adminServer.URL,
+				IngestURL: fakeIndexer1.ingestServer.URL,
+			},
+			{
+				AdminURL:  fakeIndexer2.adminServer.URL,
+				IngestURL: fakeIndexer2.ingestServer.URL,
+			},
+		},
+		Policy: config.Policy{
+			Allow: true,
+		},
+		PubSubTopic: "testtopic",
+		Replication: 1,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	assigner, err := core.NewAssigner(ctx, cfgAssignment, nil)
+	require.NoError(t, err)
+
+	assigned := assigner.Assigned(peer1ID)
+	require.Zero(t, len(assigned), "peer1 should be assigned to 0 indexers")
+
+	assigned = assigner.Assigned(peer2ID)
+	require.Zero(t, len(assigned), "peer2 should be assigned to 0 indexers")
+
+	counts := assigner.IndexerAssignedCounts()
+	require.Equal(t, 2, len(counts))
+	require.Equal(t, 0, counts[0])
+	require.Equal(t, 0, counts[1])
+
+	asmtChan, cancel := assigner.OnAssignment(peer2ID)
+	defer cancel()
+
+	// Send announce for publisher peer2. It should be assigned to indexer 0.
+	adCid, _ := cid.Decode("bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy")
+	a, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/9999")
+	addrInfo := peer.AddrInfo{
+		ID:    peer2ID,
+		Addrs: []multiaddr.Multiaddr{a},
+	}
+	err = assigner.Announce(ctx, adCid, addrInfo)
+	require.NoError(t, err)
+
+	var assignNum int
+	var assigns []int
+	timeout := time.NewTimer(3 * time.Second)
+	open := true
+	for open {
+		select {
+		case assignNum, open = <-asmtChan:
+			if !open {
+				break
+			}
+			t.Log("Publisher", peer2IDStr, "assigned to indexer", assignNum)
+			assigns = append(assigns, assignNum)
+		case <-timeout.C:
+			t.Fatal("timed out waiting for assignment")
+		}
+	}
+	if !timeout.Stop() {
+		<-timeout.C
+	}
+	require.Equal(t, 1, len(assigns))
+	require.Equal(t, 1, assigns[0], "expected assignment to indexer 1")
+
+	counts = assigner.IndexerAssignedCounts()
+	require.Equal(t, 2, len(counts))
+	require.Equal(t, 0, counts[0])
+	require.Equal(t, 1, counts[1])
+
+	asmtChan, cancel = assigner.OnAssignment(peer3ID)
+	defer cancel()
+
+	// Send announce for publisher peer3. It should be assigned to indexer 1.
+	adCid, _ = cid.Decode("QmNiV8rwXeC92hufGNu5qJ6L9AygrvDyi63gEpCQaqsE9B")
+	addrInfo.ID = peer3ID
+	err = assigner.Announce(ctx, adCid, addrInfo)
+	require.NoError(t, err)
+
+	assigns = assigns[:0]
+	timeout.Reset(3 * time.Second)
+	open = true
+	for open {
+		select {
+		case assignNum, open = <-asmtChan:
+			if !open {
+				break
+			}
+			assigns = append(assigns, assignNum)
+			t.Log("Publisher", peer3IDStr, "assigned to indexer", assignNum)
+		case <-timeout.C:
+			t.Fatal("timed out waiting for assignment")
+		}
+	}
+	if !timeout.Stop() {
+		<-timeout.C
+	}
+	require.Equal(t, 1, len(assigns))
+	require.Equal(t, 1, assigns[0], "expected assignment to indexer 1")
+
+	counts = assigner.IndexerAssignedCounts()
+	require.Equal(t, 2, len(counts))
+	require.Equal(t, 0, counts[0])
+	require.Equal(t, 2, counts[1])
+
+	require.NoError(t, assigner.Close())
+}
+
 type testIndexer struct {
 	adminServer  *httptest.Server
 	ingestServer *httptest.Server
 }
 
-func testAdminHandler(w http.ResponseWriter, req *http.Request) {
+func defaultTestAdminHandler(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
 	if req.Method == "GET" {
-		peers := []string{peer1IDStr}
-		data, err := json.Marshal(peers)
-		if err != nil {
-			panic(err.Error())
+		switch req.URL.String() {
+		case "/ingest/assigned":
+			peers := []string{peer1IDStr}
+			data, err := json.Marshal(peers)
+			if err != nil {
+				panic(err.Error())
+			}
+			writeJsonResponse(w, http.StatusOK, data)
+		case "/ingest/preferred":
+			writeJsonResponse(w, http.StatusNoContent, nil)
+		default:
+			http.Error(w, "", http.StatusNotFound)
 		}
-		writeJsonResponse(w, http.StatusOK, data)
 	} else {
 		writeJsonResponse(w, http.StatusOK, nil)
 	}
@@ -187,13 +481,15 @@ func testIngestHandler(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func newTestIndexer() *testIndexer {
-	adminServer := httptest.NewServer(http.HandlerFunc(testAdminHandler))
-	ingestServer := httptest.NewServer(http.HandlerFunc(testIngestHandler))
+func newTestIndexer(adminHandler func(http.ResponseWriter, *http.Request)) *testIndexer {
+	ah := defaultTestAdminHandler
+	if adminHandler != nil {
+		ah = adminHandler
+	}
 
 	return &testIndexer{
-		adminServer:  adminServer,
-		ingestServer: ingestServer,
+		adminServer:  httptest.NewServer(http.HandlerFunc(ah)),
+		ingestServer: httptest.NewServer(http.HandlerFunc(testIngestHandler)),
 	}
 }
 

--- a/assigner/core/order_test.go
+++ b/assigner/core/order_test.go
@@ -1,0 +1,40 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrdering(t *testing.T) {
+	pool := make([]indexerInfo, 10)
+	for i := range pool {
+		pool[i].assigned = int32(len(pool) - i)
+	}
+
+	assigner := &Assigner{
+		indexerPool: pool,
+	}
+
+	candidates := make([]int, len(pool))
+	for i := range candidates {
+		candidates[i] = i
+	}
+
+	assigner.orderCandidates(candidates, []int{1, 3})
+	require.Equal(t, []int{3, 1, 9, 8, 7, 6, 5, 4, 2, 0}, candidates)
+
+	assigner.orderCandidates(candidates, candidates)
+	require.Equal(t, []int{9, 8, 7, 6, 5, 4, 3, 2, 1, 0}, candidates)
+
+	assigner.orderCandidates(candidates, nil)
+	require.Equal(t, []int{9, 8, 7, 6, 5, 4, 3, 2, 1, 0}, candidates)
+
+	assigner.indexerPool[5].assigned = 0
+	assigner.orderCandidates(candidates, nil)
+	require.Equal(t, []int{5, 9, 8, 7, 6, 4, 3, 2, 1, 0}, candidates)
+
+	assigner.indexerPool[5].assigned = 0
+	assigner.orderCandidates(candidates, []int{2, 0, 1})
+	require.Equal(t, []int{2, 1, 0, 5, 9, 8, 7, 6, 4, 3}, candidates)
+}

--- a/command/admin.go
+++ b/command/admin.go
@@ -40,9 +40,16 @@ var importProviders = &cli.Command{
 
 var listAssigned = &cli.Command{
 	Name:   "list-assigned",
-	Usage:  "List allowed peers when configured to work with assigner service",
+	Usage:  "List assigned peers when configured to work with assigner service",
 	Flags:  adminListAssignedFlags,
 	Action: listAssignedCmd,
+}
+
+var listPreferred = &cli.Command{
+	Name:   "list-preferred",
+	Usage:  "List unassigned peers that indexer has retrieved content from",
+	Flags:  adminListPreferredFlags,
+	Action: listPreferredCmd,
 }
 
 var reload = &cli.Command{
@@ -69,6 +76,7 @@ var AdminCmd = &cli.Command{
 		block,
 		importProviders,
 		listAssigned,
+		listPreferred,
 		reload,
 		sync,
 	},
@@ -122,6 +130,21 @@ func listAssignedCmd(cctx *cli.Context) error {
 		return err
 	}
 	assigned, err := cl.ListAssignedPeers(cctx.Context)
+	if err != nil {
+		return err
+	}
+	for _, peerID := range assigned {
+		fmt.Println(peerID)
+	}
+	return nil
+}
+
+func listPreferredCmd(cctx *cli.Context) error {
+	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
+	if err != nil {
+		return err
+	}
+	assigned, err := cl.ListPreferredPeers(cctx.Context)
 	if err != nil {
 		return err
 	}

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -330,6 +330,9 @@ func daemonCommand(cctx *cli.Context) error {
 	signal.Notify(reloadSig, syscall.SIGHUP)
 
 	// Output message to user (not to log).
+	if cfg.Discovery.UseAssigner {
+		fmt.Println("Indexer configured to use assigner service")
+	}
 	fmt.Println("Indexer is ready")
 
 	var cfgPath string

--- a/command/flags.go
+++ b/command/flags.go
@@ -139,6 +139,10 @@ var adminListAssignedFlags = []cli.Flag{
 	indexerHostFlag,
 }
 
+var adminListPreferredFlags = []cli.Flag{
+	indexerHostFlag,
+}
+
 var adminSyncFlags = []cli.Flag{
 	indexerHostFlag,
 	&cli.StringFlag{

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1173,6 +1173,9 @@ func (r *Registry) loadPreferredAssignments() {
 		if _, ok := r.assigned[pinfo.Publisher]; ok {
 			continue
 		}
+		if pinfo.LastAdvertisement == cid.Undef {
+			continue
+		}
 		r.preferred[pinfo.Publisher] = struct{}{}
 	}
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -29,8 +29,9 @@ import (
 
 const (
 	// providerKeyPath is where provider info is stored in to indexer repo.
-	providerKeyPath    = "/registry/pinfo"
-	assignmentsKeyPath = "/assignments"
+	providerKeyPath       = "/registry/pinfo"
+	assignmentsKeyPath    = "/assignments-v1"
+	oldAssignmentsKeyPath = "/assignments"
 )
 
 var log = logging.Logger("indexer/registry")
@@ -55,6 +56,9 @@ type Registry struct {
 	assigned map[peer.ID]struct{}
 	// assignMutex protects assigner.
 	assignMutex sync.Mutex
+	// preferred tracks unassigned peers that indexer has previously received
+	// index data from.
+	preferred map[peer.ID]struct{}
 
 	discoveryTimeout time.Duration
 	rediscoverWait   time.Duration
@@ -267,6 +271,7 @@ func NewRegistry(ctx context.Context, cfg config.Discovery, dstore datastore.Dat
 		if err = r.loadPersistedAssignments(ctx); err != nil {
 			return nil, err
 		}
+		r.loadPreferredAssignments()
 	}
 
 	pollOverrides, err := makePollOverrideMap(cfg.PollOverrides)
@@ -469,6 +474,31 @@ func (r *Registry) ListAssignedPeers() ([]peer.ID, error) {
 	return peers, nil
 }
 
+// ListPreferredPeers returns list of unassigned peer IDs, that the indexer has
+// already retrieved advertisements from. Only available when the indexer is
+// configured to work with an assigner service. Otherwise returns error.
+func (r *Registry) ListPreferredPeers() ([]peer.ID, error) {
+	if r.assigned == nil {
+		return nil, ErrNoAssigner
+	}
+
+	r.assignMutex.Lock()
+	defer r.assignMutex.Unlock()
+
+	if len(r.preferred) == 0 {
+		return nil, nil
+	}
+
+	peers := make([]peer.ID, len(r.preferred))
+	var i int
+	for peerID := range r.preferred {
+		peers[i] = peerID
+		i++
+	}
+
+	return peers, nil
+}
+
 // AssignPeer assigns the peer to this indexer if using an assigner service.
 // This allows the indexer to accept announce messages having this peer as a
 // publisher. The assignment is persisted in the datastore.
@@ -488,12 +518,13 @@ func (r *Registry) AssignPeer(peerID peer.ID) error {
 		return fmt.Errorf("cannot save assignment: %w", err)
 	}
 	r.assigned[peerID] = struct{}{}
+
+	delete(r.preferred, peerID)
 	return nil
 }
 
-// UnassignPeer assigns the peer to this indexer if using an assigner service.
-// This allows the indexer to accept announce messages having this peer as a
-// publisher. The assignment is persisted in the datastore.
+// UnassignPeer removes a peer assignment from this indexer if using an
+// assigner service. The assignment removal is persisted in the datastore.
 func (r *Registry) UnassignPeer(peerID peer.ID) error {
 	if r.assigned == nil {
 		return ErrNoAssigner
@@ -1066,9 +1097,39 @@ func (r *Registry) deleteAssignedPeer(peerID peer.ID) error {
 	return r.dstore.Delete(context.Background(), dsKey)
 }
 
+func (r *Registry) deleteOldAssignments(ctx context.Context, prefix string) error {
+	q := query.Query{
+		Prefix:   prefix,
+		KeysOnly: true,
+	}
+	results, err := r.dstore.Query(ctx, q)
+	if err != nil {
+		return err
+	}
+
+	ents, err := results.Rest()
+	if err != nil {
+		return err
+	}
+
+	for i := range ents {
+		err = r.dstore.Delete(ctx, datastore.NewKey(ents[i].Key))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (r *Registry) loadPersistedAssignments(ctx context.Context) error {
 	if r.dstore == nil {
 		return nil
+	}
+
+	err := r.deleteOldAssignments(ctx, oldAssignmentsKeyPath)
+	if err != nil {
+		return err
 	}
 
 	// Load all assigned publishers from datastore.
@@ -1097,33 +1158,21 @@ func (r *Registry) loadPersistedAssignments(ctx context.Context) error {
 	}
 
 	log.Infow("loaded assignments into registry", "count", len(r.assigned))
-
-	// If there were no assigned publishers, and there are registered
-	// providers, then assign all publishers for the registered providers.
-	//
-	// This is used when an existing indexer is configured to work with an
-	// assigner service. It self-assigns all the publishers of the registered
-	// providers, so that the indexer will continue indexing with the
-	// publishers it is already getting content from.
-	if len(r.assigned) == 0 && len(r.providers) != 0 {
-		for _, pinfo := range r.providers {
-			if pinfo.Publisher.Validate() == nil && r.policy.Allowed(pinfo.Publisher) {
-				r.assigned[pinfo.Publisher] = struct{}{}
-			}
-		}
-
-		// Save assignment in datastore.
-		for peerID := range r.assigned {
-			dsKey := peerIDToDsKey(assignmentsKeyPath, peerID)
-			err := r.dstore.Put(context.Background(), dsKey, []byte{})
-			if err != nil {
-				return err
-			}
-		}
-		r.dstore.Sync(ctx, datastore.NewKey(assignmentsKeyPath))
-
-		log.Info("Self-assigned all providers and publishers from registered providers")
-	}
-
 	return nil
+}
+
+func (r *Registry) loadPreferredAssignments() {
+	r.preferred = make(map[peer.ID]struct{})
+	for _, pinfo := range r.providers {
+		if pinfo.Publisher.Validate() != nil {
+			continue
+		}
+		if !r.policy.Allowed(pinfo.Publisher) {
+			continue
+		}
+		if _, ok := r.assigned[pinfo.Publisher]; ok {
+			continue
+		}
+		r.preferred[pinfo.Publisher] = struct{}{}
+	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -308,8 +308,8 @@ func TestDatastore(t *testing.T) {
 	err = r.Close()
 	require.NoError(t, err)
 
-	// Test that configuring existing registry to use assigner service
-	// self-assigns existing publishers.
+	// Test that configuring existing registry to use assigner service finds
+	// existing publishers.
 	t.Log("Converted registry to work with assigner service")
 	discoveryCfg.UseAssigner = true
 	dstore, err = leveldb.NewDatastore(dataStorePath, nil)
@@ -317,10 +317,16 @@ func TestDatastore(t *testing.T) {
 	r, err = NewRegistry(ctx, discoveryCfg, dstore, mockDiscoverer)
 	require.NoError(t, err)
 
+	// There should not be any assigned yet.
 	assigned, err := r.ListAssignedPeers()
 	require.NoError(t, err)
-	// There should be 1 publisher allowed.
-	require.Equal(t, 1, len(assigned))
+	require.Zero(t, len(assigned))
+
+	// There should be 1 preferred publisher.
+	preferred, err := r.ListPreferredPeers()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(preferred))
+
 	require.NoError(t, r.Close())
 }
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -263,7 +263,10 @@ func TestDatastore(t *testing.T) {
 	err = r.Update(ctx, provider1, peer.AddrInfo{}, cid.Undef, nil)
 	require.NoError(t, err)
 
-	err = r.Update(ctx, provider2, publisher, cid.Undef, extProviders)
+	mh, err := multihash.Sum([]byte("somedata"), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+	adCid := cid.NewCidV1(cid.Raw, mh)
+	err = r.Update(ctx, provider2, publisher, adCid, extProviders)
 	require.NoError(t, err)
 
 	pinfo, allowed := r.ProviderInfo(provID1)

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -50,9 +50,38 @@ func (h *adminHandler) listAssignedPeers(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if len(assigned) == 0 {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	data, err := json.Marshal(assigned)
 	if err != nil {
-		log.Errorw("Error marshaling allow list", "err", err)
+		log.Errorw("Error marshaling assigned list", "err", err)
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+
+	httpserver.WriteJsonResponse(w, http.StatusOK, data)
+}
+
+func (h *adminHandler) listPreferredPeers(w http.ResponseWriter, r *http.Request) {
+	preferred, err := h.reg.ListPreferredPeers()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	if len(preferred) == 0 {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	data, err := json.Marshal(preferred)
+	if err != nil {
+		log.Errorw("Error marshaling preferred list", "err", err)
 		http.Error(w, "", http.StatusInternalServerError)
 		return
 	}

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -67,9 +67,11 @@ func New(listen string, indexer indexer.Interface, ingester *ingest.Ingester, re
 	r.HandleFunc("/ingest/block/{peer}", h.blockPeer).Methods(http.MethodPut)
 	r.HandleFunc("/ingest/sync/{peer}", h.sync).Methods(http.MethodPost)
 
+	// Assignment routes
 	r.HandleFunc("/ingest/assigned", h.listAssignedPeers).Methods(http.MethodGet)
 	r.HandleFunc("/ingest/assign/{peer}", h.assignPeer).Methods(http.MethodPut)
 	r.HandleFunc("/ingest/unassign/{peer}", h.unassignPeer).Methods(http.MethodPut)
+	r.HandleFunc("/ingest/preferred", h.listPreferredPeers).Methods(http.MethodGet)
 
 	// Metrics routes
 	r.Handle("/metrics", metrics.Start(coremetrics.DefaultViews))


### PR DESCRIPTION
## Indexers list unassigned publishers, with previously indexed content, and preferred

When an indexer is reconfigured to use an assigner service, it may already have some indexed content from some publishers. Instead of automatically self-assigning all of these publishers to the indexer, these publishers will instead be seen by the assigner service as preferred assignees for the indexer. This allows the assigner to choose a subset of the indexers to assign a publisher to, preferring indexer(s) that have already indexed content from that publisher.

Changed default assignment replication to 1, so that each publisher is assigned to one indexer.

## Assignment orders candidate indexers
 
When assigning a publisher to an indexer, the candidate indexers are ordered first by "preferred" status, and then by the minimum number of publishers already assigned.

Note: Publishers that are preset for assignment to specific indexers will not use candidate ordering, but will be assigned to all preset indexers.