### PR TITLE
Endpoint for advertisement id status

### DIFF
--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -319,7 +319,8 @@ Ingestion markers (`ingest.go`):
 - `syncPrefix` (`/sync/<publisherID>`) -> CID bytes of the latest fully
   processed ad for a publisher (`GetLatestSync` / `getLastKnownSync`).
 - `adProcessedPrefix` (`/adProcessed/<adCid>`) -> marks an ad as processed
-  (used to stop chain walks and skip re-processing).
+  (used to stop chain walks and skip re-processing). Value is a single byte:
+  `1` = processed, `0` = explicitly unprocessed, `2` = marked for resync.
 - `adProcessedFrozenPrefix` (`/adF/<adCid>`) -> marks ads processed while
   frozen, used to roll back on unfreeze (`Unfreeze` / `removeProcessedFrozen`).
 
@@ -449,6 +450,28 @@ This status is exposed on the find HTTP API: `GET /sync/status` returns all
 publisher statuses; `GET /sync/status/<publisherID>` returns one publisher's
 status.
 
+Whether a single advertisement's content is available from this indexer is
+exposed on the ingest HTTP API as `GET /sync/status/ad/<adCid>`. The response
+includes:
+
+- `Ad` - the requested advertisement CID
+- `Indexed` - true only when the ad was fully processed while the indexer was
+  not frozen, and is not currently marked for resync
+  (`Processed && !Resync && !Frozen` from `AdState`)
+
+`Indexed` is false when:
+
+- the ad is unknown / not yet processed
+- the ad was processed in frozen mode (provider/metadata updates only; entry
+  multihashes were not indexed)
+- the ad is marked for resync (previous processing is treated as invalidated
+  until the ad is processed again)
+
+`Indexed` does not distinguish successful content indexing from permanent skips
+(malformed/decoding/content-not-found ads are still marked processed, so they
+can report `Indexed: true`). Timestamps and provider identity are not stored
+per ad and are not returned.
+
 See [`internal/registry/syncstatus.go`](../internal/registry/syncstatus.go) for
 the tracker and its JSON serialization.
 
@@ -497,7 +520,7 @@ listed in [config.md](config.md).
 | `internal/ingest/linksystem.go` | Link system (verify + store), `ingestAd`, entry/HAMT/CAR ingestion, `indexAdMultihashes`, node decoding helpers. |
 | `internal/ingest/mirror.go` | CAR mirror read/write over the filestore. |
 | `internal/ingest/error.go` | `adIngestError` states and helpers. |
-| `server/ingest/server.go` | `/announce` and `/register` HTTP handlers. |
+| `server/ingest/server.go` | `/announce`, `/register`, and `/sync/status/ad/<cid>` HTTP handlers. |
 | `internal/registry/registry.go` | Provider registry, policy, freeze, auto-sync channel, sync status. |
 | `internal/registry/syncstatus.go` | Live per-publisher sync status tracker. |
 | `config/ingest.go` | Ingestion configuration and defaults. |

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -537,6 +537,51 @@ func (ing *Ingester) adAlreadyProcessed(adCid cid.Cid) (bool, bool, error) {
 	return processed, resync, nil
 }
 
+type AdState struct {
+	Processed bool
+	Resync    bool
+	Frozen    bool
+}
+
+// Indexed reports whether the advertisement's content should be considered
+// available from this indexer.
+//
+// An ad is indexed only when it was fully processed while the indexer was not
+// frozen. Ads marked for resync are treated as not indexed because a resync
+// invalidates the previous processing result until the ad is processed again.
+//
+// Note that Processed (and therefore Indexed) does not distinguish successful
+// content indexing from permanent skips such as malformed ads.
+func (s AdState) Indexed() bool {
+	return s.Processed && !s.Resync && !s.Frozen
+}
+
+// GetAdState returns the known state for an advertisement.
+//
+// Processed is true when the ad is marked fully processed (/adProcessed/ value
+// 1). Resync is true when the ad is marked for resync (value 2). Frozen is true
+// when the ad was processed while the indexer was in frozen mode (/adF/ key
+// present); frozen processing updates provider metadata but does not index
+// entry multihashes.
+func (ing *Ingester) GetAdState(adCid cid.Cid) (state AdState, err error) {
+	state.Processed, state.Resync, err = ing.adAlreadyProcessed(adCid)
+	if err != nil {
+		return state, err
+	}
+
+	_, err = ing.ds.Get(context.Background(), datastore.NewKey(adProcessedFrozenPrefix+adCid.String()))
+	switch {
+	case errors.Is(err, datastore.ErrNotFound):
+		state.Frozen = false
+	case err != nil:
+		return state, err
+	default:
+		state.Frozen = true
+	}
+
+	return state, nil
+}
+
 // MarkAdProcessed explicitly marks an advertisement as processed. This is used
 // to avoid ingesting this and previous advertisements.
 func (ing *Ingester) MarkAdProcessed(publisher peer.ID, adCid cid.Cid) error {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -525,17 +525,16 @@ func (ing *Ingester) markAdUnprocessed(adCid cid.Cid, forResync bool) error {
 	return ing.ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+adCid.String()), data)
 }
 
-func (ing *Ingester) adAlreadyProcessed(adCid cid.Cid) (bool, bool) {
+func (ing *Ingester) adAlreadyProcessed(adCid cid.Cid) (bool, bool, error) {
 	v, err := ing.ds.Get(context.Background(), datastore.NewKey(adProcessedPrefix+adCid.String()))
-	if err != nil {
-		if err != datastore.ErrNotFound {
-			log.Errorw("Failed to read advertisement processed state from datastore", "err", err)
-		}
-		return false, false
+	if errors.Is(err, datastore.ErrNotFound) {
+		return false, false, nil
+	} else if err != nil {
+		return false, false, err
 	}
 	processed := v[0] == byte(1)
 	resync := v[0] == byte(2)
-	return processed, resync
+	return processed, resync, nil
 }
 
 // MarkAdProcessed explicitly marks an advertisement as processed. This is used
@@ -987,7 +986,12 @@ func (ing *Ingester) processRawAdChain(ctx context.Context, syncFinished dagsync
 		// only publish Ads for one provider, but it's possible that an ad
 		// chain can include multiple providers.
 
-		processed, resync := ing.adAlreadyProcessed(c)
+		processed, resync, err := ing.adAlreadyProcessed(c)
+		if err != nil {
+			log.Errorw("Failed to read advertisement processed state from datastore", "err", err)
+			// Note: don't stop in case of an error in this place, the same check will be done
+			// later in a context of a specific provider.
+		}
 		if processed {
 			// This ad has been processed so all earlier ads already have been
 			// processed.
@@ -1121,7 +1125,18 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 			return
 		}
 
-		processed, _ := ing.adAlreadyProcessed(ai.cid)
+		processed, _, err := ing.adAlreadyProcessed(ai.cid)
+		if err != nil {
+			log.Errorw("Failed to check if advertisement is processed. Bailing early, not ingesting later ads.", "adCid", ai.cid, "err", err)
+			ing.inEvents <- adProcessedEvent{
+				publisher: publisher,
+				headAdCid: headAdCid,
+				adCid:     ai.cid,
+				err:       err,
+			}
+			procErr = err
+			return
+		}
 		if processed {
 			log.Infow("Skipping advertisement that has already been processed",
 				"adCid", ai.cid,

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -2233,6 +2233,62 @@ type testEnv struct {
 	reg              *registry.Registry
 }
 
+func TestGetAdState(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+	ads := random.Cids(4)
+
+	state, err := te.ingester.GetAdState(ads[0])
+	require.NoError(t, err)
+	require.Equal(t, AdState{}, state)
+	require.False(t, state.Indexed())
+
+	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ads[0]))
+	state, err = te.ingester.GetAdState(ads[0])
+	require.NoError(t, err)
+	require.Equal(t, AdState{Processed: true}, state)
+	require.True(t, state.Indexed())
+
+	require.NoError(t, te.ingester.markAdUnprocessed(ads[1], true))
+	state, err = te.ingester.GetAdState(ads[1])
+	require.NoError(t, err)
+	require.Equal(t, AdState{Resync: true}, state)
+	require.False(t, state.Indexed())
+
+	require.NoError(t, te.ingester.markAdUnprocessed(ads[2], false))
+	state, err = te.ingester.GetAdState(ads[2])
+	require.NoError(t, err)
+	require.Equal(t, AdState{}, state)
+	require.False(t, state.Indexed())
+
+	require.NoError(t, te.ingester.markAdProcessed(publisher, ads[3], true, false))
+	state, err = te.ingester.GetAdState(ads[3])
+	require.NoError(t, err)
+	require.Equal(t, AdState{Processed: true, Frozen: true}, state)
+	require.False(t, state.Indexed())
+}
+
+func TestAdStateIndexed(t *testing.T) {
+	tests := []struct {
+		name  string
+		state AdState
+		want  bool
+	}{
+		{name: "empty", state: AdState{}, want: false},
+		{name: "processed", state: AdState{Processed: true}, want: true},
+		{name: "resync", state: AdState{Resync: true}, want: false},
+		{name: "processed and resync", state: AdState{Processed: true, Resync: true}, want: false},
+		{name: "frozen", state: AdState{Frozen: true}, want: false},
+		{name: "processed and frozen", state: AdState{Processed: true, Frozen: true}, want: false},
+		{name: "all flags", state: AdState{Processed: true, Resync: true, Frozen: true}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.state.Indexed())
+		})
+	}
+}
+
 type testEnvOpts struct {
 	publisherLinkSysFn func(ds datastore.Batching) ipld.LinkSystem
 	ingestConfig       *config.Ingest

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -3,6 +3,7 @@ package ingest_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -163,6 +164,61 @@ func announceTest(t *testing.T, peerID peer.ID, sender announce.Sender) {
 
 	err = sender.Send(context.Background(), msg)
 	require.NoError(t, err, "Failed to announce")
+}
+
+func TestAdStatus(t *testing.T) {
+	ind := initIndex(t, true)
+	reg := initRegistry(t, providerIdent.PeerID)
+	ing := initIngest(t, ind, reg)
+	s := setupServer(ind, ing, reg, t)
+
+	errChan := make(chan error, 1)
+	go func() {
+		err := s.Start()
+		if err != http.ErrServerClosed {
+			errChan <- err
+		}
+		close(errChan)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, s.Close())
+		require.NoError(t, <-errChan)
+	})
+
+	pubID, _, err := providerIdent.Decode()
+	require.NoError(t, err)
+	ads := random.Cids(2)
+
+	getAdStatus := func(t *testing.T, ad cid.Cid) (int, string) {
+		t.Helper()
+		res, err := http.Get(s.URL() + "/sync/status/ad/" + ad.String())
+		require.NoError(t, err)
+		body, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		require.NoError(t, err)
+		return res.StatusCode, string(body)
+	}
+
+	// Unknown ad is not indexed.
+	status, body := getAdStatus(t, ads[0])
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false}`, ads[0].String()), body)
+
+	// Fully processed ad is indexed.
+	require.NoError(t, ing.MarkAdProcessed(pubID, ads[0]))
+	status, body = getAdStatus(t, ads[0])
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true}`, ads[0].String()), body)
+
+	// A different unknown ad remains not indexed.
+	status, body = getAdStatus(t, ads[1])
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false}`, ads[1].String()), body)
+
+	res, err := http.Get(s.URL() + "/sync/status/ad/not-a-cid")
+	require.NoError(t, err)
+	res.Body.Close()
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 }
 
 func registerProviderTest(t *testing.T, cl client.Interface, providerID peer.ID, privateKey crypto.PrivKey, addr string, reg *registry.Registry) {

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -77,6 +78,7 @@ func New(listen string, indexer indexer.Interface, ingester *ingest.Ingester, re
 	mux.HandleFunc("/announce", s.putAnnounce)
 	mux.HandleFunc("/health", s.getHealth)
 	mux.HandleFunc("/register", s.postRegisterProvider)
+	mux.HandleFunc("/sync/status/ad/", s.getAdStatus)
 
 	// Depricated
 	mux.HandleFunc("/ingest/announce", s.putAnnounce)
@@ -138,6 +140,48 @@ func (s *Server) getHealth(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Cache-Control", "no-cache")
 	http.Error(w, s.healthMsg, http.StatusOK)
+}
+
+type adStatusResponse struct {
+	Ad      string `json:"Ad"`
+	Indexed bool   `json:"Indexed"`
+}
+
+func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
+	if !httpserver.MethodOK(w, r, http.MethodGet) {
+		return
+	}
+
+	cidStr := path.Base(r.URL.Path)
+	adCid, err := cid.Decode(cidStr)
+	if err != nil {
+		msg := "Cannot decode advertisement cid"
+		log.Errorw(msg, "cid", cidStr, "err", err)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	resp := adStatusResponse{
+		Ad: adCid.String(),
+	}
+	if s.ingester != nil {
+		adState, err := s.ingester.GetAdState(adCid)
+		if err != nil {
+			log.Errorw("Failed to read advertisement processed state", "adCid", adCid, "err", err)
+			http.Error(w, "", http.StatusInternalServerError)
+			return
+		}
+		resp.Indexed = adState.Indexed()
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		log.Errorw("cannot marshal advertisement status", "err", err)
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+
+	httpserver.WriteJsonResponse(w, http.StatusOK, data)
 }
 
 func (s *Server) postRegisterProvider(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Context

There's no easy way for a publisher to understand whether indexer has processed a given advertisement or not. The only exposed API deals with provider info - that exposes the last processed AD id which is OK for newest AD but in case of long chains of advertisements to process, figuring out whether a given AD has already been processed may require a linear scan of the history.

## Proposed Changes

Create a simple API (with potential to be extended in the future) exposing information about a given AD to quickly check whether is has already been processed or not.

## Tests

Dedicated unit tests to check the behavior.

## Revert Strategy

This is a change exposing API only, no internal logic was changed, no new data structures added.