### PR TITLE
Prevent rescan of whole history on old ad reannouncement

### DIFF
--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -130,6 +130,9 @@ the subscriber invokes storetheindex's block hook,
   logs every `adsScannedLogInterval` (100) ads.
 - It sets the next CID to sync from `ad.PreviousID` (or `cid.Undef` at the
   chain start), which tells the segmented sync where to continue.
+- If the current ad is already marked as processed in `/adProcessed/`,
+  the segmented sync terminates early instead of continuing into older
+  segments.
 
 Important: dagsync collects the CIDs of a segment during the IPLD traversal and
 calls the block hook for each **after** the segment's fetch completes (see

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -249,6 +249,20 @@ func (ing *Ingester) Skip500EntriesError(skip bool) {
 }
 
 func (ing *Ingester) generalDagsyncBlockHook(publisher peer.ID, c cid.Cid, actions dagsync.SegmentSyncActions) {
+	// If this ad is already fully processed, all older ads are too.
+	// Stop advancing without loading the ad data.
+	processed, _, err := ing.adAlreadyProcessed(c)
+	if err != nil {
+		ing.reg.EndScan(publisher, err)
+		actions.FailSync(err)
+		return
+	}
+	if processed {
+		log.Debugw("Reached already processed advertisement; stopping scan", "publisher", publisher, "adCid", c)
+		actions.SetNextSyncCid(cid.Undef)
+		return
+	}
+
 	// The only kind of block we should get by loading CIDs here should be
 	// Advertisement.
 	//

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1231,6 +1231,102 @@ func TestSkipEarlierAdsIfAlreadyProcessedLaterAd(t *testing.T) {
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMHs)
 }
 
+func TestSegmentedSyncStopsAtProcessedAdOnSplitChain(t *testing.T) {
+	// Two chains share a common prefix:
+	//   a <- b <- c <- d   (synced first, all processed, latest = d)
+	//   a <- b <- c <- e   (announced second)
+	//
+	// When e is announced, scanning walks e -> c. Since c is already
+	// processed, the scan should stop there and not continue into b.
+	// We block reads of b to detect if scanning goes too far.
+	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
+	te := setupTestEnv(t, true, blockableLsysOpt)
+
+	adHead := typehelpers.RandomAdBuilder{
+		EntryBuilders: []typehelpers.EntryBuilder{
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 1},
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 2},
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 3},
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 4},
+		},
+	}.Build(t, te.publisherLinkSys, te.publisherPriv)
+	allAdLinks := typehelpers.AllAdLinks(t, adHead, te.publisherLinkSys)
+	bCid := allAdLinks[1].(cidlink.Link).Cid
+	cLink := allAdLinks[2]
+	dCid := allAdLinks[3].(cidlink.Link).Cid
+	chainMHs := typehelpers.AllMultihashesFromAdLink(t, adHead, te.publisherLinkSys)
+
+	peerInfo := peer.AddrInfo{
+		ID:    te.publisher.ID(),
+		Addrs: te.publisher.Addrs(),
+	}
+	ctx := t.Context()
+
+	// Sync the full chain a <- b <- c <- d; all four ads become processed.
+	te.publisher.SetRoot(dCid)
+	_, err := te.ingester.Sync(ctx, peerInfo, 0, false)
+	require.NoError(t, err)
+	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), chainMHs)
+
+	// Build ad e with PreviousID = c, creating a fork off the same prefix.
+	entriesLink, eMHs := newRandomLinkedList(t, te.publisherLinkSys, 1)
+	providerID := te.pubHost.ID()
+	adE := schema.Advertisement{
+		Provider:   providerID.String(),
+		Addresses:  []string{"/ip4/127.0.0.1/tcp/9999"},
+		Entries:    entriesLink,
+		ContextID:  []byte("test-context-id-e"),
+		Metadata:   []byte("test-metadata"),
+		PreviousID: cLink,
+	}
+	require.NoError(t, adE.Sign(te.publisherPriv))
+	node, err := adE.ToNode()
+	require.NoError(t, err)
+	eLnk, err := te.publisherLinkSys.Store(ipld.LinkContext{}, schema.Linkproto, node)
+	require.NoError(t, err)
+	eCid := eLnk.(cidlink.Link).Cid
+
+	// Block reads of b. If scanning continues past c into b, the sync
+	// will hang on the blocked read, causing a timeout.
+	blockedReads.add(bCid)
+
+	var (
+		hitsMu sync.Mutex
+		hits   []cid.Cid
+		wg     sync.WaitGroup
+		done   = make(chan struct{})
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case hit := <-hitBlockedRead:
+				hitsMu.Lock()
+				hits = append(hits, hit)
+				hitsMu.Unlock()
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	// Announce e. Scanning: e (new) -> c (already processed, stop).
+	te.publisher.SetRoot(eCid)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	require.NoError(t, err)
+	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), eMHs)
+
+	close(done)
+	wg.Wait()
+
+	for _, hit := range hits {
+		if hit.Equals(bCid) {
+			t.Fatalf("scanning reached ad %s beyond the processed boundary", bCid)
+		}
+	}
+}
+
 func TestRecursionDepthLimitsEntriesSync(t *testing.T) {
 	const entriesDepth = 10
 


### PR DESCRIPTION
## Context

The scan phase of ingestion will traverse the ad chain until reaching an ad without previous ad, or until reaching the latest processed ad. This will cause issues when the scan starts at a node that is preceeding the latest processed one in the chain. The result is that the scan will continue running until the genesis ad (without previous one) is found.

For large chains this may result with a time-consuming scans that prevent newest ads of the affected providers from being ingested. In a production environment there were observed cases of such a scan taking more than 26 hours.

## Proposed Changes

Stop the scan if we reach already processed ads.

## Tests

The issue can be best exposed using split-chain situation - announcing a new AD that only partially shares the history. In such case, only the new part of the chain should be scanned and the shared part should be skipped. Without the fix, the scan would not stop until the genesis ad is reached.

## Revert Strategy

Only code change revert is needed.