### PR TITLE
Sub paths in local mirror

### DIFF
--- a/config/mirror.go
+++ b/config/mirror.go
@@ -26,6 +26,16 @@ type Mirror struct {
 func NewMirror() Mirror {
 	return Mirror{
 		Compress: "gzip",
+		Retrieval: filestore.Config{
+			Local: filestore.LocalConfig{
+				DefaultPathSplit: []int{11, 2},
+			},
+		},
+		Storage: filestore.Config{
+			Local: filestore.LocalConfig{
+				DefaultPathSplit: []int{11, 2},
+			},
+		},
 	}
 }
 

--- a/filestore/config.go
+++ b/filestore/config.go
@@ -18,6 +18,8 @@ type Config struct {
 type LocalConfig struct {
 	// BasePath is the filesystem directory where files are stored.
 	BasePath string
+	// DefaultPathSplit determines how the car name is split into subdirectories
+	DefaultPathSplit []int
 }
 
 type S3Config struct {
@@ -38,7 +40,9 @@ type S3Config struct {
 func MakeFilestore(cfg Config) (Interface, error) {
 	switch cfg.Type {
 	case "local":
-		return NewLocal(cfg.Local.BasePath)
+		return NewLocal(cfg.Local.BasePath,
+			WithDefaultPathSplit(cfg.Local.DefaultPathSplit...),
+		)
 	case "s3":
 		return NewS3(cfg.S3.BucketName,
 			WithEndpoint(cfg.S3.Endpoint),

--- a/filestore/filestore_test.go
+++ b/filestore/filestore_test.go
@@ -106,6 +106,126 @@ func TestLocal(t *testing.T) {
 	})
 }
 
+func TestLocalWithPathSplit(t *testing.T) {
+	carDir := t.TempDir()
+
+	fileStore, err := filestore.NewLocal(carDir, filestore.WithDefaultPathSplit(2, 1))
+	require.NoError(t, err)
+	require.Equal(t, "local", fileStore.Type())
+
+	t.Run("test-Local-Put", func(t *testing.T) {
+		testPut(t, fileStore)
+	})
+
+	require.FileExists(t,
+		filepath.Join(carDir, filestore.ConfigMetadataFileName),
+		"path split requires metadata file",
+	)
+	require.FileExists(t, filepath.Join(carDir, fileName[:2], fileName[2:3], fileName))
+
+	t.Run("test-Local-Head", func(t *testing.T) {
+		testHead(t, fileStore)
+	})
+
+	t.Run("test-Local-Get", func(t *testing.T) {
+		testGet(t, fileStore)
+	})
+
+	// Some extra bogus filesystem entries that should be skipped
+	for data, fName := range map[string]string{
+		"no-path-prefix":              filepath.Join(carDir, fileName),
+		"wrong-path-prefix":           filepath.Join(carDir, fileName[:2], fileName),
+		"prefix-not-on-path-boundary": filepath.Join(carDir, "corner-"+fileName[:2], fileName[2:3], fileName),
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(fName), 0700))
+		require.NoError(t, os.WriteFile(fName, []byte(data), 0600))
+	}
+
+	t.Run("test-Local-List", func(t *testing.T) {
+		testList(t, fileStore)
+	})
+
+	t.Run("test-Local-Delete", func(t *testing.T) {
+		testDelete(t, fileStore)
+	})
+}
+
+func TestLocalMetadata(t *testing.T) {
+	t.Run("legacy format detection", func(t *testing.T) {
+		carDir := t.TempDir()
+
+		// Prepare legacy, flat structure
+		require.NoError(t, os.WriteFile(filepath.Join(carDir, fileName), []byte(data), 0666))
+		require.NoError(t, os.WriteFile(filepath.Join(carDir, fileName1), []byte(data1), 0666))
+
+		// Create filestore with default path split, it should be overwritten though
+		fileStore, err := filestore.NewLocal(carDir, filestore.WithDefaultPathSplit(2, 1))
+		require.NoError(t, err)
+
+		fi, err := fileStore.Head(t.Context(), fileName)
+		require.NoError(t, err)
+		require.NotNil(t, fi)
+
+		fi, err = fileStore.Put(t.Context(), fileName2, strings.NewReader(data2))
+		require.NoError(t, err)
+		require.NotNil(t, fi)
+
+		require.FileExists(t, filepath.Join(carDir, fileName2))
+		require.NoFileExists(t, filepath.Join(carDir, filestore.ConfigMetadataFileName))
+	})
+
+	t.Run("reopen local filestore with metadata", func(t *testing.T) {
+		carDir := t.TempDir()
+
+		_, err := filestore.NewLocal(carDir, filestore.WithDefaultPathSplit(2, 1))
+		require.NoError(t, err)
+
+		// Reopen must read the metadata file and read config from it
+		fileStore, err := filestore.NewLocal(carDir)
+		require.NoError(t, err)
+
+		require.FileExists(t, filepath.Join(carDir, filestore.ConfigMetadataFileName))
+
+		_, err = fileStore.Put(t.Context(), fileName, strings.NewReader(data))
+		require.NoError(t, err)
+
+		require.FileExists(t, filepath.Join(carDir, fileName[:2], fileName[2:3], fileName))
+	})
+
+	t.Run("invalid metadata file", func(t *testing.T) {
+		carDir := t.TempDir()
+
+		require.NoError(t, os.WriteFile(
+			filepath.Join(carDir, filestore.ConfigMetadataFileName),
+			[]byte("not a valid json file"),
+			0666,
+		))
+
+		_, err := filestore.NewLocal(carDir)
+		require.ErrorContains(t, err, "failed to decode filestore configuration file")
+
+		require.NoError(t, os.WriteFile(
+			filepath.Join(carDir, filestore.ConfigMetadataFileName),
+			[]byte(`{"Version": "bogus"}`),
+			0666,
+		))
+
+		_, err = filestore.NewLocal(carDir)
+		require.ErrorContains(t, err, "invalid filestore configuration file")
+		require.ErrorContains(t, err, "unknown version")
+
+		require.NoError(t, os.WriteFile(
+			filepath.Join(carDir, filestore.ConfigMetadataFileName),
+			[]byte(`{"Version": "v1", "PathSplit": [-1]}`),
+			0666,
+		))
+
+		_, err = filestore.NewLocal(carDir)
+		require.ErrorContains(t, err, "invalid filestore configuration file")
+		require.ErrorContains(t, err, "invalid path split config")
+	})
+}
+
 func TestMakeFilestore(t *testing.T) {
 	cfg := filestore.Config{
 		Type: "none",
@@ -127,6 +247,15 @@ func TestMakeFilestore(t *testing.T) {
 	require.ErrorContains(t, err, "base path")
 
 	cfg.Local.BasePath = t.TempDir()
+	fs, err = filestore.MakeFilestore(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, fs)
+
+	cfg.Local.DefaultPathSplit = []int{0, -1}
+	_, err = filestore.MakeFilestore(cfg)
+	require.ErrorContains(t, err, "invalid path split")
+
+	cfg.Local.DefaultPathSplit = []int{7, 5}
 	fs, err = filestore.MakeFilestore(cfg)
 	require.NoError(t, err)
 	require.NotNil(t, fs)

--- a/filestore/filestore_test.go
+++ b/filestore/filestore_test.go
@@ -1,7 +1,6 @@
 package filestore_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -11,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/ipni/storetheindex/filestore"
-	"github.com/ipni/storetheindex/fsutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/orlangure/gnomock"
@@ -89,7 +87,7 @@ func TestLocal(t *testing.T) {
 		testPut(t, fileStore)
 	})
 
-	require.True(t, fsutil.FileExists(filepath.Join(carDir, fileName)))
+	require.FileExists(t, filepath.Join(carDir, fileName))
 
 	t.Run("test-Local-Head", func(t *testing.T) {
 		testHead(t, fileStore)
@@ -135,7 +133,7 @@ func TestMakeFilestore(t *testing.T) {
 }
 
 func testPut(t *testing.T, fileStore filestore.Interface) {
-	fileInfo, err := fileStore.Put(context.Background(), fileName, strings.NewReader(data))
+	fileInfo, err := fileStore.Put(t.Context(), fileName, strings.NewReader(data))
 	require.NoError(t, err)
 	require.Equal(t, fileName, fileInfo.Path)
 	require.Equal(t, int64(len(data)), fileInfo.Size)
@@ -143,34 +141,34 @@ func testPut(t *testing.T, fileStore filestore.Interface) {
 
 func testHead(t *testing.T, fileStore filestore.Interface) {
 	// Get file that does not exist.
-	fileInfo, err := fileStore.Head(context.Background(), "not-here")
+	fileInfo, err := fileStore.Head(t.Context(), "not-here")
 	require.ErrorIs(t, err, fs.ErrNotExist)
 	require.Nil(t, fileInfo)
 
-	_, err = fileStore.Put(context.Background(), fileName3, strings.NewReader(data))
+	_, err = fileStore.Put(t.Context(), fileName3, strings.NewReader(data))
 	require.NoError(t, err)
 
-	fileInfo, err = fileStore.Head(context.Background(), fileName3)
+	fileInfo, err = fileStore.Head(t.Context(), fileName3)
 	require.NoError(t, err)
 	require.Equal(t, fileName3, fileInfo.Path)
 	require.Equal(t, int64(len(data)), fileInfo.Size)
 	require.False(t, fileInfo.Modified.IsZero())
 
 	// Should get fs.ErrNotExist when looking for subdirectory.
-	_, err = fileStore.Head(context.Background(), subdir)
+	_, err = fileStore.Head(t.Context(), subdir)
 	require.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 func testGet(t *testing.T, fileStore filestore.Interface) {
 	// Get file that does not exist.
-	fileInfo, _, err := fileStore.Get(context.Background(), "not-here")
+	fileInfo, _, err := fileStore.Get(t.Context(), "not-here")
 	require.ErrorIs(t, err, fs.ErrNotExist)
 	require.Nil(t, fileInfo)
 
-	_, err = fileStore.Put(context.Background(), fileName, strings.NewReader(data))
+	_, err = fileStore.Put(t.Context(), fileName, strings.NewReader(data))
 	require.NoError(t, err)
 
-	fileInfo, r, err := fileStore.Get(context.Background(), fileName)
+	fileInfo, r, err := fileStore.Get(t.Context(), fileName)
 	require.NoError(t, err)
 	require.Equal(t, fileName, fileInfo.Path)
 	require.Equal(t, int64(len(data)), fileInfo.Size)
@@ -185,13 +183,13 @@ func testGet(t *testing.T, fileStore filestore.Interface) {
 	require.ErrorIs(t, err, io.EOF)
 	require.NoError(t, r.Close())
 
-	_, err = fileStore.Put(context.Background(), fileName3, strings.NewReader(data3))
+	_, err = fileStore.Put(t.Context(), fileName3, strings.NewReader(data3))
 	require.NoError(t, err)
 
-	_, _, err = fileStore.Get(context.Background(), subdir)
+	_, _, err = fileStore.Get(t.Context(), subdir)
 	require.ErrorIs(t, err, fs.ErrNotExist)
 
-	fileInfo, r, err = fileStore.Get(context.Background(), fileName3)
+	fileInfo, r, err = fileStore.Get(t.Context(), fileName3)
 	require.NoError(t, err)
 	require.NoError(t, r.Close())
 	require.Equal(t, int64(len(data3)), fileInfo.Size)
@@ -199,74 +197,92 @@ func testGet(t *testing.T, fileStore filestore.Interface) {
 
 func testList(t *testing.T, fileStore filestore.Interface) {
 	// List file that does not exist.
-	fileCh, errCh := fileStore.List(context.Background(), "not-here/", false)
+	fileCh, errCh := fileStore.List(t.Context(), "not-here/", false)
 	fileInfo, ok := <-fileCh
 	require.Nil(t, fileInfo)
 	require.False(t, ok)
 	err := <-errCh
 	require.NoError(t, err)
 
-	_, err = fileStore.Put(context.Background(), fileName1, strings.NewReader(data1))
+	_, err = fileStore.Put(t.Context(), fileName1, strings.NewReader(data1))
 	require.NoError(t, err)
 
-	_, err = fileStore.Put(context.Background(), fileName2, strings.NewReader(data2))
+	_, err = fileStore.Put(t.Context(), fileName2, strings.NewReader(data2))
 	require.NoError(t, err)
 
-	_, err = fileStore.Put(context.Background(), fileName3, strings.NewReader(data3))
+	_, err = fileStore.Put(t.Context(), fileName3, strings.NewReader(data3))
 	require.NoError(t, err)
 
-	fileCh, errCh = fileStore.List(context.Background(), "", false)
-	infos := make([]*filestore.File, 0, 3)
-	for fileInfo := range fileCh {
-		infos = append(infos, fileInfo)
-	}
-	err = <-errCh
-	require.NoError(t, err)
-	require.Equal(t, 3, len(infos))
-	expectNames := []string{fileName, fileName1, fileName2}
-	expectSizes := []int64{int64(len(data)), int64(len(data1)), int64(len(data2))}
-	for i := range infos {
-		require.Equal(t, expectNames[i], infos[i].Path)
-		require.Equal(t, expectSizes[i], infos[i].Size)
-		require.False(t, infos[0].Modified.IsZero())
-	}
+	t.Run("list non-recursively", func(t *testing.T) {
+		fileCh, errCh = fileStore.List(t.Context(), "", false)
+		infos := make([]*filestore.File, 0, 3)
+		for fileInfo := range fileCh {
+			infos = append(infos, fileInfo)
+		}
+		err = <-errCh
+		require.NoError(t, err)
+		require.Equal(t, 3, len(infos))
+		expectNames := []string{fileName, fileName1, fileName2}
+		expectSizes := []int64{int64(len(data)), int64(len(data1)), int64(len(data2))}
+		for i := range infos {
+			require.Equal(t, expectNames[i], infos[i].Path)
+			require.Equal(t, expectSizes[i], infos[i].Size)
+			require.False(t, infos[0].Modified.IsZero())
+		}
+	})
 
-	fileCh, errCh = fileStore.List(context.Background(), "", true)
-	infos = infos[:0]
-	for fileInfo := range fileCh {
-		infos = append(infos, fileInfo)
-	}
-	err = <-errCh
-	require.NoError(t, err)
-	require.Equal(t, 4, len(infos))
-	require.Equal(t, fileName3, infos[0].Path)
-	require.Equal(t, int64(len(data3)), infos[0].Size)
+	t.Run("list recursively", func(t *testing.T) {
+		fileCh, errCh = fileStore.List(t.Context(), "", true)
+		infos := make([]*filestore.File, 0, 3)
+		for fileInfo := range fileCh {
+			infos = append(infos, fileInfo)
+		}
+		err = <-errCh
+		require.NoError(t, err)
+		require.Equal(t, 4, len(infos))
+		require.Equal(t, fileName3, infos[0].Path)
+		require.Equal(t, int64(len(data3)), infos[0].Size)
+	})
 
-	// File specific file.
-	fileCh, errCh = fileStore.List(context.Background(), fileName1, false)
-	infos = infos[:0]
-	for fileInfo := range fileCh {
-		infos = append(infos, fileInfo)
-	}
-	err = <-errCh
-	require.NoError(t, err)
-	require.Equal(t, 1, len(infos))
-	require.Equal(t, fileName1, infos[0].Path)
+	t.Run("specific file", func(t *testing.T) {
+		fileCh, errCh = fileStore.List(t.Context(), fileName1, false)
+		infos := make([]*filestore.File, 0, 3)
+		for fileInfo := range fileCh {
+			infos = append(infos, fileInfo)
+		}
+		err = <-errCh
+		require.NoError(t, err)
+		require.Equal(t, 1, len(infos))
+		require.Equal(t, fileName1, infos[0].Path)
+	})
 
-	// File specific file.
-	fileCh, errCh = fileStore.List(context.Background(), fileName3, false)
-	infos = infos[:0]
-	for fileInfo := range fileCh {
-		infos = append(infos, fileInfo)
-	}
-	err = <-errCh
-	require.NoError(t, err)
-	require.Equal(t, 1, len(infos))
-	require.Equal(t, fileName3, infos[0].Path)
+	t.Run("specific file at a sub-dir", func(t *testing.T) {
+		fileCh, errCh = fileStore.List(t.Context(), fileName3, false)
+		infos := make([]*filestore.File, 0, 3)
+		for fileInfo := range fileCh {
+			infos = append(infos, fileInfo)
+		}
+		err = <-errCh
+		require.NoError(t, err)
+		require.Equal(t, 1, len(infos))
+		require.Equal(t, fileName3, infos[0].Path)
+	})
+
+	t.Run("list files in a sub-folder", func(t *testing.T) {
+		fileCh, errCh = fileStore.List(t.Context(), subdir+"/", false)
+		infos := make([]*filestore.File, 0, 3)
+		for fileInfo := range fileCh {
+			infos = append(infos, fileInfo)
+		}
+		err = <-errCh
+		require.NoError(t, err)
+		require.Equal(t, 1, len(infos))
+		require.Equal(t, fileName3, infos[0].Path)
+	})
 }
 
 func testDelete(t *testing.T, fileStore filestore.Interface) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := fileStore.Put(ctx, fileName1, strings.NewReader(data1))
 	require.NoError(t, err)

--- a/filestore/local.go
+++ b/filestore/local.go
@@ -2,35 +2,96 @@ package filestore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ipni/storetheindex/fsutil"
 )
 
+const (
+	ConfigMetadataFileName    = ".filestore-config.json"
+	ConfigMetadataFileVersion = "v1"
+)
+
 // Local is a file store that stores files in the local file system.
 type Local struct {
-	basePath string
+	basePath  string
+	pathSplit []int
 }
 
-func NewLocal(basePath string) (*Local, error) {
+func NewLocal(basePath string, options ...LocalOption) (*Local, error) {
 	if !filepath.IsAbs(basePath) {
 		return nil, errors.New("base path must be absolute")
 	}
+
 	err := fsutil.DirWritable(basePath)
 	if err != nil {
 		return nil, err
 	}
-	return &Local{
-		basePath: basePath,
-	}, nil
+
+	opts, err := getLocalOpts(options)
+	if err != nil {
+		return nil, err
+	}
+
+	// BasePath configured directly, not through options
+	opts.basePath = basePath
+
+	err = processPersistedMetadata(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	l := &Local{
+		basePath:  opts.basePath,
+		pathSplit: opts.pathSplit,
+	}
+
+	return l, nil
+}
+
+// fsPath returns the filesystem path of a given object path
+// based on a given basePath with path splitting criteria applied.
+func (l *Local) fsPath(basePath, relPath string) string {
+	fsDir, fsName := filepath.Split(filepath.FromSlash(relPath))
+
+	pathSegments := make([]string, 0, len(l.pathSplit)+3)
+	pathSegments = append(pathSegments, basePath, fsDir)
+
+	pathSegments = l.appendFnamePathSegments(fsName, pathSegments)
+
+	return filepath.Join(pathSegments...)
+}
+
+func (l *Local) appendFnamePathSegments(fileName string, pathSegments []string) []string {
+	fsNameNoExt := fileName
+	if dotPos := strings.IndexByte(fileName, '.'); dotPos > 0 {
+		fsNameNoExt = fileName[:dotPos]
+	}
+
+	splitPos := 0
+	for _, split := range l.pathSplit {
+		splitPos += split
+		if splitPos > len(fsNameNoExt) {
+			break
+		}
+
+		pathSegments = append(pathSegments, fsNameNoExt[splitPos-split:splitPos])
+	}
+
+	pathSegments = append(pathSegments, fileName)
+
+	return pathSegments
 }
 
 func (l *Local) Delete(ctx context.Context, relPath string) error {
-	err := os.Remove(filepath.Join(l.basePath, filepath.FromSlash(relPath)))
+	err := os.Remove(l.fsPath(l.basePath, relPath))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -38,9 +99,7 @@ func (l *Local) Delete(ctx context.Context, relPath string) error {
 }
 
 func (l *Local) Get(ctx context.Context, relPath string) (*File, io.ReadCloser, error) {
-	absPath := filepath.Join(l.basePath, filepath.FromSlash(relPath))
-
-	f, err := os.Open(absPath)
+	f, err := os.Open(l.fsPath(l.basePath, relPath))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil, fs.ErrNotExist
@@ -67,8 +126,7 @@ func (l *Local) Get(ctx context.Context, relPath string) (*File, io.ReadCloser, 
 }
 
 func (l *Local) Head(ctx context.Context, relPath string) (*File, error) {
-	absPath := filepath.Join(l.basePath, filepath.FromSlash(relPath))
-	fi, err := os.Stat(absPath)
+	fi, err := os.Stat(l.fsPath(l.basePath, relPath))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, fs.ErrNotExist
@@ -95,7 +153,23 @@ func (l *Local) List(ctx context.Context, relPath string, recursive bool) (<-cha
 		defer close(e)
 		defer close(c)
 
-		absPath := filepath.Join(l.basePath, filepath.FromSlash(relPath))
+		// The relPath may either be a path to a file or a path prefix,
+		// those cases must be handled separately due to pathSplit that only
+		// considers the filename as a splittable segment.
+		if stat, err := os.Stat(l.fsPath(l.basePath, relPath)); err == nil && stat.Mode().IsRegular() {
+			// relPath points to a file - emit that one and exit
+			c <- &File{
+				Modified: stat.ModTime(),
+				Path:     relPath,
+				Size:     stat.Size(),
+			}
+
+			return
+		}
+
+		// relPath must be treated as a directory prefix
+		absPath := filepath.Join(l.basePath, relPath)
+
 		e <- filepath.WalkDir(absPath, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {
@@ -106,9 +180,18 @@ func (l *Local) List(ctx context.Context, relPath string, recursive bool) (<-cha
 			}
 
 			if d.IsDir() {
-				if !recursive && path != absPath {
+				if recursive || len(l.pathSplit) > 0 {
+					// For both recursive scan and filepath split, keep descending
+					// to find files in sub-directories
+					return nil
+				}
+
+				if path != absPath {
+					// Without path split only a flat structure allowed,
+					// skip any sub-directories for faster iteration
 					return fs.SkipDir
 				}
+
 				return nil
 			}
 
@@ -117,20 +200,53 @@ func (l *Local) List(ctx context.Context, relPath string, recursive bool) (<-cha
 				return nil
 			}
 
-			fi, err := d.Info()
-			if err != nil {
-				return err
+			// Skip metadata files
+			if d.Name() == ConfigMetadataFileName {
+				return nil
 			}
 
-			relFilePath, err := filepath.Rel(l.basePath, path)
+			fi, err := d.Info()
 			if err != nil {
 				return err
 			}
 
 			f := &File{
 				Modified: fi.ModTime(),
-				Path:     filepath.ToSlash(relFilePath),
 				Size:     fi.Size(),
+				// Note: Path field must be filled in below
+			}
+
+			if len(l.pathSplit) > 0 {
+				// Before emitting file entry, verify that the path is correct according
+				// to path split rules
+				fileName := filepath.Base(path)
+				expectedFileSubPath := l.fsPath("", fileName)
+
+				relAbsPath, err := filepath.Rel(absPath, path)
+				if err != nil {
+					return err
+				}
+
+				if prefix, found := strings.CutSuffix(relAbsPath, expectedFileSubPath); !found {
+					// Skip the file, path structure does not match
+					return nil
+				} else if !recursive && prefix != "" {
+					// Structure matches but is in sub-folder and not recursive mode, skip that one
+					return nil
+				} else if prefix != "" && prefix[len(prefix)-1] != filepath.Separator {
+					// Corner case - the prefix path must align with the path separator boundary
+					return nil
+				} else {
+					// All looks good, adjust the final path by removing sub-folder structure
+					f.Path = filepath.ToSlash(filepath.Join(relPath, prefix, fileName))
+				}
+			} else {
+				relFilePath, err := filepath.Rel(l.basePath, path)
+				if err != nil {
+					return err
+				}
+
+				f.Path = filepath.ToSlash(relFilePath)
 			}
 
 			select {
@@ -146,11 +262,10 @@ func (l *Local) List(ctx context.Context, relPath string, recursive bool) (<-cha
 }
 
 func (l *Local) Put(ctx context.Context, relPath string, r io.Reader) (*File, error) {
-	absPath := filepath.Join(l.basePath, filepath.FromSlash(relPath))
+	absPath := l.fsPath(l.basePath, relPath)
 
-	dir, _ := filepath.Split(relPath)
-	if dir != "" {
-		err := os.MkdirAll(filepath.Dir(absPath), 0755)
+	if dir := filepath.Dir(absPath); dir != "" {
+		err := os.MkdirAll(dir, 0755)
 		if err != nil {
 			return nil, err
 		}
@@ -190,4 +305,94 @@ func (l *Local) Put(ctx context.Context, relPath string, r io.Reader) (*File, er
 
 func (l *Local) Type() string {
 	return "local"
+}
+
+type localFilestoreMetadata struct {
+	Version   string
+	PathSplit []int
+}
+
+// processPersistedMetadata loads the metadata file from disk and updates
+// configuration accordingly
+func processPersistedMetadata(config *localConfig) error {
+	configFilePath := filepath.Join(config.basePath, ConfigMetadataFileName)
+
+	configFile, err := os.Open(configFilePath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return generatePersistedMetadata(config)
+	}
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to open filestore configuration file at %s: %w", configFilePath, err)
+	}
+
+	defer configFile.Close()
+
+	metadata := localFilestoreMetadata{}
+
+	err = json.NewDecoder(configFile).Decode(&metadata)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to decode filestore configuration file at %s: %w",
+			configFilePath, err,
+		)
+	}
+
+	if metadata.Version != ConfigMetadataFileVersion {
+		return fmt.Errorf(
+			"invalid filestore configuration file at %s: unknown version %s",
+			configFilePath, ConfigMetadataFileVersion,
+		)
+	}
+
+	err = WithDefaultPathSplit(metadata.PathSplit...)(config)
+	if err != nil {
+		return fmt.Errorf(
+			"invalid filestore configuration file at %s: %w",
+			configFilePath, err,
+		)
+	}
+
+	return nil
+}
+
+// generatePersistedMetadata attempts to build metadata file in case one is not found.
+//
+// This method uses heuristic approach to guarantee backwards compatibility with filestore
+// instances that do not have the metadata file:
+//   - if the directory looks empty - i.e. contains no entries -
+//     assume we're initializing a new filestore: write down a new metadata file using default settings
+//   - if the directory is not empty - assume we're opening existing filestore - do nothing
+func generatePersistedMetadata(config *localConfig) error {
+	// Check if this is a legacy filestore without metadata file
+	for _, err := range fsutil.DirIter(config.basePath, 100) {
+		if err != nil {
+			return fmt.Errorf("filestore layout detection failed: %w", err)
+		}
+
+		// Non-empty directory found - treat it as a legacy filestore, only use basePath
+		*config = localConfig{
+			basePath: config.basePath,
+		}
+
+		return nil
+	}
+
+	// Empty directory - generate new metadata file using defaults
+
+	configFilePath := filepath.Join(config.basePath, ConfigMetadataFileName)
+
+	jsonData, _ := json.Marshal(&localFilestoreMetadata{
+		Version:   ConfigMetadataFileVersion,
+		PathSplit: config.pathSplit,
+	})
+
+	err := os.WriteFile(configFilePath, jsonData, 0666)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to create filestore configuration file at %s: %w",
+			configFilePath, err,
+		)
+	}
+
+	return nil
 }

--- a/filestore/option.go
+++ b/filestore/option.go
@@ -13,11 +13,11 @@ type s3Config struct {
 
 type S3Option func(*s3Config) error
 
-func getOpts(opts []S3Option) (s3Config, error) {
+func getS3Opts(opts []S3Option) (s3Config, error) {
 	var cfg s3Config
 	for i, opt := range opts {
 		if err := opt(&cfg); err != nil {
-			return s3Config{}, fmt.Errorf("option %d error: %s", i, err)
+			return s3Config{}, fmt.Errorf("option %d error: %w", i, err)
 		}
 	}
 	return cfg, nil
@@ -41,6 +41,41 @@ func WithKeys(accessKey, secretKey string) S3Option {
 	return func(c *s3Config) error {
 		c.accessKey = accessKey
 		c.secretKey = secretKey
+		return nil
+	}
+}
+
+type localConfig struct {
+	basePath  string
+	pathSplit []int
+}
+
+type LocalOption func(*localConfig) error
+
+func getLocalOpts(opts []LocalOption) (localConfig, error) {
+	var cfg localConfig
+	for i, opt := range opts {
+		if err := opt(&cfg); err != nil {
+			return localConfig{}, fmt.Errorf("option %d error: %w", i, err)
+		}
+	}
+	return cfg, nil
+}
+
+func WithDefaultPathSplit(defaultPathSplit ...int) LocalOption {
+	for i, splitSegment := range defaultPathSplit {
+		if splitSegment <= 0 {
+			return func(lc *localConfig) error {
+				return fmt.Errorf(
+					"invalid path split config for segment %d of size %d: must be a positive integer",
+					i, splitSegment,
+				)
+			}
+		}
+	}
+
+	return func(lc *localConfig) error {
+		lc.pathSplit = defaultPathSplit
 		return nil
 	}
 }

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -36,7 +36,7 @@ func NewS3(bucketName string, options ...S3Option) (*S3, error) {
 		return nil, errors.New("s3 filestore requires bucket name")
 	}
 
-	opts, err := getOpts(options)
+	opts, err := getS3Opts(options)
 	if err != nil {
 		return nil, err
 	}

--- a/fsutil/fsutil.go
+++ b/fsutil/fsutil.go
@@ -3,7 +3,9 @@ package fsutil
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"iter"
 	"os"
 	"path/filepath"
 	"time"
@@ -92,4 +94,37 @@ func FileChanged(filePath string, modTime time.Time) (time.Time, bool, error) {
 func FileExists(filename string) bool {
 	_, err := os.Lstat(filename)
 	return !errors.Is(err, os.ErrNotExist)
+}
+
+// DirIter returns iterator over directory entries
+//
+// This method of directory iteration can be especially useful for iteration
+// over directories with large number of entries. It does not read all entries
+// upfront working on at most `batchSize` entries at a time
+func DirIter(path string, batchSize int) iter.Seq2[os.DirEntry, error] {
+	return func(yield func(os.DirEntry, error) bool) {
+		dir, err := os.Open(path)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		defer dir.Close()
+
+		for {
+			entries, err := dir.ReadDir(batchSize)
+			if errors.Is(err, io.EOF) {
+				return
+			} else if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			for _, entry := range entries {
+				if !yield(entry, nil) {
+					return
+				}
+			}
+		}
+	}
 }

--- a/fsutil/fsutil_test.go
+++ b/fsutil/fsutil_test.go
@@ -1,6 +1,7 @@
 package fsutil_test
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -112,4 +113,69 @@ func TestExpandHome(t *testing.T) {
 	os.Unsetenv(homeEnv)
 	_, err = fsutil.ExpandHome(origDir)
 	require.Error(t, err)
+}
+
+func TestDirIter(t *testing.T) {
+	const testEntries = 1000
+	const fileNamesPrimeFactor = 7919
+
+	dir := t.TempDir()
+
+	fileNames := make([]string, 0, testEntries)
+
+	for i := range testEntries {
+		fileName := fmt.Sprintf("test-file-%d", (i*fileNamesPrimeFactor)%testEntries)
+		fileNames = append(fileNames, fileName)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, fileName), fmt.Appendf(nil, "content-%d", i), 0600))
+	}
+
+	for _, batchSize := range []int{1, 2, 5, 100, testEntries, 2 * testEntries} {
+		t.Run(fmt.Sprintf("read - batch size:%d", batchSize), func(t *testing.T) {
+			readBackEntries := make([]string, 0, testEntries)
+
+			for entry, err := range fsutil.DirIter(dir, batchSize) {
+				require.NoError(t, err)
+				readBackEntries = append(readBackEntries, entry.Name())
+			}
+
+			require.ElementsMatch(t, fileNames, readBackEntries)
+		})
+	}
+
+	t.Run("directory not found", func(t *testing.T) {
+		loopVisited := false
+		for entry, err := range fsutil.DirIter(filepath.Join(dir, "im-not-here"), 100) {
+			require.Nil(t, entry, "expecting error for non-existing directory")
+			require.ErrorIs(t, err, fs.ErrNotExist, "must return proper error")
+			require.False(t, loopVisited, "more than one iteration detected")
+			loopVisited = true
+		}
+		require.True(t, loopVisited, "there must be exactly one loop body iteration")
+	})
+
+	t.Run("properly handle early exit", func(t *testing.T) {
+		const entriesLimit = 100
+
+		entriesProcessed := 0
+
+		for _, err := range fsutil.DirIter(dir, 100) {
+			require.NoError(t, err)
+			require.Less(t, entriesProcessed, entriesLimit)
+			entriesProcessed++
+
+			if entriesProcessed == entriesLimit {
+				break
+			}
+		}
+
+		require.Equal(t, entriesLimit, entriesProcessed)
+	})
+
+	t.Run("no permission to read", func(t *testing.T) {
+		dir2 := t.TempDir()
+		require.NoError(t, os.Chmod(dir2, 0))
+		for _, err := range fsutil.DirIter(dir2, 100) {
+			require.Error(t, err)
+		}
+	})
 }


### PR DESCRIPTION
## Context

Advertisement mirroring using a local path can create a directory with huge amount of entries causing filesystem issues.

## Proposed Changes

Introduce PathSplit configuration to the local filestore settings that will instruct the system on how to spread car files into a sub-directory structure.

## Tests

- [x] Dedicated unit 
- [x] Manual tests with a local indexer instance

## Revert Strategy

Change is backwards-compatible if no additional filestore config options are added.

To revert the change after pathSplit settings are added, manual file move is required to flatten the directory structure.