### PR TITLE
Reduce `cassette` replica count on prod to `1`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -29,7 +29,7 @@ configMapGenerator:
 
 replicas:
   - name: cassette
-    count: 3
+    count: 1
 
 images:
   - name: cassette


### PR DESCRIPTION
Reduce the `cassette` replica count on prod to 1 because:
1. response to bitswap request might land on another replica due to the nature of bitswap protocol where there request is fire and forget, then listen for messages.

2. nodes are running cool and are under-utilised.

Corss replica internal broadcasting is needed before we can scale `cassette` out to multiple replicas.ˆ
