### PR TITLE
Add metrics to car mirror ops

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1165,6 +1165,11 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 		} else {
 			// No error at all, this ad was processed successfully.
 			stats.Record(context.Background(), metrics.AdIngestSuccessCount.M(1))
+			if hasEnts {
+				stats.RecordWithOptions(context.Background(),
+					stats.WithMeasurements(metrics.AdLoadSourceCount.M(1)),
+					stats.WithTags(tag.Insert(metrics.AdSource, adDataSource.String())))
+			}
 		}
 
 		ing.reg.SetLastError(provider, nil)
@@ -1198,6 +1203,10 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 					}
 				} else {
 					log.Infow("Wrote CAR for advertisement", "path", carInfo.Path, "size", carInfo.Size)
+					// Record where the data written to the CAR mirror came from.
+					stats.RecordWithOptions(context.Background(),
+						stats.WithMeasurements(metrics.AdWriteSourceCount.M(1)),
+						stats.WithTags(tag.Insert(metrics.AdSource, adDataSource.String())))
 				}
 			}
 		}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -30,6 +30,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 
 	// Import so these codecs get registered.
@@ -322,10 +323,15 @@ func (ing *Ingester) ingestAd(ctx context.Context, publisherID peer.ID, adCid ci
 	// If using a CAR reader, then try to get the advertisement CAR file first.
 	if ing.mirror.canRead() {
 		log.Debug("Attempting to fetch entries from CAR mirror")
+		carReadStart := time.Now()
 		mhCount, adSource, err := ing.ingestEntriesFromCar(ctx, ad, providerID, adCid, entriesCid, log)
 		hasEnts := mhCount != 0
 		// If entries data successfully read from CAR file.
 		if err == nil {
+			elapsedMsec := float64(time.Since(carReadStart).Nanoseconds()) / 1e6
+			stats.RecordWithOptions(ctx,
+				stats.WithMeasurements(metrics.CarMirrorReadLatency.M(elapsedMsec)),
+				stats.WithTags(tag.Insert(metrics.AdSource, adSource.String())))
 			ing.mhsFromMirror.Add(uint64(mhCount))
 			return hasEnts, adSource, nil
 		}
@@ -352,6 +358,7 @@ func (ing *Ingester) ingestAd(ctx context.Context, publisherID peer.ID, adCid ci
 		}
 	}
 	log.Debug("Fetching entries from publisher")
+	providerFetchStart := time.Now()
 
 	// The ad.Entries link can point to either a chain of EntryChunks or a
 	// HAMT. Sync the very first entry so that we can check which type it is.
@@ -378,7 +385,14 @@ func (ing *Ingester) ingestAd(ctx context.Context, publisherID peer.ID, adCid ci
 		log.Info("syncing entries")
 		mhCount, err = ing.ingestEntriesFromPublisher(ctx, ad, publisherID, providerID, entriesCid, log)
 	}
-	return mhCount != 0, adDataSourceNone, err
+
+	// Record how long it took to fetch all the entries from the publisher.
+	if err == nil {
+		elapsedMsec := float64(time.Since(providerFetchStart).Nanoseconds()) / 1e6
+		stats.Record(ctx, metrics.ProviderFetchLatency.M(elapsedMsec))
+	}
+
+	return mhCount != 0, adDataSourceProvider, err
 }
 
 func (ing *Ingester) ingestHamtFromPublisher(ctx context.Context, ad schema.Advertisement, publisherID, providerID peer.ID, entsCid cid.Cid, log *zap.SugaredLogger) (int, error) {

--- a/internal/ingest/mirror.go
+++ b/internal/ingest/mirror.go
@@ -44,6 +44,23 @@ const (
 	adDataSourceProvider                     // data read from the provider
 )
 
+func (d adDataSource) String() string {
+	switch d {
+	case adDataSourceNone:
+		return "none"
+	case adDataSourceWriter:
+		return "writer"
+	case adDataSourceReader:
+		return "reader"
+	case adDataSourceFallback:
+		return "fallback"
+	case adDataSourceProvider:
+		return "provider"
+	default:
+		return fmt.Sprintf("unknown(%d)", d)
+	}
+}
+
 func (d adDataSource) canBeWritten() bool {
 	switch d {
 	case adDataSourceReader, adDataSourceFallback, adDataSourceProvider:

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -14,9 +14,10 @@ import (
 
 // Global Tags
 var (
-	ErrKind, _ = tag.NewKey("errKind")
-	Found, _   = tag.NewKey("found")
-	Method, _  = tag.NewKey("method")
+	ErrKind, _  = tag.NewKey("errKind")
+	Found, _    = tag.NewKey("found")
+	Method, _   = tag.NewKey("method")
+	AdSource, _ = tag.NewKey("adSource")
 )
 
 // Measures
@@ -28,7 +29,11 @@ var (
 	AdIngestActive       = stats.Int64("ingest/adactive", "Active ingest workers", stats.UnitDimensionless)
 	AdIngestSuccessCount = stats.Int64("ingest/adingestSuccess", "Number of successful ad ingest", stats.UnitDimensionless)
 	AdIngestSkippedCount = stats.Int64("ingest/adingestSkipped", "Number of ads skipped during ingest", stats.UnitDimensionless)
+	AdLoadSourceCount    = stats.Int64("ingest/adloadsource", "Number of ads with entries loaded, by data source", stats.UnitDimensionless)
+	AdWriteSourceCount   = stats.Int64("ingest/adwritesource", "Number of ads written to the CAR mirror, by data source", stats.UnitDimensionless)
 	AdLoadError          = stats.Int64("ingest/adLoadError", "Number of times an ad failed to load", stats.UnitDimensionless)
+	CarMirrorReadLatency = stats.Float64("ingest/carmirrorreadlatency", "Time to read an ad's entries from a CAR mirror", stats.UnitMilliseconds)
+	ProviderFetchLatency = stats.Float64("ingest/providerfetchlatency", "Time to fetch all of an ad's entries from the publisher", stats.UnitMilliseconds)
 	ProviderCount        = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 	PercentUsage         = stats.Float64("ingest/percentusage", "Percent usage of storage available in value store", stats.UnitDimensionless)
@@ -77,9 +82,28 @@ var (
 		Measure:     AdIngestSkippedCount,
 		Aggregation: view.Count(),
 	}
+	adLoadSource = &view.View{
+		Measure:     AdLoadSourceCount,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{AdSource},
+	}
+	adWriteSource = &view.View{
+		Measure:     AdWriteSourceCount,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{AdSource},
+	}
 	adLoadError = &view.View{
 		Measure:     AdLoadError,
 		Aggregation: view.Count(),
+	}
+	carMirrorReadLatencyView = &view.View{
+		Measure:     CarMirrorReadLatency,
+		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
+		TagKeys:     []tag.Key{AdSource},
+	}
+	providerFetchLatencyView = &view.View{
+		Measure:     ProviderFetchLatency,
+		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
 	}
 	percentUsageView = &view.View{
 		Measure:     PercentUsage,
@@ -110,7 +134,11 @@ func Start(views []*view.View) http.Handler {
 		adIngestActive,
 		adIngestSkipped,
 		adIngestSuccess,
+		adLoadSource,
+		adWriteSource,
 		adLoadError,
+		carMirrorReadLatencyView,
+		providerFetchLatencyView,
 		percentUsageView,
 		nonRemoveAdCountView,
 		removeAdCountView,


### PR DESCRIPTION
## Context

Proper metrics are needed to check the outcome of car mirroring.

## Proposed Changes

Adding metrics for car mirroring and ad ingestion.

## Tests

Local tests, tests on the standby node.

## Revert Strategy

Only new metrics added, reverting the commit and waiting for prometheus data retention will end up with a complete cleanup