### PR TITLE
Take snapshots of read-only dhstores

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dhstore-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dhstore-snapshot.yaml
@@ -6,3 +6,21 @@ spec:
   volumeSnapshotClassName: csi-aws-vsc
   source:
     persistentVolumeClaimName: dhstore-data
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: dhstore-data-gp3-20230524
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: dhstore-data-gp3
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: dhstore-data-helga-20230524
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: dhstore-data-helga


### PR DESCRIPTION
Snapshots will be used to set up volumes of smaller capacity, as `dhstore` and `dhstore-helga` are 60%(ish) utilised after compaction