### PR TITLE
Revert "Increase inga CPU"

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
@@ -14,10 +14,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "46"
+              cpu: "45"
               memory: 50Gi
             requests:
-              cpu: "46"
+              cpu: "45"
               memory: 50Gi
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Reverts ipni/storetheindex#2063

Higher CPU won't fit on worker nodes since there will be no CPU left for daemonsets that check node health. Reverting CC @gammazero 