### PR TITLE
Smaller instance type for dhstore-tetra

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-tetra/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-tetra/deployment.yaml
@@ -33,7 +33,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - c6a.8xlarge
+                      - r6a.2xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:


### PR DESCRIPTION
Move the previous main dhstore to cheaper instance type now that its resource demand is reduced.
